### PR TITLE
Remove VariationalForm

### DIFF
--- a/qiskit_nature/components/variational_forms/chc.py
+++ b/qiskit_nature/components/variational_forms/chc.py
@@ -20,10 +20,8 @@ from qiskit import QuantumRegister, QuantumCircuit
 
 from qiskit.circuit import ParameterVector, Parameter
 
-from qiskit.algorithms.variational_forms import VariationalForm
 
-
-class CHC(VariationalForm):
+class CHC:
     """ This trial wavefunction is the Compact Heuristic for Chemistry.
 
     The trial wavefunction is as defined in
@@ -37,7 +35,7 @@ class CHC(VariationalForm):
 
     def __init__(self, num_qubits: Optional[int] = None, reps: int = 1, ladder: bool = False,
                  excitations: Optional[List[List[int]]] = None,
-                 entanglement: Union[str, List[int]] = 'full',
+                 entanglement: Union[str, List[int]] = 'full',  # pylint: disable=unused-argument
                  initial_state: Optional[QuantumCircuit] = None) -> None:
         """
 
@@ -61,10 +59,6 @@ class CHC(VariationalForm):
         self._excitations = excitations
         self._bounds = [(-np.pi, np.pi)] * self._num_parameters
         self._num_qubits = num_qubits
-        if isinstance(entanglement, str):
-            self._entangler_map = VariationalForm.get_entangler_map(entanglement, num_qubits)
-        else:
-            self._entangler_map = VariationalForm.validate_entangler_map(entanglement, num_qubits)
         self._initial_state = initial_state
         self._support_parameterized_circuit = True
 

--- a/qiskit_nature/components/variational_forms/uccsd.py
+++ b/qiskit_nature/components/variational_forms/uccsd.py
@@ -31,13 +31,12 @@ from qiskit.tools.events import TextProgressBar
 
 from qiskit.utils import algorithm_globals
 from qiskit.opflow import PauliSumOp, Z2Symmetries, TwoQubitReduction
-from qiskit.algorithms.variational_forms import VariationalForm
 from qiskit_nature.fermionic_operator import FermionicOperator
 
 logger = logging.getLogger(__name__)
 
 
-class UCCSD(VariationalForm):
+class UCCSD:
     """
     This trial wavefunction is a Unitary Coupled-Cluster Single and Double excitations
     variational form.

--- a/qiskit_nature/components/variational_forms/uvcc.py
+++ b/qiskit_nature/components/variational_forms/uvcc.py
@@ -25,13 +25,12 @@ from qiskit.circuit import ParameterVector, Parameter
 
 from qiskit.utils import algorithm_globals
 from qiskit.opflow import PauliSumOp
-from qiskit.algorithms.variational_forms import VariationalForm
 from qiskit_nature.bosonic_operator import BosonicOperator
 
 logger = logging.getLogger(__name__)
 
 
-class UVCC(VariationalForm):
+class UVCC:
     """
     This trial wavefunction is a Unitary Vibrational Coupled-Cluster Single and Double excitations
     variational form.


### PR DESCRIPTION
This is a necessity after merging of https://github.com/Qiskit/qiskit-terra/pull/6064

All tests which rely on these legacy VariationalForm implementations
were disabled anyways.