### PR TITLE
Disable Conan on CI Aer build. Remove unused retworkx requirement

### DIFF
--- a/.github/actions/install-master-dependencies/action.yml
+++ b/.github/actions/install-master-dependencies/action.yml
@@ -15,12 +15,18 @@ description: 'Installs Python dependencies from Master'
 
 runs:
   using: "composite"
-  steps: 
-    - run : |
+  steps:
+    - name: Install Dependencies from Master
+      env:
+        DISABLE_CONAN: 1
+      run: |
         if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda activate
         fi
         pip install https://github.com/Qiskit/qiskit-terra/archive/master.zip
+        sudo apt-get -y install nlohmann-json3-dev
+        sudo apt-get -y install libspdlog-dev
+        sudo apt-get -y install libmuparserx-dev
         pip install https://github.com/Qiskit/qiskit-aer/archive/master.zip
       shell: bash

--- a/.pylintrc
+++ b/.pylintrc
@@ -299,7 +299,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=matplotlib.cm,numpy.random,retworkx
+ignored-modules=matplotlib.cm,numpy.random
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ psutil>=5
 scikit-learn>=0.20.0
 setuptools>=40.1.0
 h5py
-retworkx>=0.7.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Conan downloads dependencies from JFrog Bintray that goes down sometimes. This disables Conan and installs dependencies in the CI.

