### PR TITLE
Fix test case for gaussian driver

### DIFF
--- a/test/drivers/gaussiand/test_driver_methods_gaussian.py
+++ b/test/drivers/gaussiand/test_driver_methods_gaussian.py
@@ -17,6 +17,7 @@ import unittest
 from test.drivers.test_driver_methods_gsc import TestDriverMethods
 from qiskit_nature.drivers import GaussianDriver
 from qiskit_nature import QiskitNatureError
+from qiskit_nature.transformers import FreezeCoreTransformer
 
 
 class TestDriverMethodsGaussian(TestDriverMethods):
@@ -54,31 +55,31 @@ H   0.0  0.0    0.9697
     def test_lih_rhf(self):
         """ lih rhf test """
         driver = GaussianDriver(config=self.g16_lih_config.format('rhf'))
-        result = self._run_driver(driver)
+        result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
         self._assert_energy_and_dipole(result, 'lih')
 
     def test_lih_rohf(self):
         """ lih rohf test """
         driver = GaussianDriver(config=self.g16_lih_config.format('rohf'))
-        result = self._run_driver(driver)
+        result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
         self._assert_energy_and_dipole(result, 'lih')
 
     def test_lih_uhf(self):
         """ lih uhf test """
         driver = GaussianDriver(config=self.g16_lih_config.format('uhf'))
-        result = self._run_driver(driver)
+        result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
         self._assert_energy_and_dipole(result, 'lih')
 
     def test_oh_rohf(self):
         """ oh rohf test """
         driver = GaussianDriver(config=self.g16_oh_config.format('rohf'))
-        result = self._run_driver(driver)
+        result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
         self._assert_energy_and_dipole(result, 'oh')
 
     def test_oh_uhf(self):
         """ oh uhf test """
         driver = GaussianDriver(config=self.g16_oh_config.format('uhf'))
-        result = self._run_driver(driver)
+        result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
         self._assert_energy_and_dipole(result, 'oh')
 
 


### PR DESCRIPTION
There are driver tests for other methods such as uhf, rohf which are on larger molecules. To keep tests small/fast these have been done on frozen core but the logic around that was changed. The base test case for all the driver method tests, used to set frozen core to True as default. It seems this logic was changed so that False is now in effect the default, since transformer(s) need to be passed to alter that. While the pyquante, pyscf and psi4 tests were all changed, presumably as these are run in CI, the gaussian one had not been and fails if run. This changes that test case to make it logically the same as before by passing a FreezeCoreTransformer, as indeed the other driver tests were changed to do.