### PR TITLE
Fix cvxpy CI install error on python 3.7

### DIFF
--- a/.github/actions/install-master-dependencies/action.yml
+++ b/.github/actions/install-master-dependencies/action.yml
@@ -27,7 +27,6 @@ runs:
         sudo apt-get -y install libopenblas-dev
         git clone https://github.com/Qiskit/qiskit-aer.git /tmp/qiskit-aer
         cd /tmp/qiskit-aer
-        pip install -U -c /tmp/qiskit-aer/constraints.txt -r /tmp/qiskit-aer/requirements-dev.txt
         python /tmp/qiskit-aer/setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -DAER_THRUST_BACKEND=OMP -- -j4
         pip install /tmp/qiskit-aer/dist/qiskit_aer*whl
         pip install https://github.com/Qiskit/qiskit-aqua/archive/master.zip


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
cvxpy 1.1.8 doesn't install on python 3.7

### Details and comments

cvxpy is required in Aer requirements-dev.txt, however requirements-dev.txt is not required anymore in order to install Aer, so it was just removed.
