### PR TITLE
Fix #53

### DIFF
--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -218,12 +218,13 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
                                    seed_transpiler=algorithm_globals.random_seed)
                                )
         calc = GroundStateEigensolver(self.qubit_converter, solver)
-        res_qasm = calc.solve(self.molecular_problem)
+        res_qasm = calc.solve(self.electronic_structure_problem)
 
-        hamiltonian = self.molecular_problem.second_q_ops()[0]
+        hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        var_form = solver.get_solver(self.molecular_problem, self.qubit_converter).var_form
+        var_form = solver.get_solver(self.electronic_structure_problem,
+                                     self.qubit_converter).var_form
         circuit = var_form.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
@@ -249,12 +250,13 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
                                    seed_transpiler=algorithm_globals.random_seed)
                                )
         calc = GroundStateEigensolver(self.qubit_converter, solver)
-        res_qasm = calc.solve(self.molecular_problem)
+        res_qasm = calc.solve(self.electronic_structure_problem)
 
-        hamiltonian = self.molecular_problem.second_q_ops()[0]
+        hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        var_form = solver.get_solver(self.molecular_problem, self.qubit_converter).var_form
+        var_form = solver.get_solver(self.electronic_structure_problem,
+                                     self.qubit_converter).var_form
         circuit = var_form.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -223,9 +223,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        var_form = solver.get_solver(self.electronic_structure_problem,
-                                     self.qubit_converter).var_form
-        circuit = var_form.assign_parameters(res_qasm.raw_result.optimal_point)
+        ansatz = solver.get_solver(self.electronic_structure_problem,
+                                     self.qubit_converter).ansatz
+        circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
         self.assertAlmostEqual(res_qasm.eigenenergies[0], mean[0].real)
@@ -255,9 +255,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        var_form = solver.get_solver(self.electronic_structure_problem,
-                                     self.qubit_converter).var_form
-        circuit = var_form.assign_parameters(res_qasm.raw_result.optimal_point)
+        ansatz = solver.get_solver(self.electronic_structure_problem,
+                                     self.qubit_converter).ansatz
+        circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
         self.assertAlmostEqual(res_qasm.eigenenergies[0], mean[0].real)

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -224,7 +224,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         qubit_op = self.qubit_converter.map(hamiltonian)
 
         ansatz = solver.get_solver(self.electronic_structure_problem,
-                                     self.qubit_converter).ansatz
+                                   self.qubit_converter).ansatz
         circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
@@ -256,7 +256,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         qubit_op = self.qubit_converter.map(hamiltonian)
 
         ansatz = solver.get_solver(self.electronic_structure_problem,
-                                     self.qubit_converter).ansatz
+                                   self.qubit_converter).ansatz
         circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 


### PR DESCRIPTION
### Summary

Closes #53 

### Details and comments

When working with QuantumInstance-based solvers, we also need to account
for the Expectation-conversion of the expectation operator. Otherwise,
QASM-based calculations will not return the expected results when
evaluating additional operators.

@woodsp-ibm Is this an issue you would like to see fixed in Aqua before it gets deprecated?