### PR TITLE
Comply with pylint 2.7.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -304,7 +304,7 @@ ignored-modules=matplotlib.cm,numpy.random,retworkx
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local,QuantumCircuit
+ignored-classes=optparse.Values,thread._local,_thread._local,QuantumCircuit,Group
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/qiskit_nature/components/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/components/bosonic_bases/harmonic_basis.py
@@ -150,7 +150,7 @@ class HarmonicBasis(BosonicBasis):
 
             # Note: these negative indices as detected below are explicitly generated in
             # _compute_modes for other potential uses. They are not wanted by this logic.
-            if any([index < 0 for index in indices]):
+            if any(index < 0 for index in indices):
                 kinetic_term = True
                 indices = np.absolute(indices)
             indexes = {}  # type: Dict[int, int]

--- a/qiskit_nature/drivers/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/fcidumpd/parser.py
@@ -238,6 +238,6 @@ def _permute_2e_ints(hijkl: np.ndarray,
         for perm in {e1 + e2 for e1, e2 in permutations}:
             if perm in elements:
                 continue
-            hijkl[shifted] = hijkl[tuple([e-((e >= norb) * norb) for e in perm])]
+            hijkl[shifted] = hijkl[tuple(e - (e >= norb) * norb for e in perm)]
             elements.remove(elem)
             break

--- a/qiskit_nature/drivers/gaussiand/gaussiandriver.py
+++ b/qiskit_nature/drivers/gaussiand/gaussiandriver.py
@@ -364,6 +364,6 @@ class GaussianDriver(FermionicDriver):
         m_x = mel.matlist.get(name)
         if m_x is None:
             return None
-        dims = tuple([abs(i) for i in m_x.dimens])
+        dims = tuple(abs(i) for i in m_x.dimens)
         mat = np.reshape(m_x.expand(), dims, order='F')
         return mat

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -68,7 +68,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
         aux_ops_copy = copy.deepcopy(aux_ops)
 
         _ = calc.solve(self.driver, aux_ops)
-        assert all([a == b for a, b in zip(aux_ops, aux_ops_copy)])
+        assert all(a == b for a, b in zip(aux_ops, aux_ops_copy))
 
     def test_custom_minimum_eigensolver(self):
         """ Test custom MES """

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -83,7 +83,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         aux_ops_copy = copy.deepcopy(aux_ops)
 
         _ = calc.solve(self.driver, aux_ops)
-        assert all([a == b for a, b in zip(aux_ops, aux_ops_copy)])
+        assert all(a == b for a, b in zip(aux_ops, aux_ops_copy))
 
     def _setup_evaluation_operators(self):
         # first we run a ground state calculation


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

pylint 2.7.0 just got released and introduced a new check as well as a new "problem" which are being fixed in this PR.

### Details and comments

- the new check suggests generators whenever possible. A few cases had to be adapted in our code base accordingly.
- a "problem" occurs with the type detection in the `QMolecule.load` method. There, a lot of variables are supposedly of the `h5py.Group` type although they should be either numpy arrays or `h5py.Dataset`s. I added the `Group` class to the ignored pylint classes for the time being.
