### PR TITLE
Use simpler, more performant construction of array in qubit mapper

### DIFF
--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -96,7 +96,7 @@ class QubitMapper(ABC):
             return real_part + imag_part
 
         # 1. Initialize an operator list with the identity scaled by the `self.coeff`
-        all_false = np.asarray([False] * nmodes, dtype=bool)
+        all_false = np.zeros(nmodes, dtype=bool)
 
         ret_op_list = []
 

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -96,7 +96,7 @@ class QubitMapper(ABC):
             return real_part + imag_part
 
         # 1. Initialize an operator list with the identity scaled by the `self.coeff`
-        all_false = np.zeros(nmodes, dtype=bool)
+        all_false = np.full(nmodes, False)
 
         ret_op_list = []
 


### PR DESCRIPTION
This constructs a numpy array directly instead of constructing and converting a list.
The construction is both simpler and more performant, although it is unlikely to make the enclosing function faster
in this case.

