### PR TITLE
Add missing black settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39']

--- a/qiskit_nature/algorithms/excited_states_solvers/excited_states_eigensolver.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/excited_states_eigensolver.py
@@ -112,8 +112,6 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
         eigenstate_result.raw_result = raw_es_result
         eigenstate_result.eigenenergies = raw_es_result.eigenvalues
         eigenstate_result.eigenstates = raw_es_result.eigenstates
-        eigenstate_result.aux_operator_eigenvalues = (
-            raw_es_result.aux_operator_eigenvalues
-        )
+        eigenstate_result.aux_operator_eigenvalues = raw_es_result.aux_operator_eigenvalues
         result = problem.interpret(eigenstate_result)
         return result

--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -72,7 +72,7 @@ class QEOM(ExcitedStatesSolver):
         directly be provided."""
         if isinstance(excitations, str) and excitations not in ["s", "d", "sd"]:
             raise ValueError(
-                "Excitation type must be s (singles), d (doubles) or sd " "(singles and doubles)"
+                "Excitation type must be s (singles), d (doubles) or sd (singles and doubles)"
             )
         self._excitations = excitations
 

--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -72,8 +72,7 @@ class QEOM(ExcitedStatesSolver):
         directly be provided."""
         if isinstance(excitations, str) and excitations not in ["s", "d", "sd"]:
             raise ValueError(
-                "Excitation type must be s (singles), d (doubles) or sd "
-                "(singles and doubles)"
+                "Excitation type must be s (singles), d (doubles) or sd " "(singles and doubles)"
             )
         self._excitations = excitations
 
@@ -106,9 +105,7 @@ class QEOM(ExcitedStatesSolver):
         groundstate_result = self._gsc.solve(problem)
 
         # 2. Prepare the excitation operators
-        self._untapered_qubit_op_main = self._gsc._qubit_converter.map(
-            problem.second_q_ops()[0]
-        )
+        self._untapered_qubit_op_main = self._gsc._qubit_converter.map(problem.second_q_ops()[0])
         matrix_operators_dict, size = self._prepare_matrix_operators(problem)
 
         # 3. Evaluate eom operators
@@ -130,9 +127,7 @@ class QEOM(ExcitedStatesSolver):
         ) = self._build_eom_matrices(measurement_results, size)
 
         # 5. solve pseudo-eigenvalue problem
-        energy_gaps, expansion_coefs = self._compute_excitation_energies(
-            m_mat, v_mat, q_mat, w_mat
-        )
+        energy_gaps, expansion_coefs = self._compute_excitation_energies(m_mat, v_mat, q_mat, w_mat)
 
         qeom_result = QEOMResult()
         qeom_result.ground_state_raw_result = groundstate_result.raw_result
@@ -149,16 +144,12 @@ class QEOM(ExcitedStatesSolver):
 
         eigenstate_result = EigenstateResult()
         eigenstate_result.eigenstates = groundstate_result.eigenstates
-        eigenstate_result.aux_operator_eigenvalues = (
-            groundstate_result.aux_operator_eigenvalues
-        )
+        eigenstate_result.aux_operator_eigenvalues = groundstate_result.aux_operator_eigenvalues
         eigenstate_result.raw_result = qeom_result
 
         eigenstate_result.eigenenergies = np.append(
             groundstate_result.eigenenergies,
-            np.asarray(
-                [groundstate_result.eigenenergies[0] + gap for gap in energy_gaps]
-            ),
+            np.asarray([groundstate_result.eigenenergies[0] + gap for gap in energy_gaps]),
         )
 
         result = problem.interpret(eigenstate_result)
@@ -245,9 +236,7 @@ class QEOM(ExcitedStatesSolver):
             z2_symmetries = Z2Symmetries([], [], [])
 
         if not z2_symmetries.is_empty():
-            combinations = itertools.product(
-                [1, -1], repeat=len(z2_symmetries.symmetries)
-            )
+            combinations = itertools.product([1, -1], repeat=len(z2_symmetries.symmetries))
             for targeted_tapering_values in combinations:
                 logger.info(
                     "In sector: (%s)",
@@ -268,9 +257,7 @@ class QEOM(ExcitedStatesSolver):
 
         else:
             # untapered_qubit_op is a PauliSumOp and should not be exposed.
-            _build_one_sector(
-                hopping_operators, self._untapered_qubit_op_main, z2_symmetries
-            )
+            _build_one_sector(hopping_operators, self._untapered_qubit_op_main, z2_symmetries)
 
         return all_matrix_operators
 
@@ -339,9 +326,7 @@ class QEOM(ExcitedStatesSolver):
 
     def _build_eom_matrices(
         self, gs_results: Dict[str, List[float]], size: int
-    ) -> Tuple[
-        np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, float, float
-    ]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, float, float]:
         """Constructs the M, V, Q and W matrices from the results on the ground state
 
         Args:

--- a/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
@@ -216,7 +216,7 @@ class AdaptVQE(GroundStateEigensolver):
                 logger.info(gradlog)
             if np.abs(max_grad[0]) < self._threshold:
                 logger.info(
-                    "Adaptive VQE terminated successfully " "with a final maximum gradient: %s",
+                    "Adaptive VQE terminated successfully with a final maximum gradient: %s",
                     str(np.abs(max_grad[0])),
                 )
                 threshold_satisfied = True

--- a/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
@@ -99,9 +99,7 @@ class AdaptVQE(GroundStateEigensolver):
             vqe.ansatz = self._ansatz
             ansatz_params = vqe.ansatz._parameter_table.keys()
             # construct the expectation operator of the VQE
-            vqe._expect_op = vqe.construct_expectation(
-                ansatz_params, self._main_operator
-            )
+            vqe._expect_op = vqe.construct_expectation(ansatz_params, self._main_operator)
             # evaluate energies
             parameter_sets = theta + [-self._delta] + theta + [self._delta]
             energy_results = vqe._energy_evaluation(np.asarray(parameter_sets))
@@ -179,13 +177,9 @@ class AdaptVQE(GroundStateEigensolver):
             vqe = self._solver
 
         if not isinstance(vqe, VQE):
-            raise QiskitNatureError(
-                "The AdaptVQE algorithm requires the use of the VQE solver"
-            )
+            raise QiskitNatureError("The AdaptVQE algorithm requires the use of the VQE solver")
         if not isinstance(vqe.ansatz, UCC):
-            raise QiskitNatureError(
-                "The AdaptVQE algorithm requires the use of the UCC ansatz"
-            )
+            raise QiskitNatureError("The AdaptVQE algorithm requires the use of the UCC ansatz")
 
         # We construct the ansatz once to be able to extract the full set of excitation operators.
         self._ansatz = copy.deepcopy(vqe.ansatz)
@@ -222,8 +216,7 @@ class AdaptVQE(GroundStateEigensolver):
                 logger.info(gradlog)
             if np.abs(max_grad[0]) < self._threshold:
                 logger.info(
-                    "Adaptive VQE terminated successfully "
-                    "with a final maximum gradient: %s",
+                    "Adaptive VQE terminated successfully " "with a final maximum gradient: %s",
                     str(np.abs(max_grad[0])),
                 )
                 threshold_satisfied = True
@@ -263,9 +256,7 @@ class AdaptVQE(GroundStateEigensolver):
         elif max_iterations_exceeded:
             finishing_criterion = "Maximum number of iterations reached"
         else:
-            raise QiskitNatureError(
-                "The algorithm finished due to an unforeseen reason!"
-            )
+            raise QiskitNatureError("The algorithm finished due to an unforeseen reason!")
 
         electronic_result = problem.interpret(raw_vqe_result)
 

--- a/qiskit_nature/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -54,9 +54,7 @@ class GroundStateEigensolver(GroundStateSolver):
         return self._solver
 
     @solver.setter
-    def solver(
-        self, solver: Union[MinimumEigensolver, MinimumEigensolverFactory]
-    ) -> None:
+    def solver(self, solver: Union[MinimumEigensolver, MinimumEigensolverFactory]) -> None:
         """Sets the minimum eigensolver or factory."""
         self._solver = solver
 
@@ -129,9 +127,7 @@ class GroundStateEigensolver(GroundStateSolver):
             OperatorBase,
         ],
         operators: Union[PauliSumOp, OperatorBase, list, dict],
-    ) -> Union[
-        Optional[float], List[Optional[float]], Dict[str, List[Optional[float]]]
-    ]:
+    ) -> Union[Optional[float], List[Optional[float]], Dict[str, List[Optional[float]]]]:
         """Evaluates additional operators at the given state.
 
         Args:
@@ -160,18 +156,14 @@ class GroundStateEigensolver(GroundStateSolver):
                 if op is None:
                     results.append(None)
                 else:
-                    results.append(
-                        self._eval_op(state, op, quantum_instance, expectation)
-                    )
+                    results.append(self._eval_op(state, op, quantum_instance, expectation))
         elif isinstance(operators, dict):
             results = {}  # type: ignore
             for name, op in operators.items():
                 if op is None:
                     results[name] = None
                 else:
-                    results[name] = self._eval_op(
-                        state, op, quantum_instance, expectation
-                    )
+                    results[name] = self._eval_op(state, op, quantum_instance, expectation)
         else:
             if operators is None:
                 results = None

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
@@ -198,9 +198,7 @@ class VQEUCCFactory(MinimumEigensolverFactory):
 
         initial_state = self.initial_state
         if initial_state is None:
-            initial_state = HartreeFock(
-                num_spin_orbitals, num_particles, qubit_converter
-            )
+            initial_state = HartreeFock(num_spin_orbitals, num_particles, qubit_converter)
 
         ansatz = self.ansatz
         if ansatz is None:

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
@@ -189,9 +189,7 @@ class VQEUVCCFactory(MinimumEigensolverFactory):
             by ``transformation``.
         """
 
-        watson_hamiltonian_transformed = cast(
-            WatsonHamiltonian, problem.molecule_data_transformed
-        )
+        watson_hamiltonian_transformed = cast(WatsonHamiltonian, problem.molecule_data_transformed)
         num_modals = problem.num_modals
         num_modes = watson_hamiltonian_transformed.num_modes
 

--- a/qiskit_nature/algorithms/pes_samplers/bopes_sampler.py
+++ b/qiskit_nature/algorithms/pes_samplers/bopes_sampler.py
@@ -77,9 +77,7 @@ class BOPESSampler:
                 if not isinstance(self._extrapolator, WindowExtrapolator):
                     raise QiskitNatureError(
                         "If num_bootstrap >= 2 then the extrapolator must be an instance "
-                        "of WindowExtrapolator, got {} instead".format(
-                            self._extrapolator
-                        )
+                        "of WindowExtrapolator, got {} instead".format(self._extrapolator)
                     )
                 self._num_bootstrap = num_bootstrap
                 self._extrapolator.window = num_bootstrap  # window for extrapolator
@@ -176,9 +174,7 @@ class BOPESSampler:
             # Set initial params # if prev_points not empty
             if prev_points:
                 if n_pp <= n_boot:
-                    distances = np.array(point) - np.array(prev_points).reshape(
-                        n_pp, -1
-                    )
+                    distances = np.array(point) - np.array(prev_points).reshape(n_pp, -1)
                     # find min 'distance' from point to previous points
                     min_index = np.argmin(np.linalg.norm(distances, axis=1))
                     # update initial point

--- a/qiskit_nature/algorithms/pes_samplers/extrapolator.py
+++ b/qiskit_nature/algorithms/pes_samplers/extrapolator.py
@@ -269,9 +269,7 @@ class WindowExtrapolator(Extrapolator):
         """
         ret_params = {}
         sorted_points = sorted(points)
-        reference_points = [
-            pt for pt in sorted(param_dict.keys()) if pt < max(sorted_points)
-        ]
+        reference_points = [pt for pt in sorted(param_dict.keys()) if pt < max(sorted_points)]
 
         for bottom_index, bottom in enumerate(reference_points):
             if bottom_index < len(reference_points) - 1:
@@ -340,9 +338,7 @@ class PCAExtrapolator(Extrapolator):
 
     def __init__(
         self,
-        extrapolator: Optional[
-            Union[PolynomialExtrapolator, DifferentialExtrapolator]
-        ] = None,
+        extrapolator: Optional[Union[PolynomialExtrapolator, DifferentialExtrapolator]] = None,
         kernel: Optional[str] = None,
         window: int = 2,
     ) -> None:
@@ -360,9 +356,7 @@ class PCAExtrapolator(Extrapolator):
         Raises:
             QiskitNatureError: if kernel is not defined in sklearn module.
         """
-        self._extrapolator = WindowExtrapolator(
-            extrapolator=extrapolator, window=window
-        )
+        self._extrapolator = WindowExtrapolator(extrapolator=extrapolator, window=window)
         self._kernel = kernel
         if self._kernel is None:
             self._pca_model = PCA()
@@ -391,12 +385,9 @@ class PCAExtrapolator(Extrapolator):
         # run pca fitting and extrapolate in pca space
         self._pca_model.fit(list(param_dict.values()))
         updated_params = {
-            pt: self._pca_model.transform([param_dict[pt]])[0]
-            for pt in list(param_dict.keys())
+            pt: self._pca_model.transform([param_dict[pt]])[0] for pt in list(param_dict.keys())
         }
-        output_params = self._extrapolator.extrapolate(
-            points, param_dict=updated_params
-        )
+        output_params = self._extrapolator.extrapolate(points, param_dict=updated_params)
 
         ret_params = {
             point: self._pca_model.inverse_transform(param) if not param else []
@@ -414,9 +405,7 @@ class SieveExtrapolator(Extrapolator):
 
     def __init__(
         self,
-        extrapolator: Optional[
-            Union[PolynomialExtrapolator, DifferentialExtrapolator]
-        ] = None,
+        extrapolator: Optional[Union[PolynomialExtrapolator, DifferentialExtrapolator]] = None,
         window: int = 2,
         filter_before: bool = True,
         filter_after: bool = True,
@@ -432,9 +421,7 @@ class SieveExtrapolator(Extrapolator):
             filter_after: Keyword to perform clustering after extrapolation.
 
         """
-        self._extrapolator = WindowExtrapolator(
-            extrapolator=extrapolator, window=window
-        )
+        self._extrapolator = WindowExtrapolator(extrapolator=extrapolator, window=window)
         self._filter_before = filter_before
         self._filter_after = filter_after
 
@@ -461,27 +448,19 @@ class SieveExtrapolator(Extrapolator):
         """
         # determine clustering cutoff
         param_arr = np.transpose(list(param_dict.values()))
-        param_averages = np.array(
-            sorted(np.average(np.log10(np.abs(param_arr)), axis=0))
-        )
+        param_averages = np.array(sorted(np.average(np.log10(np.abs(param_arr)), axis=0)))
         gaps = param_averages[1:] - param_averages[:-1]
         max_gap = int(np.argmax(gaps))
-        sieve_cutoff = 10 ** np.average(
-            [param_averages[max_gap], param_averages[max_gap + 1]]
-        )
+        sieve_cutoff = 10 ** np.average([param_averages[max_gap], param_averages[max_gap + 1]])
 
         if self._filter_before:
             filtered_dict = {
                 point: list(map(lambda x: x if np.abs(x) > sieve_cutoff else 0, param))
                 for (point, param) in param_dict.items()
             }
-            output_params = self._extrapolator.extrapolate(
-                points, param_dict=filtered_dict
-            )
+            output_params = self._extrapolator.extrapolate(points, param_dict=filtered_dict)
         else:
-            output_params = self._extrapolator.extrapolate(
-                points, param_dict=param_dict
-            )
+            output_params = self._extrapolator.extrapolate(points, param_dict=param_dict)
 
         if self._filter_after:
             ret_params = cast(

--- a/qiskit_nature/algorithms/pes_samplers/potentials/harmonic_potential.py
+++ b/qiskit_nature/algorithms/pes_samplers/potentials/harmonic_potential.py
@@ -122,9 +122,7 @@ class HarmonicPotential(PotentialBase):
         # do the Harmonic potential fit here, the order of parameters is
         # [k (Hartrees/(Ang**2)), r_0 (Ang), energy_shift (Hartrees)]
         h_p0 = initial_vals if initial_vals is not None else np.array([0.2, 0.735, 1.5])
-        h_bounds = (
-            bounds_list if bounds_list is not None else ([0, -1, -2], [2, 3.0, 2])
-        )
+        h_bounds = bounds_list if bounds_list is not None else ([0, -1, -2], [2, 3.0, 2])
 
         xdata_fit = xdata
         ydata_fit = ydata
@@ -238,9 +236,7 @@ class HarmonicPotential(PotentialBase):
         return e_n * const.J_TO_HARTREE
 
     @classmethod
-    def process_fit_data(
-        cls, xdata: List[float], ydata: List[float]
-    ) -> Tuple[list, list]:
+    def process_fit_data(cls, xdata: List[float], ydata: List[float]) -> Tuple[list, list]:
         """
         Mostly for internal use. Preprocesses the data passed to fit_to_data()
             so that only the points around the minimum are fit (which gives
@@ -265,9 +261,7 @@ class HarmonicPotential(PotentialBase):
         # is minimum
         all_of_min = np.array([], dtype=int)
         for i in x_min:
-            all_of_min = np.concatenate(
-                (all_of_min, np.where(xdata_s == xdata_s[i])[0])
-            )
+            all_of_min = np.concatenate((all_of_min, np.where(xdata_s == xdata_s[i])[0]))
         # array of indices where X is equal to the next smaller value
         left_of_min = []
         if min(all_of_min) > 0:

--- a/qiskit_nature/algorithms/pes_samplers/potentials/morse_potential.py
+++ b/qiskit_nature/algorithms/pes_samplers/potentials/morse_potential.py
@@ -58,9 +58,7 @@ class MorsePotential(PotentialBase):
             raise ValueError("Molecule masses need to be provided")
 
     @staticmethod
-    def fit_function(
-        x: float, d_e: float, alpha: float, r_0: float, m_shift: float
-    ) -> float:
+    def fit_function(x: float, d_e: float, alpha: float, r_0: float, m_shift: float) -> float:
         """Functional form of the potential.
 
         Args:
@@ -130,20 +128,12 @@ class MorsePotential(PotentialBase):
         # do the Morse potential fit
         # here, the order of parameters is
         # [d_e (Hartree), alpha (1/ang), r_0 (ang), energy_shift (Hartree)]
-        m_p0 = (
-            initial_vals
-            if initial_vals is not None
-            else np.array([0.25, 2, 0.735, 1.5])
-        )
+        m_p0 = initial_vals if initial_vals is not None else np.array([0.25, 2, 0.735, 1.5])
         m_bounds = (
-            bounds_list
-            if bounds_list is not None
-            else ([0, 0, 0.3, -5], [2.5, np.inf, 1.0, 5])
+            bounds_list if bounds_list is not None else ([0, 0, 0.3, -5], [2.5, np.inf, 1.0, 5])
         )
 
-        fit, _ = curve_fit(
-            self.fit_function, xdata, ydata, p0=m_p0, maxfev=100000, bounds=m_bounds
-        )
+        fit, _ = curve_fit(self.fit_function, xdata, ydata, p0=m_p0, maxfev=100000, bounds=m_bounds)
 
         self.d_e = fit[0]
         self.alpha = fit[1]
@@ -233,9 +223,9 @@ class MorsePotential(PotentialBase):
         d_e = self.d_e * const.HARTREE_TO_J  # Hartree, need J/molecule
 
         omega_0 = self.fundamental_frequency()
-        e_n = const.H_J_S * omega_0 * (n + 0.5) - (
-            (const.H_J_S * omega_0 * (n + 0.5)) ** 2
-        ) / (4 * d_e)
+        e_n = const.H_J_S * omega_0 * (n + 0.5) - ((const.H_J_S * omega_0 * (n + 0.5)) ** 2) / (
+            4 * d_e
+        )
 
         # energy level
         return e_n * const.J_TO_HARTREE

--- a/qiskit_nature/circuit/library/ansatzes/chc.py
+++ b/qiskit_nature/circuit/library/ansatzes/chc.py
@@ -173,9 +173,7 @@ class CHC(BlueprintCircuit):
         q = self.qubits
 
         if isinstance(self._initial_state, QuantumCircuit):
-            self.append(
-                self._initial_state.to_gate(), range(self._initial_state.num_qubits)
-            )
+            self.append(self._initial_state.to_gate(), range(self._initial_state.num_qubits))
 
         count = 0
         for _ in range(self._reps):

--- a/qiskit_nature/circuit/library/ansatzes/evolved_operator_ansatz.py
+++ b/qiskit_nature/circuit/library/ansatzes/evolved_operator_ansatz.py
@@ -116,9 +116,7 @@ class EvolvedOperatorAnsatz(BlueprintCircuit):
 
         if len(operators) > 1:
             num_qubits = operators[0].num_qubits
-            if any(
-                operators[i].num_qubits != num_qubits for i in range(1, len(operators))
-            ):
+            if any(operators[i].num_qubits != num_qubits for i in range(1, len(operators))):
                 raise ValueError("All operators must act on the same number of qubits.")
 
         self._invalidate()
@@ -163,9 +161,7 @@ class EvolvedOperatorAnsatz(BlueprintCircuit):
 
         # get the evolved operators as circuits
         coeff = Parameter("c")
-        evolved_ops = [
-            self.evolution.convert((coeff * op).exp_i()) for op in self.operators
-        ]
+        evolved_ops = [self.evolution.convert((coeff * op).exp_i()) for op in self.operators]
         circuits = [evolved_op.reduce().to_circuit() for evolved_op in evolved_ops]
 
         # set the registers
@@ -189,9 +185,7 @@ class EvolvedOperatorAnsatz(BlueprintCircuit):
                 else:
                     if self._insert_barriers:
                         self.barrier()
-                self.compose(
-                    circuit.assign_parameters({coeff: next(times_it)}), inplace=True
-                )
+                self.compose(circuit.assign_parameters({coeff: next(times_it)}), inplace=True)
 
         if self._initial_state:
             self.compose(self._initial_state, front=True, inplace=True)

--- a/qiskit_nature/circuit/library/ansatzes/puccd.py
+++ b/qiskit_nature/circuit/library/ansatzes/puccd.py
@@ -132,9 +132,7 @@ class PUCCD(UCC):
         alpha_unocc = list(range(num_electrons, beta_index_shift))
         # the Cartesian product of these lists gives all possible single alpha-spin excitations
         alpha_excitations = list(itertools.product(alpha_occ, alpha_unocc))
-        logger.debug(
-            "Generated list of single alpha excitations: %s", alpha_excitations
-        )
+        logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
 
         for alpha_exc in alpha_excitations:
             # create the beta-spin excitation by shifting into the upper block-spin orbital indices

--- a/qiskit_nature/circuit/library/ansatzes/succd.py
+++ b/qiskit_nature/circuit/library/ansatzes/succd.py
@@ -136,9 +136,7 @@ class SUCCD(UCC):
         alpha_unocc = list(range(num_electrons, beta_index_shift))
         # the Cartesian product of these lists gives all possible single alpha-spin excitations
         alpha_excitations = list(itertools.product(alpha_occ, alpha_unocc))
-        logger.debug(
-            "Generated list of single alpha excitations: %s", alpha_excitations
-        )
+        logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
 
         # Find all possible double excitations constructed from the list of single excitations.
         # Note, that we use `combinations_with_replacement` here, in order to also get those double

--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -165,9 +165,7 @@ class UCC(EvolvedOperatorAnsatz):
         self._beta_spin = beta_spin
         self._max_spin_excitation = max_spin_excitation
 
-        super().__init__(
-            reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state
-        )
+        super().__init__(reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state)
 
         # We cache these, because the generation may be quite expensive (depending on the generator)
         # and the user may want quick access to inspect these. Also, it speeds up testing for the
@@ -225,9 +223,7 @@ class UCC(EvolvedOperatorAnsatz):
     def _check_configuration(self, raise_on_failure: bool = True) -> bool:
         if self.num_spin_orbitals < 0:
             if raise_on_failure:
-                raise ValueError(
-                    "The number of spin orbitals cannot be smaller than 0."
-                )
+                raise ValueError("The number of spin orbitals cannot be smaller than 0.")
             return False
 
         if any(n < 0 for n in self.num_particles):
@@ -266,9 +262,7 @@ class UCC(EvolvedOperatorAnsatz):
             # the converter inserting None as the result if an operator did not commute. Here
             # we are not interested in that just getting the valid set of operators so that
             # behavior is suppressed.
-            self.operators = self.qubit_converter.convert_match(
-                excitation_ops, suppress_none=True
-            )
+            self.operators = self.qubit_converter.convert_match(excitation_ops, suppress_none=True)
 
         logger.debug("Building QuantumCircuit...")
         super()._build()
@@ -324,38 +318,28 @@ class UCC(EvolvedOperatorAnsatz):
                     partial(
                         generate_fermionic_excitations,
                         num_excitations=self.EXCITATION_TYPE[exc],
-                        **extra_kwargs
+                        **extra_kwargs,
                     )
                 )
         elif isinstance(self.excitations, int):
             generators.append(
                 partial(
-                    generate_fermionic_excitations,
-                    num_excitations=self.excitations,
-                    **extra_kwargs
+                    generate_fermionic_excitations, num_excitations=self.excitations, **extra_kwargs
                 )
             )
         elif isinstance(self.excitations, list):
             for exc in self.excitations:  # type: ignore
                 generators.append(
-                    partial(
-                        generate_fermionic_excitations,
-                        num_excitations=exc,
-                        **extra_kwargs
-                    )
+                    partial(generate_fermionic_excitations, num_excitations=exc, **extra_kwargs)
                 )
         elif callable(self.excitations):
             generators = [self.excitations]
         else:
-            raise QiskitNatureError(
-                "Invalid excitation configuration: {}".format(self.excitations)
-            )
+            raise QiskitNatureError("Invalid excitation configuration: {}".format(self.excitations))
 
         return generators
 
-    def _build_fermionic_excitation_ops(
-        self, excitations: Sequence
-    ) -> List[FermionicOp]:
+    def _build_fermionic_excitation_ops(self, excitations: Sequence) -> List[FermionicOp]:
         """Builds all possible excitation operators with the given number of excitations for the
         specified number of particles distributed in the number of orbitals.
 

--- a/qiskit_nature/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
+++ b/qiskit_nature/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
@@ -65,19 +65,13 @@ def generate_fermionic_excitations(
         alpha_unocc = list(range(num_particles[0], num_spin_orbitals // 2))
         # the Cartesian product of these lists gives all possible single alpha-spin excitations
         alpha_excitations = list(itertools.product(alpha_occ, alpha_unocc))
-        logger.debug(
-            "Generated list of single alpha excitations: %s", alpha_excitations
-        )
+        logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
 
     beta_excitations: List[Tuple[int, int]] = []
     if beta_spin:
         # generate beta-spin orbital indices for occupied and unoccupied ones
-        beta_occ = list(
-            range(num_spin_orbitals // 2, num_spin_orbitals // 2 + num_particles[1])
-        )
-        beta_unocc = list(
-            range(num_spin_orbitals // 2 + num_particles[1], num_spin_orbitals)
-        )
+        beta_occ = list(range(num_spin_orbitals // 2, num_spin_orbitals // 2 + num_particles[1]))
+        beta_unocc = list(range(num_spin_orbitals // 2 + num_particles[1], num_spin_orbitals))
         # the Cartesian product of these lists gives all possible single beta-spin excitations
         beta_excitations = list(itertools.product(beta_occ, beta_unocc))
         logger.debug("Generated list of single beta excitations: %s", beta_excitations)

--- a/qiskit_nature/circuit/library/ansatzes/uvcc.py
+++ b/qiskit_nature/circuit/library/ansatzes/uvcc.py
@@ -91,9 +91,7 @@ class UVCC(EvolvedOperatorAnsatz):
         self._num_modals = num_modals
         self._excitations = excitations
 
-        super().__init__(
-            reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state
-        )
+        super().__init__(reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state)
 
         # We cache these, because the generation may be quite expensive (depending on the generator)
         # and the user may want quick access to inspect these. Also, it speeds up testing for the
@@ -166,9 +164,7 @@ class UVCC(EvolvedOperatorAnsatz):
             excitation_ops = self.excitation_ops()
 
             logger.debug("Converting SecondQuantizedOps into PauliSumOps...")
-            self.operators = self.qubit_converter.convert_match(
-                excitation_ops, suppress_none=True
-            )
+            self.operators = self.qubit_converter.convert_match(excitation_ops, suppress_none=True)
 
         logger.debug("Building QuantumCircuit...")
         super()._build()
@@ -237,15 +233,11 @@ class UVCC(EvolvedOperatorAnsatz):
         elif callable(self.excitations):
             generators = [self.excitations]
         else:
-            raise QiskitNatureError(
-                "Invalid excitation configuration: {}".format(self.excitations)
-            )
+            raise QiskitNatureError("Invalid excitation configuration: {}".format(self.excitations))
 
         return generators
 
-    def _build_vibration_excitation_ops(
-        self, excitations: Sequence
-    ) -> List[VibrationalOp]:
+    def _build_vibration_excitation_ops(self, excitations: Sequence) -> List[VibrationalOp]:
         """Builds all possible excitation operators with the given number of excitations for the
         specified number of particles distributed in the number of orbitals.
 

--- a/qiskit_nature/circuit/library/initial_states/hartree_fock.py
+++ b/qiskit_nature/circuit/library/initial_states/hartree_fock.py
@@ -62,9 +62,7 @@ class HartreeFock(QuantumCircuit):
                 self.x(i)
 
 
-def hartree_fock_bitstring(
-    num_spin_orbitals: int, num_particles: Tuple[int, int]
-) -> List[bool]:
+def hartree_fock_bitstring(num_spin_orbitals: int, num_particles: Tuple[int, int]) -> List[bool]:
     """Compute the bitstring representing the Hartree-Fock state for the specified system.
 
     Args:

--- a/qiskit_nature/circuit/library/initial_states/vscf.py
+++ b/qiskit_nature/circuit/library/initial_states/vscf.py
@@ -57,9 +57,7 @@ class VSCF(QuantumCircuit):
 
         # encode the bitstring in a `VibrationalOp`
         label = ["+" if bit else "I" for bit in bitstr]
-        bitstr_op = VibrationalOp(
-            "".join(label), num_modes=len(num_modals), num_modals=num_modals
-        )
+        bitstr_op = VibrationalOp("".join(label), num_modes=len(num_modals), num_modals=num_modals)
 
         # map the `VibrationalOp` to a qubit operator
         if qubit_converter is not None:

--- a/qiskit_nature/converters/second_quantization/qubit_converter.py
+++ b/qiskit_nature/converters/second_quantization/qubit_converter.py
@@ -113,9 +113,7 @@ class QubitConverter:
         return self._z2symmetry_reduction
 
     @z2symmetry_reduction.setter
-    def z2symmetry_reduction(
-        self, z2symmetry_reduction: Optional[Union[str, List[int]]]
-    ) -> None:
+    def z2symmetry_reduction(self, z2symmetry_reduction: Optional[Union[str, List[int]]]) -> None:
         """Set z2symmetry_reduction"""
         if z2symmetry_reduction is not None:
             if isinstance(z2symmetry_reduction, str):
@@ -127,9 +125,7 @@ class QubitConverter:
             elif not np.all(np.isin(z2symmetry_reduction, [-1, 1])):
                 raise ValueError(
                     "z2symmetry_reduction tapering values list must "
-                    "contain -1's and/or 1's only but was {}".format(
-                        z2symmetry_reduction
-                    )
+                    "contain -1's and/or 1's only but was {}".format(z2symmetry_reduction)
                 )
 
         self._z2symmetry_reduction = z2symmetry_reduction
@@ -253,8 +249,7 @@ class QubitConverter:
 
         qubit_ops = [self._map(second_q_op) for second_q_op in second_q_ops]
         reduced_ops = [
-            self._two_qubit_reduce(qubit_op, self._num_particles)
-            for qubit_op in qubit_ops
+            self._two_qubit_reduce(qubit_op, self._num_particles) for qubit_op in qubit_ops
         ]
         tapered_ops = self._symmetry_reduce(reduced_ops, suppress_none)
 
@@ -317,9 +312,7 @@ class QubitConverter:
                 if sector_locator is not None and self.z2symmetry_reduction == "auto":
                     z2symmetry_reduction = sector_locator(z2_symmetries)
                     if z2symmetry_reduction is not None:
-                        self.z2symmetry_reduction = (
-                            z2symmetry_reduction  # Overrides any value
-                        )
+                        self.z2symmetry_reduction = z2symmetry_reduction  # Overrides any value
 
                     # We may end up that neither were we given a sector nor that the locator
                     # returned one. Since though we may have found valid symmetries above we should
@@ -389,9 +382,7 @@ class QubitConverter:
     def _check_commutes(cliffords: List[PauliSumOp], qubit_op: PauliSumOp) -> bool:
         commutes = []
         for clifford in cliffords:
-            commuting_rows = qubit_op.primitive.table.commutes_with_all(
-                clifford.primitive.table
-            )
+            commuting_rows = qubit_op.primitive.table.commutes_with_all(clifford.primitive.table)
             commutes.append(len(commuting_rows) == qubit_op.primitive.size)
         does_commute = bool(np.all(commutes))
         logger.debug("  '%s' commutes: %s, %s", id(qubit_op), does_commute, commutes)

--- a/qiskit_nature/drivers/bosonic_bases/bosonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/bosonic_basis.py
@@ -18,9 +18,7 @@ from typing import List, Tuple
 class BosonicBasis:
     """Basis to express a second quantization Bosonic Hamiltonian."""
 
-    def convert(
-        self, threshold: float = 1e-6
-    ) -> List[List[Tuple[List[List[int]], complex]]]:
+    def convert(self, threshold: float = 1e-6) -> List[List[Tuple[List[List[int]], complex]]]:
         """
         This prepares an array object representing a bosonic hamiltonian expressed
         in the harmonic basis. This object can directly be given to the BosonicOperator

--- a/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
@@ -106,7 +106,7 @@ class HarmonicBasis(BosonicBasis):
             elif m - n == 4:
                 coeff = np.sqrt(m * (m - 1) * (m - 2) * (m - 3)) / 4
         else:
-            raise ValueError("The Q power is to high, only up to 4 is " "currently supported.")
+            raise ValueError("The Q power is to high, only up to 4 is currently supported.")
         return coeff * (np.sqrt(2) ** power)
 
     def _is_in_basis(self, indices, order, i):
@@ -340,7 +340,7 @@ class HarmonicBasis(BosonicBasis):
                                                 ] += coeff
             else:
                 raise ValueError(
-                    "Expansion of the PES is too large, only " "up to 3-body terms are supported"
+                    "Expansion of the PES is too large, only up to 3-body terms are supported"
                 )
 
         harmonics = []  # type: List[List[Tuple[List[List[int]], complex]]]

--- a/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
@@ -54,9 +54,7 @@ class HarmonicBasis(BosonicBasis):
         self._truncation_order = truncation_order
 
     @staticmethod
-    def _harmonic_integrals(
-        m: int, n: int, power: int, kinetic_term: bool = False
-    ) -> float:
+    def _harmonic_integrals(m: int, n: int, power: int, kinetic_term: bool = False) -> float:
         r"""Computes the integral of the Hamiltonian with the harmonic basis.
 
         This computation is as shown in [1].
@@ -108,9 +106,7 @@ class HarmonicBasis(BosonicBasis):
             elif m - n == 4:
                 coeff = np.sqrt(m * (m - 1) * (m - 2) * (m - 3)) / 4
         else:
-            raise ValueError(
-                "The Q power is to high, only up to 4 is " "currently supported."
-            )
+            raise ValueError("The Q power is to high, only up to 4 is " "currently supported.")
         return coeff * (np.sqrt(2) ** power)
 
     def _is_in_basis(self, indices, order, i):
@@ -122,9 +118,7 @@ class HarmonicBasis(BosonicBasis):
 
         return in_basis
 
-    def convert(
-        self, threshold: float = 1e-6
-    ) -> List[List[Tuple[List[List[int]], complex]]]:
+    def convert(self, threshold: float = 1e-6) -> List[List[Tuple[List[List[int]], complex]]]:
         """
         This prepares an array object representing a bosonic hamiltonian expressed
         in the harmonic basis. This object can directly be given to the BosonicOperator
@@ -145,9 +139,7 @@ class HarmonicBasis(BosonicBasis):
 
         harmonic_dict = {
             1: np.zeros((num_modes, num_modals, num_modals)),
-            2: np.zeros(
-                (num_modes, num_modals, num_modals, num_modes, num_modals, num_modals)
-            ),
+            2: np.zeros((num_modes, num_modals, num_modals, num_modes, num_modals, num_modals)),
             3: np.zeros(
                 (
                     num_modes,
@@ -163,9 +155,7 @@ class HarmonicBasis(BosonicBasis):
             ),
         }
 
-        for (
-            entry
-        ) in self._watson.data:  # Entry is coeff (float) followed by indices (ints)
+        for entry in self._watson.data:  # Entry is coeff (float) followed by indices (ints)
             coeff0 = cast(float, entry[0])
             indices = cast(List[int], entry[1:])
 
@@ -350,8 +340,7 @@ class HarmonicBasis(BosonicBasis):
                                                 ] += coeff
             else:
                 raise ValueError(
-                    "Expansion of the PES is too large, only "
-                    "up to 3-body terms are supported"
+                    "Expansion of the PES is too large, only " "up to 3-body terms are supported"
                 )
 
         harmonics = []  # type: List[List[Tuple[List[List[int]], complex]]]

--- a/qiskit_nature/drivers/fcidumpd/dumper.py
+++ b/qiskit_nature/drivers/fcidumpd/dumper.py
@@ -53,9 +53,7 @@ def dump(
     mos = range(norb)
     with open(outpath, "w") as outfile:
         # print header
-        outfile.write(
-            "&FCI NORB={:4d},NELEC={:4d},MS2={:4d}\n".format(norb, nelec, ms2)
-        )
+        outfile.write("&FCI NORB={:4d},NELEC={:4d},MS2={:4d}\n".format(norb, nelec, ms2))
         if orbsym is None:
             outfile.write(" ORBSYM=" + "1," * norb + "\n")
         else:
@@ -87,9 +85,7 @@ def _dump_1e_ints(
     hij_elements = set()
     for i, j in itertools.product(mos, repeat=2):
         if i == j:
-            _write_to_outfile(
-                outfile, hij[i][j], (i + idx_offset, j + idx_offset, 0, 0)
-            )
+            _write_to_outfile(outfile, hij[i][j], (i + idx_offset, j + idx_offset, 0, 0))
             continue
         if (j, i) in hij_elements and np.isclose(hij[i][j], hij[j][i]):
             continue

--- a/qiskit_nature/drivers/fcidumpd/fcidumpdriver.py
+++ b/qiskit_nature/drivers/fcidumpd/fcidumpdriver.py
@@ -49,9 +49,7 @@ class FCIDumpDriver(FermionicDriver):
         super().__init__()
 
         if not isinstance(fcidump_input, str):
-            raise QiskitNatureError(
-                "The fcidump_input must be str, not '{}'".format(fcidump_input)
-            )
+            raise QiskitNatureError("The fcidump_input must be str, not '{}'".format(fcidump_input))
         self._fcidump_input = fcidump_input
 
         if (
@@ -60,9 +58,7 @@ class FCIDumpDriver(FermionicDriver):
             and not all(sym in QMolecule.symbols for sym in atoms)
         ):
             raise QiskitNatureError(
-                "The atoms must be a list of valid atomic symbols, not '{}'".format(
-                    atoms
-                )
+                "The atoms must be a list of valid atomic symbols, not '{}'".format(atoms)
             )
         self.atoms = atoms
 
@@ -85,9 +81,7 @@ class FCIDumpDriver(FermionicDriver):
         if self.atoms is not None:
             q_mol.num_atoms = len(self.atoms)
             q_mol.atom_symbol = self.atoms
-            q_mol.atom_xyz = [[float("NaN")] * 3] * len(
-                self.atoms
-            )  # ensures QMolecule.log() works
+            q_mol.atom_xyz = [[float("NaN")] * 3] * len(self.atoms)  # ensures QMolecule.log() works
 
         q_mol.mo_onee_ints = fcidump_data.get("hij", None)
         q_mol.mo_onee_ints_b = fcidump_data.get("hij_b", None)

--- a/qiskit_nature/drivers/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/fcidumpd/parser.py
@@ -37,9 +37,7 @@ def parse(fcidump: str) -> Dict[str, Any]:
         with open(fcidump, "r") as file:
             fcidump_str = file.read()
     except OSError as ex:
-        raise QiskitNatureError(
-            "Input file '{}' cannot be read!".format(fcidump)
-        ) from ex
+        raise QiskitNatureError("Input file '{}' cannot be read!".format(fcidump)) from ex
 
     output = {}  # type: Dict[str, Any]
 
@@ -57,16 +55,12 @@ def parse(fcidump: str) -> Dict[str, Any]:
     # we parse the values in the order in which they are listed in Knowles1989
     _norb = re.search("NORB" + pattern, metadata)
     if _norb is None:
-        raise QiskitNatureError(
-            "The required NORB entry of the FCIDump format is missing!"
-        )
+        raise QiskitNatureError("The required NORB entry of the FCIDump format is missing!")
     norb = int(_norb.groups()[0])
     output["NORB"] = norb
     _nelec = re.search("NELEC" + pattern, metadata)
     if _nelec is None:
-        raise QiskitNatureError(
-            "The required NELEC entry of the FCIDump format is missing!"
-        )
+        raise QiskitNatureError("The required NELEC entry of the FCIDump format is missing!")
     output["NELEC"] = int(_nelec.groups()[0])
     # the rest of these values may occur and are set to their defaults otherwise
     _ms2 = re.search("MS2" + pattern, metadata)
@@ -123,12 +117,8 @@ def parse(fcidump: str) -> Dict[str, Any]:
         hijkl_ab = np.zeros((norb, norb, norb, norb))
         hijkl_ba = np.zeros((norb, norb, norb, norb))
         hijkl_bb = np.zeros((norb, norb, norb, norb))
-        hijkl_ab_elements = set(
-            itertools.product(range(norb), range(norb), beta_range, beta_range)
-        )
-        hijkl_ba_elements = set(
-            itertools.product(beta_range, beta_range, range(norb), range(norb))
-        )
+        hijkl_ab_elements = set(itertools.product(range(norb), range(norb), beta_range, beta_range))
+        hijkl_ba_elements = set(itertools.product(beta_range, beta_range, range(norb), range(norb)))
         hijkl_bb_elements = set(itertools.product(beta_range, repeat=4))
     orbital_data = fcidump_str[namelist_end.end(0) :].split("\n")
     for orbital in orbital_data:
@@ -137,9 +127,7 @@ def parse(fcidump: str) -> Dict[str, Any]:
         x = float(orbital.split()[0])
         # Note: differing naming than ijkl due to E741 and this iajb is inline with this:
         # https://hande.readthedocs.io/en/latest/manual/integrals.html#fcidump-format
-        i, a, j, b = [
-            int(i) for i in orbital.split()[1:]
-        ]  # pylint: disable=invalid-name
+        i, a, j, b = [int(i) for i in orbital.split()[1:]]  # pylint: disable=invalid-name
         if i == a == j == b == 0:
             output["ecore"] = x
         elif a == j == b == 0:
@@ -175,9 +163,7 @@ def parse(fcidump: str) -> Dict[str, Any]:
                             hijkl_ba[i - 1 - norb][a - 1 - norb][j - 1][b - 1] = x
                         except KeyError:
                             hijkl_bb_elements.remove((i - 1, a - 1, j - 1, b - 1))
-                            hijkl_bb[i - 1 - norb][a - 1 - norb][j - 1 - norb][
-                                b - 1 - norb
-                            ] = x
+                            hijkl_bb[i - 1 - norb][a - 1 - norb][j - 1 - norb][b - 1 - norb] = x
                 else:
                     raise QiskitNatureError(
                         "Unkown 2-electron integral indices encountered in \

--- a/qiskit_nature/drivers/gaussiand/gaussian_forces_driver.py
+++ b/qiskit_nature/drivers/gaussiand/gaussian_forces_driver.py
@@ -69,9 +69,7 @@ class GaussianForcesDriver(BosonicDriver):
             QiskitNatureError: If `jcf` or `molecule` given and Gaussian™ 16 executable
                 cannot be located.
         """
-        super().__init__(
-            molecule=molecule, basis=basis, hf_method="", supports_molecule=True
-        )
+        super().__init__(molecule=molecule, basis=basis, hf_method="", supports_molecule=True)
         self._jcf = jcf
         self._logfile = None
         self._normalize = normalize
@@ -104,16 +102,11 @@ class GaussianForcesDriver(BosonicDriver):
         elif self.molecule.units == UnitsType.BOHR:
             units = "Bohr"
         else:
-            raise QiskitNatureError(
-                "Unknown unit '{}'".format(self.molecule.units.value)
-            )
+            raise QiskitNatureError("Unknown unit '{}'".format(self.molecule.units.value))
         cfg1 = f"#p B3LYP/{self.basis} UNITS={units} Freq=(Anharm) Int=Ultrafine SCF=VeryTight\n\n"
         name = "".join([name for (name, _) in self.molecule.geometry])
         geom = "\n".join(
-            [
-                name + " " + " ".join(map(str, coord))
-                for (name, coord) in self.molecule.geometry
-            ]
+            [name + " " + " ".join(map(str, coord)) for (name, coord) in self.molecule.geometry]
         )
         cfg2 = f"{name} geometry optimization\n\n"
         cfg3 = f"{self.molecule.charge} {self.molecule.multiplicity}\n{geom}\n\n"

--- a/qiskit_nature/drivers/gaussiand/gaussian_log_driver.py
+++ b/qiskit_nature/drivers/gaussiand/gaussian_log_driver.py
@@ -49,9 +49,7 @@ class GaussianLogDriver(BaseDriver):
         GaussianLogDriver._check_valid()
 
         if not isinstance(jcf, list) and not isinstance(jcf, str):
-            raise QiskitNatureError(
-                "Invalid input for Gaussian Log Driver '{}'".format(jcf)
-            )
+            raise QiskitNatureError("Invalid input for Gaussian Log Driver '{}'".format(jcf))
 
         if isinstance(jcf, list):
             jcf = "\n".join(jcf)

--- a/qiskit_nature/drivers/gaussiand/gaussian_log_result.py
+++ b/qiskit_nature/drivers/gaussiand/gaussian_log_result.py
@@ -173,15 +173,11 @@ class GaussianLogResult:
                 if re.search(r"\s+\(H\)\s+\|", line) is not None:
                     logger.debug(line)
                     found_h = True
-                    h_nums = [
-                        x.strip() for x in line.split("|") if x and "(H)" not in x
-                    ]
+                    h_nums = [x.strip() for x in line.split("|") if x and "(H)" not in x]
                 elif re.search(r"\s+\(A\)\s+\|", line) is not None:
                     logger.debug(line)
                     found_a = True
-                    a_nums = [
-                        x.strip() for x in line.split("|") if x and "(A)" not in x
-                    ]
+                    a_nums = [x.strip() for x in line.split("|") if x and "(A)" not in x]
 
                 if found_h and found_a:
                     for i, a_num in enumerate(a_nums):

--- a/qiskit_nature/drivers/gaussiand/gaussian_utils.py
+++ b/qiskit_nature/drivers/gaussiand/gaussian_utils.py
@@ -52,9 +52,7 @@ def run_g16(cfg: str) -> str:
     """
     process = None
     try:
-        with Popen(
-            _GAUSSIAN_16, stdin=PIPE, stdout=PIPE, universal_newlines=True
-        ) as process:
+        with Popen(_GAUSSIAN_16, stdin=PIPE, stdout=PIPE, universal_newlines=True) as process:
             stdout, _ = process.communicate(cfg)
             process.wait()
     except Exception as ex:
@@ -74,9 +72,7 @@ def run_g16(cfg: str) -> str:
                 logger.error(lines[i])
                 errmsg += lines[i] + "\n"
         raise QiskitNatureError(
-            "{} process return code {}\n{}".format(
-                _GAUSSIAN_16_DESC, process.returncode, errmsg
-            )
+            "{} process return code {}\n{}".format(_GAUSSIAN_16_DESC, process.returncode, errmsg)
         )
 
     all_text = ""

--- a/qiskit_nature/drivers/gaussiand/gaussiandriver.py
+++ b/qiskit_nature/drivers/gaussiand/gaussiandriver.py
@@ -71,9 +71,7 @@ class GaussianDriver(FermionicDriver):
         """
         GaussianDriver._check_valid()
         if not isinstance(config, str) and not isinstance(config, list):
-            raise QiskitNatureError(
-                "Invalid config for Gaussian Driver '{}'".format(config)
-            )
+            raise QiskitNatureError("Invalid config for Gaussian Driver '{}'".format(config))
 
         if isinstance(config, list):
             config = "\n".join(config)
@@ -97,16 +95,11 @@ class GaussianDriver(FermionicDriver):
         elif self.molecule.units == UnitsType.BOHR:
             units = "Bohr"
         else:
-            raise QiskitNatureError(
-                "Unknown unit '{}'".format(self.molecule.units.value)
-            )
+            raise QiskitNatureError("Unknown unit '{}'".format(self.molecule.units.value))
         cfg1 = f"# {self.hf_method}/{self.basis} UNITS={units} scf(conventional)\n\n"
         name = "".join([name for (name, _) in self.molecule.geometry])
         geom = "\n".join(
-            [
-                name + " " + " ".join(map(str, coord))
-                for (name, coord) in self.molecule.geometry
-            ]
+            [name + " " + " ".join(map(str, coord)) for (name, coord) in self.molecule.geometry]
         )
         cfg2 = f"{name} molecule\n\n"
         cfg3 = f"{self.molecule.charge} {self.molecule.multiplicity}\n{geom}\n\n"
@@ -169,9 +162,7 @@ class GaussianDriver(FermionicDriver):
                         while not added:
                             line = inf.readline()
                             if not line:
-                                raise QiskitNatureError(
-                                    "Unexpected end of Gaussian input"
-                                )
+                                raise QiskitNatureError("Unexpected end of Gaussian input")
                             if not line.strip():
                                 outf.write(
                                     "# Window=Full Int=NoRaff Symm=(NoInt,None) "
@@ -229,9 +220,7 @@ class GaussianDriver(FermionicDriver):
         """
         try:
             # add gauopen to sys.path so that binaries can be loaded
-            gauopen_directory = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "gauopen"
-            )
+            gauopen_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gauopen")
             if gauopen_directory not in sys.path:
                 sys.path.insert(0, gauopen_directory)
             # pylint: disable=import-outside-toplevel
@@ -297,9 +286,7 @@ class GaussianDriver(FermionicDriver):
             # From Gaussian interfacing documentation: "The two
             # core Hamiltonians are identical unless
             # a Fermi contact perturbation has been applied."
-            logger.debug(
-                "CORE HAMILTONIAN ALPHA and BETA identical, keeping only ALPHA"
-            )
+            logger.debug("CORE HAMILTONIAN ALPHA and BETA identical, keeping only ALPHA")
             hcore_b = None
         logger.debug(
             "CORE HAMILTONIAN BETA %s",
@@ -312,9 +299,7 @@ class GaussianDriver(FermionicDriver):
         mohij = QMolecule.oneeints2mo(hcore, moc)
         mohij_b = None
         if moc_b is not None:
-            mohij_b = QMolecule.oneeints2mo(
-                hcore if hcore_b is None else hcore_b, moc_b
-            )
+            mohij_b = QMolecule.oneeints2mo(hcore if hcore_b is None else hcore_b, moc_b)
 
         eri = GaussianDriver._get_matrix(mel, "REGULAR 2E INTEGRALS")
         logger.debug("REGULAR 2E INTEGRALS %s", eri.shape)

--- a/qiskit_nature/drivers/molecule.py
+++ b/qiskit_nature/drivers/molecule.py
@@ -71,9 +71,7 @@ class Molecule:
         self._perturbations = None  # type: Optional[List[float]]
 
     @staticmethod
-    def _check_consistency(
-        geometry: List[Tuple[str, List[float]]], masses: Optional[List[float]]
-    ):
+    def _check_consistency(geometry: List[Tuple[str, List[float]]], masses: Optional[List[float]]):
         if masses is not None and len(masses) != len(geometry):
             raise ValueError(
                 "Length of masses {} must match length of geometries {}".format(
@@ -110,9 +108,7 @@ class Molecule:
         starting_distance_vector = starting_coord1 - coord2
         starting_l2distance = np.linalg.norm(starting_distance_vector)
         new_l2distance = function(starting_l2distance, parameter)
-        new_distance_vector = starting_distance_vector * (
-            new_l2distance / starting_l2distance
-        )
+        new_distance_vector = starting_distance_vector * (new_l2distance / starting_l2distance)
         new_coord1 = coord2 + new_distance_vector
 
         ending_geometry = copy.deepcopy(geometry)
@@ -242,9 +238,7 @@ class Molecule:
         )
         new_angle = function(starting_angle, parameter)
         perturbation = new_angle - starting_angle
-        rot_matrix = scipy.linalg.expm(
-            np.cross(np.eye(3), rot_unit_axis * perturbation)
-        )
+        rot_matrix = scipy.linalg.expm(np.cross(np.eye(3), rot_unit_axis * perturbation))
         new_coord1 = rot_matrix @ starting_coord1
 
         ending_geometry = copy.deepcopy(geometry)

--- a/qiskit_nature/drivers/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/psi4d/psi4driver.py
@@ -69,9 +69,7 @@ class PSI4Driver(FermionicDriver):
         """
         self._check_valid()
         if not isinstance(config, str) and not isinstance(config, list):
-            raise QiskitNatureError(
-                "Invalid config for PSI4 Driver '{}'".format(config)
-            )
+            raise QiskitNatureError("Invalid config for PSI4 Driver '{}'".format(config))
 
         if isinstance(config, list):
             config = "\n".join(config)
@@ -96,15 +94,10 @@ class PSI4Driver(FermionicDriver):
         elif self.molecule.units == UnitsType.BOHR:
             units = "bohr"
         else:
-            raise QiskitNatureError(
-                "Unknown unit '{}'".format(self.molecule.units.value)
-            )
+            raise QiskitNatureError("Unknown unit '{}'".format(self.molecule.units.value))
         name = "".join([name for (name, _) in self.molecule.geometry])
         geom = "\n".join(
-            [
-                name + " " + " ".join(map(str, coord))
-                for (name, coord) in self.molecule.geometry
-            ]
+            [name + " " + " ".join(map(str, coord)) for (name, coord) in self.molecule.geometry]
         )
         cfg1 = f"molecule {name} {{\nunits {units}\n"
         cfg2 = f"{self.molecule.charge} {self.molecule.multiplicity}\n"
@@ -120,17 +113,13 @@ class PSI4Driver(FermionicDriver):
 
         psi4d_directory = os.path.dirname(os.path.realpath(__file__))
         template_file = psi4d_directory + "/_template.txt"
-        qiskit_chemistry_directory = os.path.abspath(
-            os.path.join(psi4d_directory, "../..")
-        )
+        qiskit_chemistry_directory = os.path.abspath(os.path.join(psi4d_directory, "../.."))
 
         molecule = QMolecule()
 
         input_text = cfg + "\n"
         input_text += "import sys\n"
-        syspath = (
-            "['" + qiskit_chemistry_directory + "','" + "','".join(sys.path) + "']"
-        )
+        syspath = "['" + qiskit_chemistry_directory + "','" + "','".join(sys.path) + "']"
 
         input_text += "sys.path = " + syspath + " + sys.path\n"
         input_text += "from qiskit_nature.drivers.qmolecule import QMolecule\n"

--- a/qiskit_nature/drivers/pyquanted/integrals.py
+++ b/qiskit_nature/drivers/pyquanted/integrals.py
@@ -55,9 +55,7 @@ def compute_integrals(
     return q_mol
 
 
-def _calculate_integrals(
-    molecule, basis="sto3g", hf_method="rhf", tol=1e-8, maxiters=100
-):
+def _calculate_integrals(molecule, basis="sto3g", hf_method="rhf", tol=1e-8, maxiters=100):
     """Function to calculate the one and two electron terms. Perform a Hartree-Fock calculation in
         the given basis.
     Args:
@@ -115,9 +113,7 @@ def _calculate_integrals(
     mohijkl_ba = None
     if orbs_b is not None:
         mohijkl_bb = hijkl.transform(orbs_b)
-        mohijkl_ba = np.einsum(
-            "aI,bJ,cK,dL,abcd->IJKL", orbs_b, orbs_b, orbs, orbs, hijkl[...]
-        )
+        mohijkl_ba = np.einsum("aI,bJ,cK,dL,abcd->IJKL", orbs_b, orbs_b, orbs, orbs, hijkl[...])
 
     # Create driver level molecule object and populate
     _q_ = QMolecule()

--- a/qiskit_nature/drivers/pyquanted/pyquantedriver.py
+++ b/qiskit_nature/drivers/pyquanted/pyquantedriver.py
@@ -82,9 +82,7 @@ class PyQuanteDriver(FermionicDriver):
         validate_min("maxiters", maxiters, 1)
         self._check_valid()
         if not isinstance(atoms, str) and not isinstance(atoms, list):
-            raise QiskitNatureError(
-                "Invalid atom input for PYQUANTE Driver '{}'".format(atoms)
-            )
+            raise QiskitNatureError("Invalid atom input for PYQUANTE Driver '{}'".format(atoms))
 
         if isinstance(atoms, list):
             atoms = ";".join(atoms)
@@ -106,9 +104,7 @@ class PyQuanteDriver(FermionicDriver):
 
     @staticmethod
     def _check_valid():
-        err_msg = (
-            "PyQuante2 is not installed. See https://github.com/rpmuller/pyquante2"
-        )
+        err_msg = "PyQuante2 is not installed. See https://github.com/rpmuller/pyquante2"
         try:
             spec = importlib.util.find_spec("pyquante2")
             if spec is not None:
@@ -122,10 +118,7 @@ class PyQuanteDriver(FermionicDriver):
     def run(self) -> QMolecule:
         if self.molecule is not None:
             atoms = ";".join(
-                [
-                    name + " " + " ".join(map(str, coord))
-                    for (name, coord) in self.molecule.geometry
-                ]
+                [name + " " + " ".join(map(str, coord)) for (name, coord) in self.molecule.geometry]
             )
             charge = self.molecule.charge
             multiplicity = self.molecule.multiplicity

--- a/qiskit_nature/drivers/pyscfd/integrals.py
+++ b/qiskit_nature/drivers/pyscfd/integrals.py
@@ -32,9 +32,7 @@ try:
 
     warnings.filterwarnings("ignore", category=DeprecationWarning, module="pyscf")
 except ImportError:
-    logger.info(
-        "PySCF is not installed. See https://sunqm.github.io/pyscf/install.html"
-    )
+    logger.info("PySCF is not installed. See https://sunqm.github.io/pyscf/install.html")
 
 
 def compute_integrals(
@@ -116,9 +114,7 @@ def _check_molecule_format(val):
     return val
 
 
-def _calculate_integrals(
-    mol, hf_method="rhf", conv_tol=1e-9, max_cycle=50, init_guess="minao"
-):
+def _calculate_integrals(mol, hf_method="rhf", conv_tol=1e-9, max_cycle=50, init_guess="minao"):
     """Function to calculate the one and two electron terms. Perform a Hartree-Fock calculation in
         the given basis.
     Args:

--- a/qiskit_nature/drivers/pyscfd/pyscfdriver.py
+++ b/qiskit_nature/drivers/pyscfd/pyscfdriver.py
@@ -88,9 +88,7 @@ class PySCFDriver(FermionicDriver):
         """
         self._check_valid()
         if not isinstance(atom, str) and not isinstance(atom, list):
-            raise QiskitNatureError(
-                "Invalid atom input for PYSCF Driver '{}'".format(atom)
-            )
+            raise QiskitNatureError("Invalid atom input for PYSCF Driver '{}'".format(atom))
 
         if isinstance(atom, list):
             atom = ";".join(atom)
@@ -115,9 +113,7 @@ class PySCFDriver(FermionicDriver):
 
     @staticmethod
     def _check_valid():
-        err_msg = (
-            "PySCF is not installed. See https://sunqm.github.io/pyscf/install.html"
-        )
+        err_msg = "PySCF is not installed. See https://sunqm.github.io/pyscf/install.html"
         try:
             spec = importlib.util.find_spec("pyscf")
             if spec is not None:
@@ -131,10 +127,7 @@ class PySCFDriver(FermionicDriver):
     def run(self) -> QMolecule:
         if self.molecule is not None:
             atom = ";".join(
-                [
-                    name + " " + " ".join(map(str, coord))
-                    for (name, coord) in self.molecule.geometry
-                ]
+                [name + " " + " ".join(map(str, coord)) for (name, coord) in self.molecule.geometry]
             )
             charge = self.molecule.charge
             spin = self.molecule.multiplicity - 1

--- a/qiskit_nature/drivers/qmolecule.py
+++ b/qiskit_nature/drivers/qmolecule.py
@@ -129,9 +129,7 @@ class QMolecule:
     @property
     def two_body_integrals(self):
         """Returns two body electron integrals."""
-        return QMolecule.twoe_to_spin(
-            self.mo_eri_ints, self.mo_eri_ints_bb, self.mo_eri_ints_ba
-        )
+        return QMolecule.twoe_to_spin(self.mo_eri_ints, self.mo_eri_ints_bb, self.mo_eri_ints_ba)
 
     def has_dipole_integrals(self):
         """Check if dipole integrals are present."""
@@ -169,9 +167,7 @@ class QMolecule:
             A list of core orbital indices.
         """
         if self.num_atoms is None:
-            logger.warning(
-                "Missing molecule information! Returning empty core orbital list."
-            )
+            logger.warning("Missing molecule information! Returning empty core orbital list.")
             return []
         count = 0
         for i in range(self.num_atoms):
@@ -241,9 +237,7 @@ class QMolecule:
                 data = file["energy/hf_energy"][...]
                 self.hf_energy = float(data) if data.dtype.num != 0 else None
                 data = file["energy/nuclear_repulsion_energy"][...]
-                self.nuclear_repulsion_energy = (
-                    float(data) if data.dtype.num != 0 else None
-                )
+                self.nuclear_repulsion_energy = float(data) if data.dtype.num != 0 else None
                 if version > 2:
                     self.energy_shift = read_dict("energy/energy_shift")
                     self.x_dip_energy_shift = read_dict("energy/x_dip_energy_shift")
@@ -258,23 +252,17 @@ class QMolecule:
                 # Orbitals
                 try:
                     data = file["orbitals/num_molecular_orbitals"][...]
-                    self.num_molecular_orbitals = (
-                        int(data) if data.dtype.num != 0 else None
-                    )
+                    self.num_molecular_orbitals = int(data) if data.dtype.num != 0 else None
                 except KeyError:
                     # try the legacy attribute name
                     data = file["orbitals/num_orbitals"][...]
-                    self.num_molecular_orbitals = (
-                        int(data) if data.dtype.num != 0 else None
-                    )
+                    self.num_molecular_orbitals = int(data) if data.dtype.num != 0 else None
                 data = file["orbitals/num_alpha"][...]
                 self.num_alpha = int(data) if data.dtype.num != 0 else None
                 data = file["orbitals/num_beta"][...]
                 self.num_beta = int(data) if data.dtype.num != 0 else None
                 self.mo_coeff = read_array("orbitals/mo_coeff")
-                self.mo_coeff_b = (
-                    read_array("orbitals/mo_coeff_B") if version > 1 else None
-                )
+                self.mo_coeff_b = read_array("orbitals/mo_coeff_B") if version > 1 else None
                 self.orbital_energies = read_array("orbitals/orbital_energies")
                 self.orbital_energies_b = (
                     read_array("orbitals/orbital_energies_B") if version > 1 else None
@@ -314,29 +302,17 @@ class QMolecule:
                 )
 
                 # dipole integrals in AO basis
-                self.x_dip_ints = (
-                    read_array("dipole/x_dip_ints") if version > 1 else None
-                )
-                self.y_dip_ints = (
-                    read_array("dipole/y_dip_ints") if version > 1 else None
-                )
-                self.z_dip_ints = (
-                    read_array("dipole/z_dip_ints") if version > 1 else None
-                )
+                self.x_dip_ints = read_array("dipole/x_dip_ints") if version > 1 else None
+                self.y_dip_ints = read_array("dipole/y_dip_ints") if version > 1 else None
+                self.z_dip_ints = read_array("dipole/z_dip_ints") if version > 1 else None
 
                 # dipole integrals in MO basis
                 self.x_dip_mo_ints = read_array("dipole/x_dip_mo_ints")
-                self.x_dip_mo_ints_b = (
-                    read_array("dipole/x_dip_mo_ints_B") if version > 1 else None
-                )
+                self.x_dip_mo_ints_b = read_array("dipole/x_dip_mo_ints_B") if version > 1 else None
                 self.y_dip_mo_ints = read_array("dipole/y_dip_mo_ints")
-                self.y_dip_mo_ints_b = (
-                    read_array("dipole/y_dip_mo_ints_B") if version > 1 else None
-                )
+                self.y_dip_mo_ints_b = read_array("dipole/y_dip_mo_ints_B") if version > 1 else None
                 self.z_dip_mo_ints = read_array("dipole/z_dip_mo_ints")
-                self.z_dip_mo_ints_b = (
-                    read_array("dipole/z_dip_mo_ints_B") if version > 1 else None
-                )
+                self.z_dip_mo_ints_b = read_array("dipole/z_dip_mo_ints_B") if version > 1 else None
                 self.nuclear_dipole_moment = file["dipole/nuclear_dipole_moment"][...]
                 self.reverse_dipole_sign = file["dipole/reverse_dipole_sign"][...]
 
@@ -376,9 +352,7 @@ class QMolecule:
                     for k, v in value.items():
                         sub_group.create_dataset(k, data=v)
                 else:
-                    group.create_dataset(
-                        name, data=(value if value is not None else False)
-                    )
+                    group.create_dataset(name, data=(value if value is not None else False))
 
             file.create_dataset("version", data=(self.QMOLECULE_VERSION,))
 
@@ -412,9 +386,7 @@ class QMolecule:
             # Energies
             g_energy = file.create_group("energy")
             create_dataset(g_energy, "hf_energy", self.hf_energy)
-            create_dataset(
-                g_energy, "nuclear_repulsion_energy", self.nuclear_repulsion_energy
-            )
+            create_dataset(g_energy, "nuclear_repulsion_energy", self.nuclear_repulsion_energy)
             create_dataset(g_energy, "energy_shift", self.energy_shift)
             create_dataset(g_energy, "x_dip_energy_shift", self.x_dip_energy_shift)
             create_dataset(g_energy, "y_dip_energy_shift", self.y_dip_energy_shift)
@@ -422,9 +394,7 @@ class QMolecule:
 
             # Orbitals
             g_orbitals = file.create_group("orbitals")
-            create_dataset(
-                g_orbitals, "num_molecular_orbitals", self.num_molecular_orbitals
-            )
+            create_dataset(g_orbitals, "num_molecular_orbitals", self.num_molecular_orbitals)
             create_dataset(g_orbitals, "num_alpha", self.num_alpha)
             create_dataset(g_orbitals, "num_beta", self.num_beta)
             create_dataset(g_orbitals, "mo_coeff", self.mo_coeff)
@@ -473,9 +443,7 @@ class QMolecule:
             create_dataset(g_dipole, "y_dip_mo_ints_B", self.y_dip_mo_ints_b)
             create_dataset(g_dipole, "z_dip_mo_ints", self.z_dip_mo_ints)
             create_dataset(g_dipole, "z_dip_mo_ints_B", self.z_dip_mo_ints_b)
-            create_dataset(
-                g_dipole, "nuclear_dipole_moment", self.nuclear_dipole_moment
-            )
+            create_dataset(g_dipole, "nuclear_dipole_moment", self.nuclear_dipole_moment)
             create_dataset(g_dipole, "reverse_dipole_sign", self.reverse_dipole_sign)
 
     def remove_file(self, file_name=None):
@@ -775,12 +743,8 @@ class QMolecule:
             # Originating driver name & config if set
             if self.origin_driver_name and self.origin_driver_name != "?":
                 logger.info("Originating driver name: %s", self.origin_driver_name)
-                logger.info(
-                    "Originating driver version: %s", self.origin_driver_version
-                )
-                logger.info(
-                    "Originating driver config:\n%s", self.origin_driver_config[:-1]
-                )
+                logger.info("Originating driver version: %s", self.origin_driver_version)
+                logger.info("Originating driver config:\n%s", self.origin_driver_config[:-1])
 
             logger.info("Computed Hartree-Fock energy: %s", self.hf_energy)
             logger.info("Nuclear repulsion energy: %s", self.nuclear_repulsion_energy)
@@ -792,9 +756,7 @@ class QMolecule:
                 )
             logger.info("Number of orbitals is %s", self.num_molecular_orbitals)
             logger.info("%s alpha and %s beta electrons", self.num_alpha, self.num_beta)
-            logger.info(
-                "Molecule comprises %s atoms and in xyz format is ::", self.num_atoms
-            )
+            logger.info("Molecule comprises %s atoms and in xyz format is ::", self.num_atoms)
             logger.info("  %s, %s", self.molecular_charge, self.multiplicity)
             if self.num_atoms is not None:
                 for n in range(0, self.num_atoms):
@@ -849,14 +811,10 @@ class QMolecule:
                 logger.info("Two body ERI MO AA integrals: %s", self.mo_eri_ints.shape)
                 logger.debug("\n%s", self.mo_eri_ints)
             if self.mo_eri_ints_bb is not None:
-                logger.info(
-                    "Two body ERI MO BB integrals: %s", self.mo_eri_ints_bb.shape
-                )
+                logger.info("Two body ERI MO BB integrals: %s", self.mo_eri_ints_bb.shape)
                 logger.debug("\n%s", self.mo_eri_ints_bb)
             if self.mo_eri_ints_ba is not None:
-                logger.info(
-                    "Two body ERI MO BA integrals: %s", self.mo_eri_ints_ba.shape
-                )
+                logger.info("Two body ERI MO BA integrals: %s", self.mo_eri_ints_ba.shape)
                 logger.debug("\n%s", self.mo_eri_ints_ba)
 
             if self.x_dip_ints is not None:

--- a/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
@@ -128,12 +128,8 @@ class BravyiKitaevMapper(FermionicMapper):
 
             remainder_sets.append(np.setdiff1d(parity_sets[j], flip_sets[j]))
 
-            update_pauli.append(
-                Pauli((np.zeros(nmodes, dtype=bool), np.zeros(nmodes, dtype=bool)))
-            )
-            parity_pauli.append(
-                Pauli((np.zeros(nmodes, dtype=bool), np.zeros(nmodes, dtype=bool)))
-            )
+            update_pauli.append(Pauli((np.zeros(nmodes, dtype=bool), np.zeros(nmodes, dtype=bool))))
+            parity_pauli.append(Pauli((np.zeros(nmodes, dtype=bool), np.zeros(nmodes, dtype=bool))))
             remainder_pauli.append(
                 Pauli((np.zeros(nmodes, dtype=bool), np.zeros(nmodes, dtype=bool)))
             )

--- a/qiskit_nature/mappers/second_quantization/linear_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/linear_mapper.py
@@ -40,31 +40,21 @@ class LinearMapper(SpinMapper):
 
             operatorlist: List[PauliSumOp] = []
 
-            for n_x, n_y, n_z in zip(
-                second_q_op.x[idx], second_q_op.y[idx], second_q_op.z[idx]
-            ):
+            for n_x, n_y, n_z in zip(second_q_op.x[idx], second_q_op.y[idx], second_q_op.z[idx]):
 
                 operator_on_spin_i: List[PauliSumOp] = []
 
                 if n_x > 0:
-                    operator_on_spin_i.append(
-                        reduce(operator.matmul, [spinx] * int(n_x))
-                    )
+                    operator_on_spin_i.append(reduce(operator.matmul, [spinx] * int(n_x)))
 
                 if n_y > 0:
-                    operator_on_spin_i.append(
-                        reduce(operator.matmul, [spiny] * int(n_y))
-                    )
+                    operator_on_spin_i.append(reduce(operator.matmul, [spiny] * int(n_y)))
 
                 if n_z > 0:
-                    operator_on_spin_i.append(
-                        reduce(operator.matmul, [spinz] * int(n_z))
-                    )
+                    operator_on_spin_i.append(reduce(operator.matmul, [spinz] * int(n_z)))
 
                 if np.any([n_x, n_y, n_z]) > 0:
-                    single_operator_on_spin_i = reduce(
-                        operator.matmul, operator_on_spin_i
-                    )
+                    single_operator_on_spin_i = reduce(operator.matmul, operator_on_spin_i)
                     operatorlist.append(single_operator_on_spin_i.reduce())
 
                 else:
@@ -137,8 +127,7 @@ class LinearMapper(SpinMapper):
             # get the first upper diagonal of coeff.
             z_summands.append(
                 PauliSumOp(
-                    coeff / 2.0 * SparsePauliOp(pauli_z(i))
-                    + coeff / 2.0 * SparsePauliOp(pauli_id)
+                    coeff / 2.0 * SparsePauliOp(pauli_z(i)) + coeff / 2.0 * SparsePauliOp(pauli_id)
                 )
             )
 

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -131,7 +131,7 @@ class QubitMapper(ABC):
                 # catch any disallowed labels
                 else:
                     raise QiskitNatureError(
-                        f"FermionicOp label included '{char}'. " "Allowed characters: I, N, E, +, -"
+                        f"FermionicOp label included '{char}'. Allowed characters: I, N, E, +, -"
                     )
             ret_op_list.append(ret_op)
 

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -131,8 +131,7 @@ class QubitMapper(ABC):
                 # catch any disallowed labels
                 else:
                     raise QiskitNatureError(
-                        f"FermionicOp label included '{char}'. "
-                        "Allowed characters: I, N, E, +, -"
+                        f"FermionicOp label included '{char}'. " "Allowed characters: I, N, E, +, -"
                     )
             ret_op_list.append(ret_op)
 

--- a/qiskit_nature/operators/second_quantization/fermionic_op.py
+++ b/qiskit_nature/operators/second_quantization/fermionic_op.py
@@ -165,14 +165,10 @@ class FermionicOp(SecondQuantizedOp):
         self._labels: List[str]
 
         if not isinstance(data, (tuple, list, str)):
-            raise TypeError(
-                f"Type of data must be str, tuple, or list, not {type(data)}."
-            )
+            raise TypeError(f"Type of data must be str, tuple, or list, not {type(data)}.")
 
         if isinstance(data, tuple):
-            if not isinstance(data[0], str) or not isinstance(
-                data[1], (int, float, complex)
-            ):
+            if not isinstance(data[0], str) or not isinstance(data[1], (int, float, complex)):
                 raise TypeError(
                     f"Data tuple must be (str, number), not ({type(data[0])}, {type(data[1])})."
                 )
@@ -195,13 +191,9 @@ class FermionicOp(SecondQuantizedOp):
             if not all(len(label) == self._register_length for label in labels):
                 raise ValueError("Lengths of strings of label are different.")
             label_pattern = re.compile(r"^[I\+\-NE]+$")
-            invalid_labels = [
-                label for label in labels if not label_pattern.match(label)
-            ]
+            invalid_labels = [label for label in labels if not label_pattern.match(label)]
             if invalid_labels:
-                raise ValueError(
-                    f"Invalid labels for dense labels are given: {invalid_labels}"
-                )
+                raise ValueError(f"Invalid labels for dense labels are given: {invalid_labels}")
             self._labels = list(labels)
         else:  # Sparse label
             validate_min("register_length", register_length, 1)
@@ -213,22 +205,16 @@ class FermionicOp(SecondQuantizedOp):
                 if not all(label_pattern.match(lb) for lb in label.split())
             ]
             if invalid_labels:
-                raise ValueError(
-                    f"Invalid labels for sparse labels are given: {invalid_labels}"
-                )
+                raise ValueError(f"Invalid labels for sparse labels are given: {invalid_labels}")
             list_label = [["I"] * self._register_length for _ in labels]
             for term, label in enumerate(labels):
                 prev_index: Optional[int] = None
                 for split_label in label.split():
                     op_label, index_str = split_label.split("_", 1)
                     index = int(index_str)
-                    validate_range_exclusive_max(
-                        "index", index, 0, self._register_length
-                    )
+                    validate_range_exclusive_max("index", index, 0, self._register_length)
                     if prev_index is not None and prev_index > index:
-                        raise ValueError(
-                            "Indices of labels must be in ascending order."
-                        )
+                        raise ValueError("Indices of labels must be in ascending order.")
                     if list_label[term][index] != "I":
                         raise ValueError(f"Duplicate index {index} is given.")
                     list_label[term][index] = op_label
@@ -248,9 +234,7 @@ class FermionicOp(SecondQuantizedOp):
         if len(self) == 1:
             label, coeff = self.to_list()[0]
             return f"{label} * {coeff}"
-        return "  " + "\n+ ".join(
-            [f"{label} * {coeff}" for label, coeff in self.to_list()]
-        )
+        return "  " + "\n+ ".join([f"{label} * {coeff}" for label, coeff in self.to_list()])
 
     def __len__(self):
         return len(self._labels)
@@ -325,9 +309,7 @@ class FermionicOp(SecondQuantizedOp):
     @classmethod
     def _single_mul(cls, label1: str, label2: str) -> Tuple[str, complex]:
         if len(label1) != len(label2):
-            raise QiskitNatureError(
-                "Operators act on Fermion Registers of different length"
-            )
+            raise QiskitNatureError("Operators act on Fermion Registers of different length")
 
         new_label = []
         sign = 1
@@ -403,13 +385,9 @@ class FermionicOp(SecondQuantizedOp):
             label_list.append("".join(daggered_label))
             coeff_list.append(conjugated_coeff)
 
-        return FermionicOp(
-            list(zip(label_list, np.array(coeff_list, dtype=np.complex128)))
-        )
+        return FermionicOp(list(zip(label_list, np.array(coeff_list, dtype=np.complex128))))
 
-    def reduce(
-        self, atol: Optional[float] = None, rtol: Optional[float] = None
-    ) -> "FermionicOp":
+    def reduce(self, atol: Optional[float] = None, rtol: Optional[float] = None) -> "FermionicOp":
         if atol is None:
             atol = self.atol
         if rtol is None:
@@ -420,12 +398,8 @@ class FermionicOp(SecondQuantizedOp):
         for i, val in zip(indices, self._coeffs):
             coeff_list[i] += val
         non_zero = [
-            i
-            for i, v in enumerate(coeff_list)
-            if not np.isclose(v, 0, atol=atol, rtol=rtol)
+            i for i, v in enumerate(coeff_list) if not np.isclose(v, 0, atol=atol, rtol=rtol)
         ]
         if not non_zero:
             return FermionicOp(("I" * self.register_length, 0))
-        return FermionicOp(
-            list(zip(label_list[non_zero].tolist(), coeff_list[non_zero]))
-        )
+        return FermionicOp(list(zip(label_list[non_zero].tolist(), coeff_list[non_zero])))

--- a/qiskit_nature/operators/second_quantization/qubit_converter.py
+++ b/qiskit_nature/operators/second_quantization/qubit_converter.py
@@ -125,9 +125,7 @@ class QubitConverter:
         return self._z2symmetry_reduction
 
     @z2symmetry_reduction.setter
-    def z2symmetry_reduction(
-        self, z2symmetry_reduction: Optional[Union[str, List[int]]]
-    ) -> None:
+    def z2symmetry_reduction(self, z2symmetry_reduction: Optional[Union[str, List[int]]]) -> None:
         """Set z2symmetry_reduction"""
         if z2symmetry_reduction is not None:
             if isinstance(z2symmetry_reduction, str):
@@ -139,9 +137,7 @@ class QubitConverter:
             elif not np.all(np.isin(z2symmetry_reduction, [-1, 1])):
                 raise ValueError(
                     "z2symmetry_reduction tapering values list must "
-                    "contain -1's and/or 1's only but was {}".format(
-                        z2symmetry_reduction
-                    )
+                    "contain -1's and/or 1's only but was {}".format(z2symmetry_reduction)
                 )
 
         self._z2symmetry_reduction = z2symmetry_reduction
@@ -265,8 +261,7 @@ class QubitConverter:
 
         qubit_ops = [self._map(second_q_op) for second_q_op in second_q_ops]
         reduced_ops = [
-            self._two_qubit_reduce(qubit_op, self._num_particles)
-            for qubit_op in qubit_ops
+            self._two_qubit_reduce(qubit_op, self._num_particles) for qubit_op in qubit_ops
         ]
         tapered_ops = self._symmetry_reduce(reduced_ops, suppress_none)
 
@@ -332,9 +327,7 @@ class QubitConverter:
                 if sector_locator is not None and self.z2symmetry_reduction == "auto":
                     z2symmetry_reduction = sector_locator(z2_symmetries)
                     if z2symmetry_reduction is not None:
-                        self.z2symmetry_reduction = (
-                            z2symmetry_reduction  # Overrides any value
-                        )
+                        self.z2symmetry_reduction = z2symmetry_reduction  # Overrides any value
 
                     # We may end up that neither were we given a sector nor that the locator
                     # returned one. Since though we may have found valid symmetries above we should
@@ -404,9 +397,7 @@ class QubitConverter:
     def _check_commutes(cliffords: List[PauliSumOp], qubit_op: PauliSumOp) -> bool:
         commutes = []
         for clifford in cliffords:
-            commuting_rows = qubit_op.primitive.table.commutes_with_all(
-                clifford.primitive.table
-            )
+            commuting_rows = qubit_op.primitive.table.commutes_with_all(clifford.primitive.table)
             commutes.append(len(commuting_rows) == qubit_op.primitive.size)
         does_commute = bool(np.all(commutes))
         logger.debug("  '%s' commutes: %s, %s", id(qubit_op), does_commute, commutes)

--- a/qiskit_nature/operators/second_quantization/spin_op.py
+++ b/qiskit_nature/operators/second_quantization/spin_op.py
@@ -199,9 +199,7 @@ class SpinOp(SecondQuantizedOp):
             )
         self._dim = int(2 * spin + 1)
 
-        if isinstance(data, tuple) and all(
-            isinstance(datum, np.ndarray) for datum in data
-        ):
+        if isinstance(data, tuple) and all(isinstance(datum, np.ndarray) for datum in data):
             self._spin_array = np.array(data[0], dtype=np.uint8)
             self._register_length = self._spin_array.shape[2]
             self._coeffs = np.array(data[1], dtype=dtype)
@@ -222,19 +220,13 @@ class SpinOp(SecondQuantizedOp):
                 sparse = r"([IXYZ]_\d+(\^\d+)?|[\+\-]_\d+?)"
                 # space (\s) separated sparse label or empty string
                 label_pattern = re.compile(rf"^({sparse}\s)*{sparse}(?!\s)$|^$")
-                invalid_labels = [
-                    label for label, _ in data if not label_pattern.match(label)
-                ]
+                invalid_labels = [label for label, _ in data if not label_pattern.match(label)]
                 if invalid_labels:
-                    raise ValueError(
-                        f"Invalid labels for sparse labels: {invalid_labels}."
-                    )
+                    raise ValueError(f"Invalid labels for sparse labels: {invalid_labels}.")
             else:  # dense_label
                 # dense label (repeat of [IXYZ+-])
                 label_pattern = re.compile(r"^[IXYZ\+\-]+$")
-                invalid_labels = [
-                    label for label, _ in data if not label_pattern.match(label)
-                ]
+                invalid_labels = [label for label, _ in data if not label_pattern.match(label)]
                 if invalid_labels:
                     raise ValueError(
                         f"Invalid labels for dense labels: {invalid_labels} (if you want to use "
@@ -254,13 +246,9 @@ class SpinOp(SecondQuantizedOp):
             if register_length is None:  # Dense label
                 self._register_length = len(labels[0])
                 label_pattern = re.compile(r"^[IXYZ]+$")
-                invalid_labels = [
-                    label for label in labels if not label_pattern.match(label)
-                ]
+                invalid_labels = [label for label in labels if not label_pattern.match(label)]
                 if invalid_labels:
-                    raise ValueError(
-                        f"Invalid labels for dense labels are given: {invalid_labels}"
-                    )
+                    raise ValueError(f"Invalid labels for dense labels are given: {invalid_labels}")
                 self._spin_array = np.array(
                     [
                         [[char == "X", char == "Y", char == "Z"] for char in label]
@@ -303,9 +291,7 @@ class SpinOp(SecondQuantizedOp):
         if len(self) == 1:
             label, coeff = self.to_list()[0]
             return f"{label} * {coeff}"
-        return "  " + "\n+ ".join(
-            [f"{label} * {coeff}" for label, coeff in self.to_list()]
-        )
+        return "  " + "\n+ ".join([f"{label} * {coeff}" for label, coeff in self.to_list()])
 
     def __len__(self) -> int:
         return len(self._coeffs)
@@ -350,17 +336,14 @@ class SpinOp(SecondQuantizedOp):
     def add(self, other: "SpinOp") -> "SpinOp":
         if not isinstance(other, SpinOp):
             raise TypeError(
-                "Unsupported operand type(s) for +: 'SpinOp' and "
-                f"'{type(other).__name__}'"
+                "Unsupported operand type(s) for +: 'SpinOp' and " f"'{type(other).__name__}'"
             )
 
         if self.register_length != other.register_length:
             raise TypeError("Incompatible register lengths for '+'.")
 
         if self.spin != other.spin:
-            raise TypeError(
-                f"Addition between spin {self.spin} and spin {other.spin} is invalid."
-            )
+            raise TypeError(f"Addition between spin {self.spin} and spin {other.spin} is invalid.")
 
         return SpinOp(
             (
@@ -392,9 +375,7 @@ class SpinOp(SecondQuantizedOp):
         # to simply complex conjugating the coefficient.
         return SpinOp((self._spin_array, self._coeffs.conjugate()), spin=self.spin)
 
-    def reduce(
-        self, atol: Optional[float] = None, rtol: Optional[float] = None
-    ) -> "SpinOp":
+    def reduce(self, atol: Optional[float] = None, rtol: Optional[float] = None) -> "SpinOp":
         if atol is None:
             atol = self.atol
         if rtol is None:
@@ -407,9 +388,7 @@ class SpinOp(SecondQuantizedOp):
         for i, val in zip(indices, self._coeffs):
             coeff_list[i] += val
         non_zero = [
-            i
-            for i, v in enumerate(coeff_list)
-            if not np.isclose(v, 0, atol=atol, rtol=rtol)
+            i for i, v in enumerate(coeff_list) if not np.isclose(v, 0, atol=atol, rtol=rtol)
         ]
         if not non_zero:
             return SpinOp(
@@ -470,10 +449,7 @@ class SpinOp(SecondQuantizedOp):
         y_mat = np.fromfunction(
             lambda i, j: np.where(
                 np.abs(i - j) == 1,
-                1j
-                * (i - j)
-                * np.sqrt((self._dim + 1) * (i + j + 1) / 2 - (i + 1) * (j + 1))
-                / 2,
+                1j * (i - j) * np.sqrt((self._dim + 1) * (i + j + 1) / 2 - (i + 1) * (j + 1)) / 2,
                 0,
             ),
             (self._dim, self._dim),
@@ -505,9 +481,7 @@ class SpinOp(SecondQuantizedOp):
         xyz_dict = {"X": 0, "Y": 1, "Z": 2}
 
         # 3-dimensional ndarray (XYZ, terms, register)
-        self._spin_array = np.zeros(
-            (3, len(labels), self.register_length), dtype=np.uint8
-        )
+        self._spin_array = np.zeros((3, len(labels), self.register_length), dtype=np.uint8)
         for term, label in enumerate(labels):
             for split_label in label.split():
                 xyz, nums = split_label.split("_", 1)
@@ -516,9 +490,7 @@ class SpinOp(SecondQuantizedOp):
                     continue
 
                 xyz_num = xyz_dict[xyz]
-                index, power = (
-                    map(int, nums.split("^", 1)) if "^" in nums else (int(nums), 1)
-                )
+                index, power = map(int, nums.split("^", 1)) if "^" in nums else (int(nums), 1)
                 if index >= self.register_length:
                     raise ValueError(
                         f"Index {index} must be smaller than register_length {self.register_length}"

--- a/qiskit_nature/operators/second_quantization/vibrational_op.py
+++ b/qiskit_nature/operators/second_quantization/vibrational_op.py
@@ -85,9 +85,7 @@ class VibrationalOp(SecondQuantizedOp):
 
     # a valid pattern consists of a single "+" or "-" operator followed by "_" and a mode index
     # followed by "*" and a modal index, possibly appearing multiple times and separated by a space
-    _VALID_VIBR_LABEL_PATTERN = re.compile(
-        r"^([\+\-]_\d+\*\d+\s)*[\+\-]_\d+\*\d+(?!\s)$|^[\+\-]+$"
-    )
+    _VALID_VIBR_LABEL_PATTERN = re.compile(r"^([\+\-]_\d+\*\d+\s)*[\+\-]_\d+\*\d+(?!\s)$|^[\+\-]+$")
 
     def __init__(
         self,
@@ -109,14 +107,10 @@ class VibrationalOp(SecondQuantizedOp):
             ValueError: invalid labels.
         """
         if not isinstance(data, (tuple, list, str)):
-            raise TypeError(
-                f"Type of data must be str, tuple, or list, not {type(data)}."
-            )
+            raise TypeError(f"Type of data must be str, tuple, or list, not {type(data)}.")
 
         if isinstance(data, tuple):
-            if not isinstance(data[0], str) or not isinstance(
-                data[1], (int, float, complex)
-            ):
+            if not isinstance(data[0], str) or not isinstance(data[1], (int, float, complex)):
                 raise TypeError(
                     f"Data tuple must be (str, number), not ({type(data[0])}, {type(data[1])})."
                 )
@@ -149,13 +143,9 @@ class VibrationalOp(SecondQuantizedOp):
             if not all(len(label) == self._register_length for label in labels):
                 raise ValueError("Lengths of strings of label are different.")
             label_pattern = re.compile(r"^[I\+\-NE]+$")
-            invalid_labels = [
-                label for label in labels if not label_pattern.match(label)
-            ]
+            invalid_labels = [label for label in labels if not label_pattern.match(label)]
             if invalid_labels:
-                raise ValueError(
-                    f"Invalid labels for dense labels are given: {invalid_labels}"
-                )
+                raise ValueError(f"Invalid labels for dense labels are given: {invalid_labels}")
             self._labels = list(labels)
         else:
             # Sparse label
@@ -165,10 +155,7 @@ class VibrationalOp(SecondQuantizedOp):
             for dense_label, coeff in dense_labels:
                 new_op = reduce(
                     lambda a, b: a @ b,
-                    (
-                        VibrationalOp((label, 1), num_modes, num_modals)
-                        for label in dense_label
-                    ),
+                    (VibrationalOp((label, 1), num_modes, num_modals) for label in dense_label),
                 )
                 # We ignore the type here because mypy only sees the complex coefficient
                 ops.append(coeff * new_op)  # type: ignore
@@ -189,9 +176,7 @@ class VibrationalOp(SecondQuantizedOp):
         if len(self) == 1:
             label, coeff = self.to_list()[0]
             return f"{label} * {coeff}"
-        return "  " + "\n+ ".join(
-            [f"{label} * {coeff}" for label, coeff in self.to_list()]
-        )
+        return "  " + "\n+ ".join([f"{label} * {coeff}" for label, coeff in self.to_list()])
 
     def __len__(self):
         return len(self._labels)
@@ -279,9 +264,7 @@ class VibrationalOp(SecondQuantizedOp):
             self._num_modals,
         )
 
-    def reduce(
-        self, atol: Optional[float] = None, rtol: Optional[float] = None
-    ) -> "VibrationalOp":
+    def reduce(self, atol: Optional[float] = None, rtol: Optional[float] = None) -> "VibrationalOp":
         if atol is None:
             atol = self.atol
         if rtol is None:
@@ -292,9 +275,7 @@ class VibrationalOp(SecondQuantizedOp):
         for i, val in zip(indices, self._coeffs):
             coeff_list[i] += val
         non_zero = [
-            i
-            for i, v in enumerate(coeff_list)
-            if not np.isclose(v, 0, atol=atol, rtol=rtol)
+            i for i, v in enumerate(coeff_list) if not np.isclose(v, 0, atol=atol, rtol=rtol)
         ]
         if not non_zero:
             return VibrationalOp(("I_0*0", 0), self._num_modes, self._num_modals)
@@ -362,9 +343,7 @@ class VibrationalOp(SecondQuantizedOp):
     @classmethod
     def _single_mul(cls, label1: str, label2: str) -> Tuple[str, bool]:
         if len(label1) != len(label2):
-            raise QiskitNatureError(
-                "Operators act on Fermion Registers of different length"
-            )
+            raise QiskitNatureError("Operators act on Fermion Registers of different length")
 
         new_label = []
 
@@ -428,12 +407,8 @@ class VibrationalOp(SecondQuantizedOp):
                 op, mode_index_str, modal_index_str = re.split("[*_]", label)
                 mode_index = int(mode_index_str)
                 modal_index = int(modal_index_str)
-                if self._is_index_out_of_range(
-                    mode_index, num_modes, modal_index, num_modals
-                ):
-                    raise ValueError(
-                        f"Indices out of the declared range for label {label}."
-                    )
+                if self._is_index_out_of_range(mode_index, num_modes, modal_index, num_modals):
+                    raise ValueError(f"Indices out of the declared range for label {label}.")
                 if self._is_label_duplicated(
                     mode_index,
                     prev_mode_index,
@@ -442,9 +417,7 @@ class VibrationalOp(SecondQuantizedOp):
                     op,
                     prev_op,
                 ):
-                    raise ValueError(
-                        f"Operators in a label duplicated for label {label}."
-                    )
+                    raise ValueError(f"Operators in a label duplicated for label {label}.")
                 if self._is_order_incorrect(
                     mode_index,
                     prev_mode_index,
@@ -484,11 +457,7 @@ class VibrationalOp(SecondQuantizedOp):
         op: str,
         prev_op: str,
     ) -> bool:
-        return (
-            modal_index == prev_modal_index
-            and mode_index == prev_mode_index
-            and op == prev_op
-        )
+        return modal_index == prev_modal_index and mode_index == prev_mode_index and op == prev_op
 
     def _is_order_incorrect(
         self,
@@ -559,15 +528,11 @@ class VibrationalOp(SecondQuantizedOp):
 
         dense_labels = []
         for labels, coeff in vibrational_labels:
-            coeff_new_labels = self._build_coeff_dense_labels(
-                labels, partial_sum_modals
-            )
+            coeff_new_labels = self._build_coeff_dense_labels(labels, partial_sum_modals)
             dense_labels.append((coeff_new_labels, coeff))
         return dense_labels
 
-    def _build_coeff_dense_labels(
-        self, labels: str, partial_sum_modals: List[int]
-    ) -> List[str]:
+    def _build_coeff_dense_labels(self, labels: str, partial_sum_modals: List[int]) -> List[str]:
         coeff_labels_split = labels.split()
         coeff_new_labels = []
         for label in coeff_labels_split:
@@ -577,9 +542,7 @@ class VibrationalOp(SecondQuantizedOp):
             coeff_new_labels.append("".join(new_label))
         return coeff_new_labels
 
-    def _build_dense_label(
-        self, label: str, partial_sum_modals: List[int]
-    ) -> Tuple[str, int]:
+    def _build_dense_label(self, label: str, partial_sum_modals: List[int]) -> Tuple[str, int]:
         op, mode_index, modal_index = re.split("[*_]", label)
         index = partial_sum_modals[int(mode_index)] + int(modal_index)
         return (op, index)

--- a/qiskit_nature/problems/second_quantization/base_problem.py
+++ b/qiskit_nature/problems/second_quantization/base_problem.py
@@ -28,9 +28,7 @@ from qiskit_nature.transformers import BaseTransformer
 class BaseProblem(ABC):
     """Base Problem"""
 
-    def __init__(
-        self, driver: BaseDriver, transformers: Optional[List[BaseTransformer]] = None
-    ):
+    def __init__(self, driver: BaseDriver, transformers: Optional[List[BaseTransformer]] = None):
         """
 
         Args:
@@ -74,9 +72,7 @@ class BaseProblem(ABC):
             data = transformer.transform(data)
         return data
 
-    def symmetry_sector_locator(
-        self, z2_symmetries: Z2Symmetries
-    ) -> Optional[List[int]]:
+    def symmetry_sector_locator(self, z2_symmetries: Z2Symmetries) -> Optional[List[int]]:
         # pylint: disable=unused-argument
         """Given the detected Z2Symmetries, it can determine the correct sector of the tapered
         operators so the correct one can be returned
@@ -105,9 +101,7 @@ class BaseProblem(ABC):
     @abstractmethod
     def get_default_filter_criterion(
         self,
-    ) -> Optional[
-        Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]
-    ]:
+    ) -> Optional[Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]]:
         """Returns a default filter criterion method to filter the eigenvalues computed by the
         eigen solver. For more information see also
         qiskit.algorithms.eigen_solvers.NumPyEigensolver.filter_criterion.
@@ -126,9 +120,7 @@ class BaseProblem(ABC):
             str,
             int,
             List[int],
-            Callable[
-                [int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]
-            ],
+            Callable[[int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]],
         ] = "sd",
     ) -> Tuple[
         Dict[str, PauliSumOp],

--- a/qiskit_nature/problems/second_quantization/electronic/builders/aux_fermionic_ops_builder.py
+++ b/qiskit_nature/problems/second_quantization/electronic/builders/aux_fermionic_ops_builder.py
@@ -44,9 +44,7 @@ def _create_all_aux_operators(q_molecule: QMolecule) -> List[FermionicOp]:
     ]
 
     if q_molecule.has_dipole_integrals():
-        x_dipole_operator, y_dipole_operator, z_dipole_operator = _create_dipole_ops(
-            q_molecule
-        )
+        x_dipole_operator, y_dipole_operator, z_dipole_operator = _create_dipole_ops(q_molecule)
         aux_second_quantized_ops_list += [
             x_dipole_operator,
             y_dipole_operator,

--- a/qiskit_nature/problems/second_quantization/electronic/builders/fermionic_op_builder.py
+++ b/qiskit_nature/problems/second_quantization/electronic/builders/fermionic_op_builder.py
@@ -76,9 +76,7 @@ def _build_ferm_op_helper(
 ) -> FermionicOp:
     one_body_base_ops_labels = _create_one_body_base_ops(one_body_integrals)
     two_body_base_ops_labels = (
-        _create_two_body_base_ops(two_body_integrals)
-        if two_body_integrals is not None
-        else []
+        _create_two_body_base_ops(two_body_integrals) if two_body_integrals is not None else []
     )
     base_ops_labels = one_body_base_ops_labels + two_body_base_ops_labels
     initial_label_with_ceoff = ("I" * len(one_body_integrals), 0)
@@ -95,18 +93,14 @@ def _create_one_body_base_ops(
     one_body_integrals: np.ndarray,
 ) -> List[Tuple[str, complex]]:
     repeat_num = 2
-    return _create_base_ops_labels(
-        one_body_integrals, repeat_num, _calc_coeffs_with_ops_one_body
-    )
+    return _create_base_ops_labels(one_body_integrals, repeat_num, _calc_coeffs_with_ops_one_body)
 
 
 def _create_two_body_base_ops(
     two_body_integrals: np.ndarray,
 ) -> List[Tuple[str, complex]]:
     repeat_num = 4
-    return _create_base_ops_labels(
-        two_body_integrals, repeat_num, _calc_coeffs_with_ops_two_body
-    )
+    return _create_base_ops_labels(two_body_integrals, repeat_num, _calc_coeffs_with_ops_two_body)
 
 
 def _create_base_ops_labels(

--- a/qiskit_nature/problems/second_quantization/electronic/builders/hopping_ops_builder.py
+++ b/qiskit_nature/problems/second_quantization/electronic/builders/hopping_ops_builder.py
@@ -65,18 +65,13 @@ def _build_qeom_hopping_ops(
 
     excitations_list: List[Tuple[Tuple[int, ...], Tuple[int, ...]]]
     if isinstance(excitations, (str, int)) or (
-        isinstance(excitations, list)
-        and all(isinstance(exc, int) for exc in excitations)
+        isinstance(excitations, list) and all(isinstance(exc, int) for exc in excitations)
     ):
         excitations = cast(Union[str, int, List[int]], excitations)
-        ansatz = UCC(
-            qubit_converter, (num_alpha, num_beta), num_spin_orbitals, excitations
-        )
+        ansatz = UCC(qubit_converter, (num_alpha, num_beta), num_spin_orbitals, excitations)
         excitations_list = ansatz._get_excitation_list()
     else:
-        excitations_list = cast(
-            List[Tuple[Tuple[int, ...], Tuple[int, ...]]], excitations
-        )
+        excitations_list = cast(List[Tuple[Tuple[int, ...], Tuple[int, ...]]], excitations)
 
     size = len(excitations_list)
 
@@ -127,9 +122,7 @@ def _build_single_hopping_operator(
     if not z2_symmetries.is_empty():
         for symmetry in z2_symmetries.symmetries:
             symmetry_op = PauliSumOp.from_list([(symmetry.to_label(), 1.0)])
-            commuting = qubit_op.primitive.table.commutes_with_all(
-                symmetry_op.primitive.table
-            )
+            commuting = qubit_op.primitive.table.commutes_with_all(symmetry_op.primitive.table)
             anticommuting = qubit_op.primitive.table.anticommutes_with_all(
                 symmetry_op.primitive.table
             )

--- a/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
@@ -67,14 +67,12 @@ class ElectronicStructureProblem(BaseProblem):
             operator, and (if available) x, y, z dipole operators.
         """
         self._molecule_data = cast(QMolecule, self.driver.run())
-        self._molecule_data_transformed = cast(
-            QMolecule, self._transform(self._molecule_data)
-        )
+        self._molecule_data_transformed = cast(QMolecule, self._transform(self._molecule_data))
 
         electronic_fermionic_op = _build_fermionic_op(self._molecule_data_transformed)
-        second_quantized_ops_list = [
-            electronic_fermionic_op
-        ] + _create_all_aux_operators(self._molecule_data_transformed)
+        second_quantized_ops_list = [electronic_fermionic_op] + _create_all_aux_operators(
+            self._molecule_data_transformed
+        )
 
         return second_quantized_ops_list
 
@@ -85,9 +83,7 @@ class ElectronicStructureProblem(BaseProblem):
             str,
             int,
             List[int],
-            Callable[
-                [int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]
-            ],
+            Callable[[int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]],
         ] = "sd",
     ) -> Tuple[
         Dict[str, PauliSumOp],
@@ -119,9 +115,7 @@ class ElectronicStructureProblem(BaseProblem):
 
     def interpret(
         self,
-        raw_result: Union[
-            EigenstateResult, EigensolverResult, MinimumEigensolverResult
-        ],
+        raw_result: Union[EigenstateResult, EigensolverResult, MinimumEigensolverResult],
     ) -> ElectronicStructureResult:
         """Interprets an EigenstateResult in the context of this transformation.
 
@@ -137,9 +131,7 @@ class ElectronicStructureProblem(BaseProblem):
 
     def get_default_filter_criterion(
         self,
-    ) -> Optional[
-        Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]
-    ]:
+    ) -> Optional[Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]]:
         """Returns a default filter criterion method to filter the eigenvalues computed by the
         eigen solver. For more information see also
         qiskit.algorithms.eigen_solvers.NumPyEigensolver.filter_criterion.
@@ -165,9 +157,7 @@ class ElectronicStructureProblem(BaseProblem):
 
         return partial(filter_criterion, self)
 
-    def symmetry_sector_locator(
-        self, z2_symmetries: Z2Symmetries
-    ) -> Optional[List[int]]:
+    def symmetry_sector_locator(self, z2_symmetries: Z2Symmetries) -> Optional[List[int]]:
         """Given the detected Z2Symmetries can determine the correct sector of the tapered
         operators so the correct one can be returned
 
@@ -183,9 +173,7 @@ class ElectronicStructureProblem(BaseProblem):
             num_spin_orbitals=2 * q_molecule.num_molecular_orbitals,
             num_particles=self.num_particles,
         )
-        sector_locator = ElectronicStructureProblem._pick_sector(
-            z2_symmetries, hf_bitstr
-        )
+        sector_locator = ElectronicStructureProblem._pick_sector(z2_symmetries, hf_bitstr)
 
         return sector_locator
 
@@ -194,9 +182,7 @@ class ElectronicStructureProblem(BaseProblem):
         # Finding all the symmetries using the find_Z2_symmetries:
         taper_coeff: List[int] = []
         for sym in z2_symmetries.symmetries:
-            coeff = (
-                -1 if np.logical_xor.reduce(np.logical_and(sym.z[::-1], hf_str)) else 1
-            )
+            coeff = -1 if np.logical_xor.reduce(np.logical_and(sym.z[::-1], hf_str)) else 1
             taper_coeff.append(coeff)
 
         return taper_coeff

--- a/qiskit_nature/problems/second_quantization/electronic/integrals_calculators/angular_momentum_integrals_calculator.py
+++ b/qiskit_nature/problems/second_quantization/electronic/integrals_calculators/angular_momentum_integrals_calculator.py
@@ -39,26 +39,18 @@ def calc_total_ang_momentum_ints(num_modes: int) -> Tuple[np.ndarray, np.ndarray
 
 
 def _calc_s_x_squared_ints(num_modes: int) -> Tuple[np.ndarray, np.ndarray]:
-    return _calc_squared_ints(
-        num_modes, _modify_s_x_squared_ints_neq, _modify_s_x_squared_ints_eq
-    )
+    return _calc_squared_ints(num_modes, _modify_s_x_squared_ints_neq, _modify_s_x_squared_ints_eq)
 
 
 def _calc_s_y_squared_ints(num_modes: int) -> Tuple[np.ndarray, np.ndarray]:
-    return _calc_squared_ints(
-        num_modes, _modify_s_y_squared_ints_neq, _modify_s_y_squared_ints_eq
-    )
+    return _calc_squared_ints(num_modes, _modify_s_y_squared_ints_neq, _modify_s_y_squared_ints_eq)
 
 
 def _calc_s_z_squared_ints(num_modes: int) -> Tuple[np.ndarray, np.ndarray]:
-    return _calc_squared_ints(
-        num_modes, _modify_s_z_squared_ints_neq, _modify_s_z_squared_ints_eq
-    )
+    return _calc_squared_ints(num_modes, _modify_s_z_squared_ints_neq, _modify_s_z_squared_ints_eq)
 
 
-def _calc_squared_ints(
-    num_modes: int, func_neq, func_eq
-) -> Tuple[np.ndarray, np.ndarray]:
+def _calc_squared_ints(num_modes: int, func_neq, func_eq) -> Tuple[np.ndarray, np.ndarray]:
     # calculates 1- and 2-body integrals for a given angular momentum axis (x or y or z,
     # specified by func_neq and func_eq)
     num_modes_2 = num_modes // 2
@@ -93,9 +85,7 @@ def _modify_s_x_squared_ints_neq(
     return _add_values_to_s_squared_ints(h_2, indices, values)
 
 
-def _modify_s_x_squared_ints_eq(
-    h_2: np.ndarray, p_ind: int, num_modes_2: int
-) -> np.ndarray:
+def _modify_s_x_squared_ints_eq(h_2: np.ndarray, p_ind: int, num_modes_2: int) -> np.ndarray:
     indices = [
         (p_ind, p_ind + num_modes_2, p_ind, p_ind + num_modes_2),
         (p_ind + num_modes_2, p_ind, p_ind + num_modes_2, p_ind),
@@ -123,9 +113,7 @@ def _modify_s_y_squared_ints_neq(
     return _add_values_to_s_squared_ints(h_2, indices, values)
 
 
-def _modify_s_y_squared_ints_eq(
-    h_2: np.ndarray, p_ind: int, num_modes_2: int
-) -> np.ndarray:
+def _modify_s_y_squared_ints_eq(h_2: np.ndarray, p_ind: int, num_modes_2: int) -> np.ndarray:
     indices = [
         (p_ind, p_ind + num_modes_2, p_ind, p_ind + num_modes_2),
         (p_ind + num_modes_2, p_ind, p_ind + num_modes_2, p_ind),
@@ -158,9 +146,7 @@ def _modify_s_z_squared_ints_neq(
     return _add_values_to_s_squared_ints(h_2, indices, values)
 
 
-def _modify_s_z_squared_ints_eq(
-    h_2: np.ndarray, p_ind: int, num_modes_2: int
-) -> np.ndarray:
+def _modify_s_z_squared_ints_eq(h_2: np.ndarray, p_ind: int, num_modes_2: int) -> np.ndarray:
     indices = [
         (p_ind, p_ind + num_modes_2, p_ind + num_modes_2, p_ind),
         (p_ind + num_modes_2, p_ind, p_ind, p_ind + num_modes_2),

--- a/qiskit_nature/problems/second_quantization/electronic/result_interpreter.py
+++ b/qiskit_nature/problems/second_quantization/electronic/result_interpreter.py
@@ -62,15 +62,11 @@ def _interpret_raw_result(raw_result):
         eigenstate_result.raw_result = raw_result
         eigenstate_result.eigenenergies = np.asarray([raw_result.eigenvalue])
         eigenstate_result.eigenstates = [raw_result.eigenstate]
-        eigenstate_result.aux_operator_eigenvalues = [
-            raw_result.aux_operator_eigenvalues
-        ]
+        eigenstate_result.aux_operator_eigenvalues = [raw_result.aux_operator_eigenvalues]
     return eigenstate_result
 
 
-def _interpret_electr_struct_result(
-    eigenstate_result, molecule_data, molecule_data_transformed
-):
+def _interpret_electr_struct_result(eigenstate_result, molecule_data, molecule_data_transformed):
     q_molecule = cast(QMolecule, molecule_data)
     q_molecule_transformed = cast(QMolecule, molecule_data_transformed)
     result = ElectronicStructureResult()
@@ -84,9 +80,7 @@ def _interpret_electr_struct_result(
 
 def _interpret_eigenstate_results(eigenstate_result, result):
     result.combine(eigenstate_result)
-    result.computed_energies = np.asarray(
-        [e.real for e in eigenstate_result.eigenenergies]
-    )
+    result.computed_energies = np.asarray([e.real for e in eigenstate_result.eigenenergies])
 
 
 def _interpret_q_molecule_results(q_molecule, result):
@@ -127,9 +121,7 @@ def _interpret_aux_ops_results(q_molecule_transformed, result):
             result.magnetization.append(aux_op_eigenvalues[2][0].real)  # type: ignore
 
         if len(aux_op_eigenvalues) >= 6 and q_molecule_transformed.has_dipole_integrals:
-            _interpret_dipole_results(
-                aux_op_eigenvalues, q_molecule_transformed, result
-            )
+            _interpret_dipole_results(aux_op_eigenvalues, q_molecule_transformed, result)
 
 
 def _interpret_dipole_results(aux_op_eigenvalues, q_molecule_transformed, result):

--- a/qiskit_nature/problems/second_quantization/vibrational/builders/aux_vibrational_ops_builder.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/builders/aux_vibrational_ops_builder.py
@@ -33,16 +33,12 @@ def _create_all_aux_operators(num_modals: List[int]) -> List[VibrationalOp]:
     aux_second_quantized_ops_list = []
 
     for mode in range(len(num_modals)):
-        aux_second_quantized_ops_list.append(
-            _create_occ_modals_per_mode(num_modals, mode)
-        )
+        aux_second_quantized_ops_list.append(_create_occ_modals_per_mode(num_modals, mode))
 
     return aux_second_quantized_ops_list
 
 
-def _create_occ_modals_per_mode(
-    num_modals: List[int], mode_index: int
-) -> VibrationalOp:
+def _create_occ_modals_per_mode(num_modals: List[int], mode_index: int) -> VibrationalOp:
     return build_vibrational_op_from_ints(
         calc_occ_modals_per_mode_ints(num_modals, mode_index),
         len(num_modals),

--- a/qiskit_nature/problems/second_quantization/vibrational/builders/hopping_ops_builder.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/builders/hopping_ops_builder.py
@@ -56,16 +56,13 @@ def _build_qeom_hopping_ops(
 
     excitations_list: List[Tuple[Tuple[int, ...], Tuple[int, ...]]]
     if isinstance(excitations, (str, int)) or (
-        isinstance(excitations, list)
-        and all(isinstance(exc, int) for exc in excitations)
+        isinstance(excitations, list) and all(isinstance(exc, int) for exc in excitations)
     ):
         excitations = cast(Union[str, int, List[int]], excitations)
         ansatz = UVCC(qubit_converter, num_modals, excitations)
         excitations_list = ansatz._get_excitation_list()
     else:
-        excitations_list = cast(
-            List[Tuple[Tuple[int, ...], Tuple[int, ...]]], excitations
-        )
+        excitations_list = cast(List[Tuple[Tuple[int, ...], Tuple[int, ...]]], excitations)
 
     size = len(excitations_list)
 

--- a/qiskit_nature/problems/second_quantization/vibrational/builders/vibrational_op_builder.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/builders/vibrational_op_builder.py
@@ -61,9 +61,7 @@ def _build_vibrational_op(
         watson_hamiltonian, num_modals, truncation_order
     ).convert()
 
-    return build_vibrational_op_from_ints(
-        boson_hamilt_harm_basis, num_modes, num_modals
-    )
+    return build_vibrational_op_from_ints(boson_hamilt_harm_basis, num_modes, num_modals)
 
 
 def build_vibrational_op_from_ints(

--- a/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
@@ -60,9 +60,7 @@ class VibrationalStructureProblem(BaseProblem):
         Returns:
             A list of `SecondQuantizedOp` in the following order: ... .
         """
-        self._molecule_data: WatsonHamiltonian = cast(
-            WatsonHamiltonian, self.driver.run()
-        )
+        self._molecule_data: WatsonHamiltonian = cast(WatsonHamiltonian, self.driver.run())
         self._molecule_data_transformed: WatsonHamiltonian = cast(
             WatsonHamiltonian, self._transform(self._molecule_data)
         )
@@ -77,9 +75,7 @@ class VibrationalStructureProblem(BaseProblem):
         else:
             num_modals = self.num_modals
 
-        second_quantized_ops_list = [vibrational_spin_op] + _create_all_aux_operators(
-            num_modals
-        )
+        second_quantized_ops_list = [vibrational_spin_op] + _create_all_aux_operators(num_modals)
 
         return second_quantized_ops_list
 
@@ -90,9 +86,7 @@ class VibrationalStructureProblem(BaseProblem):
             str,
             int,
             List[int],
-            Callable[
-                [int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]
-            ],
+            Callable[[int, Tuple[int, int]], List[Tuple[Tuple[int, ...], Tuple[int, ...]]]],
         ] = "sd",
     ) -> Tuple[
         Dict[str, PauliSumOp],
@@ -129,9 +123,7 @@ class VibrationalStructureProblem(BaseProblem):
 
     def interpret(
         self,
-        raw_result: Union[
-            EigenstateResult, EigensolverResult, MinimumEigensolverResult
-        ],
+        raw_result: Union[EigenstateResult, EigensolverResult, MinimumEigensolverResult],
     ) -> VibrationalStructureResult:
         """Interprets an EigenstateResult in the context of this transformation.
         Args:
@@ -144,9 +136,7 @@ class VibrationalStructureProblem(BaseProblem):
 
     def get_default_filter_criterion(
         self,
-    ) -> Optional[
-        Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]
-    ]:
+    ) -> Optional[Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]]:
         """Returns a default filter criterion method to filter the eigenvalues computed by the
         eigen solver. For more information see also
         aqua.algorithms.eigen_solvers.NumPyEigensolver.filter_criterion.

--- a/qiskit_nature/results/electronic_structure_result.py
+++ b/qiskit_nature/results/electronic_structure_result.py
@@ -40,9 +40,7 @@ class ElectronicStructureResult(EigenstateResult):
         self._nuclear_dipole_moment: Optional[DipoleTuple] = None
         self._computed_energies: Optional[np.ndarray] = None
         self._extracted_transformer_energies: Dict[str, float] = {}
-        self._extracted_transformer_dipoles: Optional[
-            List[Dict[str, DipoleTuple]]
-        ] = None
+        self._extracted_transformer_dipoles: Optional[List[Dict[str, DipoleTuple]]] = None
         self._reverse_dipole_sign: bool = False
 
     @property
@@ -81,11 +79,7 @@ class ElectronicStructureResult(EigenstateResult):
     @property
     def total_energies(self) -> np.ndarray:
         """Returns ground state energy if nuclear_repulsion_energy is available from driver"""
-        nre = (
-            self.nuclear_repulsion_energy
-            if self.nuclear_repulsion_energy is not None
-            else 0
-        )
+        nre = self.nuclear_repulsion_energy if self.nuclear_repulsion_energy is not None else 0
         # Adding float to np.ndarray adds it to each entry
         return self.electronic_energies + nre
 
@@ -127,10 +121,7 @@ class ElectronicStructureResult(EigenstateResult):
 
     def has_dipole(self) -> bool:
         """Returns whether dipole moment is present in result or not"""
-        return (
-            self.nuclear_dipole_moment is not None
-            and self.electronic_dipole_moment is not None
-        )
+        return self.nuclear_dipole_moment is not None and self.electronic_dipole_moment is not None
 
     @property
     def reverse_dipole_sign(self) -> bool:
@@ -214,9 +205,7 @@ class ElectronicStructureResult(EigenstateResult):
         return self._extracted_transformer_dipoles
 
     @extracted_transformer_dipoles.setter
-    def extracted_transformer_dipoles(
-        self, value: List[Dict[str, DipoleTuple]]
-    ) -> None:
+    def extracted_transformer_dipoles(self, value: List[Dict[str, DipoleTuple]]) -> None:
         """Sets the dipole moments extracted by any applied transformers."""
         self._extracted_transformer_dipoles = value
 
@@ -299,13 +288,9 @@ class ElectronicStructureResult(EigenstateResult):
                 round(self.electronic_energies[0], 12)
             )
         )
-        lines.append(
-            "  - computed part:      {}".format(round(self.computed_energies[0], 12))
-        )
+        lines.append("  - computed part:      {}".format(round(self.computed_energies[0], 12)))
         for name, value in self.extracted_transformer_energies.items():
-            lines.append(
-                "  - {} extracted energy part: {}".format(name, round(value, 12))
-            )
+            lines.append("  - {} extracted energy part: {}".format(name, round(value, 12)))
         if self.nuclear_repulsion_energy is not None:
             lines.append(
                 "~ Nuclear repulsion energy (Hartree): {}".format(
@@ -327,26 +312,17 @@ class ElectronicStructureResult(EigenstateResult):
             ):
                 lines.append("{: 3d}: ".format(idx + 1))
                 lines.append(
-                    "* Electronic excited state energy (Hartree): {}".format(
-                        round(elec_energy, 12)
-                    )
+                    "* Electronic excited state energy (Hartree): {}".format(round(elec_energy, 12))
                 )
                 lines.append(
-                    "> Total excited state energy (Hartree): {}".format(
-                        round(total_energy, 12)
-                    )
+                    "> Total excited state energy (Hartree): {}".format(round(total_energy, 12))
                 )
 
         if self.has_observables():
             lines.append(" ")
             lines.append("=== MEASURED OBSERVABLES ===")
             lines.append(" ")
-            for idx, (
-                num_particles,
-                spin,
-                total_angular_momentum,
-                magnetization,
-            ) in enumerate(
+            for idx, (num_particles, spin, total_angular_momentum, magnetization,) in enumerate(
                 zip(
                     self.num_particles,
                     self.spin,
@@ -376,15 +352,7 @@ class ElectronicStructureResult(EigenstateResult):
                     )
                 )
                 lines.append(" ")
-            for idx, (
-                elec_dip,
-                comp_dip,
-                extr_dip,
-                dip,
-                tot_dip,
-                dip_db,
-                tot_dip_db,
-            ) in enumerate(
+            for idx, (elec_dip, comp_dip, extr_dip, dip, tot_dip, dip_db, tot_dip_db,) in enumerate(
                 zip(
                     self.electronic_dipole_moment,
                     self.computed_dipole_moment,
@@ -397,18 +365,12 @@ class ElectronicStructureResult(EigenstateResult):
             ):
                 lines.append("{: 3d}: ".format(idx))
                 lines.append(
-                    "  * Electronic dipole moment (a.u.): {}".format(
-                        _dipole_to_string(elec_dip)
-                    )
+                    "  * Electronic dipole moment (a.u.): {}".format(_dipole_to_string(elec_dip))
                 )
-                lines.append(
-                    "    - computed part:      {}".format(_dipole_to_string(comp_dip))
-                )
+                lines.append("    - computed part:      {}".format(_dipole_to_string(comp_dip)))
                 for name, ex_dip in extr_dip.items():
                     lines.append(
-                        "    - {} extracted energy part: {}".format(
-                            name, _dipole_to_string(ex_dip)
-                        )
+                        "    - {} extracted energy part: {}".format(name, _dipole_to_string(ex_dip))
                     )
                 if self.nuclear_dipole_moment is not None:
                     lines.append(
@@ -426,9 +388,7 @@ class ElectronicStructureResult(EigenstateResult):
         return lines
 
 
-def _dipole_tuple_add(
-    x: Optional[DipoleTuple], y: Optional[DipoleTuple]
-) -> Optional[DipoleTuple]:
+def _dipole_tuple_add(x: Optional[DipoleTuple], y: Optional[DipoleTuple]) -> Optional[DipoleTuple]:
     """Utility to add two dipole tuples element-wise for dipole additions"""
     if x is None or y is None:
         return None
@@ -453,8 +413,4 @@ def _float_to_string(value: Optional[float], precision: int = 8) -> str:
     if value is None:
         return "None"
     else:
-        return (
-            "0.0"
-            if value == 0
-            else ("{:." + str(precision) + "f}").format(value).rstrip("0")
-        )
+        return "0.0" if value == 0 else ("{:." + str(precision) + "f}").format(value).rstrip("0")

--- a/qiskit_nature/results/vibrational_structure_result.py
+++ b/qiskit_nature/results/vibrational_structure_result.py
@@ -82,8 +82,6 @@ class VibrationalStructureResult(EigenstateResult):
         if len(self.num_occupied_modals_per_mode) > 0:
             lines.append("The number of occupied modals is")
         for i in range(len(self.num_occupied_modals_per_mode)):
-            lines.append(
-                "- Mode {}: {}".format(i, self.num_occupied_modals_per_mode[i])
-            )
+            lines.append("- Mode {}: {}".format(i, self.num_occupied_modals_per_mode[i]))
 
         return lines

--- a/qiskit_nature/transformers/active_space_transformer.py
+++ b/qiskit_nature/transformers/active_space_transformer.py
@@ -139,13 +139,9 @@ class ActiveSpaceTransformer(BaseTransformer):
         self._beta = mo_coeff_full[1] is not None
         # get molecular orbital occupation numbers
         mo_occ_full = self._extract_mo_occupation_vector(molecule_data)
-        self._mo_occ_total = (
-            mo_occ_full[0] + mo_occ_full[1] if self._beta else mo_occ_full[0]
-        )
+        self._mo_occ_total = mo_occ_full[0] + mo_occ_full[1] if self._beta else mo_occ_full[0]
 
-        active_orbs_idxs, inactive_orbs_idxs = self._determine_active_space(
-            molecule_data
-        )
+        active_orbs_idxs, inactive_orbs_idxs = self._determine_active_space(molecule_data)
 
         # split molecular orbitals coefficients into active and inactive parts
         self._mo_coeff_inactive = (
@@ -171,9 +167,7 @@ class ActiveSpaceTransformer(BaseTransformer):
         molecule_data_reduced.num_beta = self._num_particles[1]
         molecule_data_reduced.mo_coeff = self._mo_coeff_active[0]
         molecule_data_reduced.mo_coeff_b = self._mo_coeff_active[1]
-        molecule_data_reduced.orbital_energies = molecule_data.orbital_energies[
-            active_orbs_idxs
-        ]
+        molecule_data_reduced.orbital_energies = molecule_data.orbital_energies[active_orbs_idxs]
         if self._beta:
             molecule_data_reduced.orbital_energies_b = molecule_data.orbital_energies_b[
                 active_orbs_idxs
@@ -232,10 +226,7 @@ class ActiveSpaceTransformer(BaseTransformer):
                     self._num_electrons,
                 )
         elif isinstance(self._num_electrons, tuple):
-            if not all(
-                isinstance(n_elec, int) and n_elec >= 0
-                for n_elec in self._num_electrons
-            ):
+            if not all(isinstance(n_elec, int) and n_elec >= 0 for n_elec in self._num_electrons):
                 raise QiskitNatureError(
                     "Neither the number of alpha, nor the number of beta electrons can be "
                     "negative:",
@@ -339,10 +330,7 @@ class ActiveSpaceTransformer(BaseTransformer):
         """
         if self._active_orbitals is None:
             norbs_inactive = nelec_inactive // 2
-            if (
-                norbs_inactive + self._num_molecular_orbitals
-                > molecule_data.num_molecular_orbitals
-            ):
+            if norbs_inactive + self._num_molecular_orbitals > molecule_data.num_molecular_orbitals:
                 raise QiskitNatureError("More orbitals requested than available.")
         else:
             if self._num_molecular_orbitals != len(self._active_orbitals):
@@ -428,9 +416,7 @@ class ActiveSpaceTransformer(BaseTransformer):
 
         energy_shift = self._compute_inactive_energy(ao_1e_matrix, inactive_op)
 
-        mo_1e_matrix, mo_2e_matrix = self._compute_active_integrals(
-            inactive_op, ao_2e_matrix
-        )
+        mo_1e_matrix, mo_2e_matrix = self._compute_active_integrals(inactive_op, ao_2e_matrix)
 
         getattr(molecule_data_reduced, energy_shift_attribute)[
             "ActiveSpaceTransformer"
@@ -468,18 +454,10 @@ class ActiveSpaceTransformer(BaseTransformer):
         fock_inactive_b = coulomb_inactive_b = exchange_inactive_b = None
 
         if self._beta:
-            coulomb_inactive_b = np.einsum(
-                "ijkl,ji->kl", eri, self._density_inactive[1]
-            )
-            exchange_inactive_b = np.einsum(
-                "ijkl,jk->il", eri, self._density_inactive[1]
-            )
-            fock_inactive = (
-                hcore[0] + coulomb_inactive + coulomb_inactive_b - exchange_inactive
-            )
-            fock_inactive_b = (
-                hcore[1] + coulomb_inactive + coulomb_inactive_b - exchange_inactive_b
-            )
+            coulomb_inactive_b = np.einsum("ijkl,ji->kl", eri, self._density_inactive[1])
+            exchange_inactive_b = np.einsum("ijkl,jk->il", eri, self._density_inactive[1])
+            fock_inactive = hcore[0] + coulomb_inactive + coulomb_inactive_b - exchange_inactive
+            fock_inactive_b = hcore[1] + coulomb_inactive + coulomb_inactive_b - exchange_inactive_b
 
         return (fock_inactive, fock_inactive_b)
 

--- a/qiskit_nature/transformers/freeze_core_transformer.py
+++ b/qiskit_nature/transformers/freeze_core_transformer.py
@@ -100,9 +100,7 @@ class FreezeCoreTransformer(ActiveSpaceTransformer):
         if self._remove_orbitals is not None:
             inactive_orbs_idxs.extend(self._remove_orbitals)
         active_orbs_idxs = [
-            o
-            for o in range(molecule_data.num_molecular_orbitals)
-            if o not in inactive_orbs_idxs
+            o for o in range(molecule_data.num_molecular_orbitals) if o not in inactive_orbs_idxs
         ]
         self._active_orbitals = active_orbs_idxs
         self._num_molecular_orbitals = len(active_orbs_idxs)

--- a/test/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
+++ b/test/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
@@ -63,9 +63,7 @@ class TestNumPyEigensolverFactory(QiskitNatureTestCase):
             return np.isclose(aux_values[0][0], 3.0)
 
         self._numpy_eigensolver_factory.filter_criterion = filter_criterion
-        self.assertEqual(
-            self._numpy_eigensolver_factory.filter_criterion, filter_criterion
-        )
+        self.assertEqual(self._numpy_eigensolver_factory.filter_criterion, filter_criterion)
 
         # k
         self.assertEqual(self._numpy_eigensolver_factory.k, self.k)
@@ -77,9 +75,7 @@ class TestNumPyEigensolverFactory(QiskitNatureTestCase):
         self._numpy_eigensolver_factory.use_default_filter_criterion = True
         self.assertTrue(self._numpy_eigensolver_factory.use_default_filter_criterion)
         # get_solver
-        solver = self._numpy_eigensolver_factory.get_solver(
-            self.electronic_structure_problem
-        )
+        solver = self._numpy_eigensolver_factory.get_solver(self.electronic_structure_problem)
         self.assertIsInstance(solver, NumPyEigensolver)
         self.assertEqual(solver.k, 100)
         self.assertEqual(solver.filter_criterion, filter_criterion)

--- a/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -109,9 +109,7 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
                 computed_energies.append(comp_energy)
 
         for idx in range(len(self.reference_energies)):
-            self.assertAlmostEqual(
-                computed_energies[idx], self.reference_energies[idx], places=4
-            )
+            self.assertAlmostEqual(computed_energies[idx], self.reference_energies[idx], places=4)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
+++ b/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
@@ -51,9 +51,7 @@ class TestVQEUCCFactory(QiskitNatureTestCase):
         """Test Getter/Setter"""
 
         with self.subTest("Quantum Instance"):
-            self.assertEqual(
-                self._vqe_ucc_factory.quantum_instance, self.quantum_instance
-            )
+            self.assertEqual(self._vqe_ucc_factory.quantum_instance, self.quantum_instance)
             self._vqe_ucc_factory.quantum_instance = None
             self.assertEqual(self._vqe_ucc_factory.quantum_instance, None)
 

--- a/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
+++ b/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
@@ -49,9 +49,7 @@ class TestVQEUVCCFactory(QiskitNatureTestCase):
         """Test Getter/Setter"""
 
         with self.subTest("Quantum Instance"):
-            self.assertEqual(
-                self._vqe_uvcc_factory.quantum_instance, self.quantum_instance
-            )
+            self.assertEqual(self._vqe_uvcc_factory.quantum_instance, self.quantum_instance)
             self._vqe_uvcc_factory.quantum_instance = None
             self.assertEqual(self._vqe_uvcc_factory.quantum_instance, None)
 

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -58,9 +58,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
 
     def test_default(self):
         """Default execution"""
-        solver = VQEUCCFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = VQEUCCFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
         calc = AdaptVQE(self.qubit_converter, solver)
         res = calc.solve(self.problem)
         self.assertAlmostEqual(res.electronic_energies[0], self.expected, places=6)
@@ -68,9 +66,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
     def test_aux_ops_reusability(self):
         """Test that the auxiliary operators can be reused"""
         # Regression test against #1475
-        solver = VQEUCCFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = VQEUCCFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
         calc = AdaptVQE(self.qubit_converter, solver)
 
         modes = 4
@@ -81,8 +77,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
 
         _ = calc.solve(self.problem)
         assert all(
-            frozenset(a.to_list()) == frozenset(b.to_list())
-            for a, b in zip(aux_ops, aux_ops_copy)
+            frozenset(a.to_list()) == frozenset(b.to_list()) for a, b in zip(aux_ops, aux_ops_copy)
         )
 
     def test_custom_minimum_eigensolver(self):
@@ -92,9 +87,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
             """A custom MESFactory"""
 
             def get_solver(self, problem, qubit_converter):
-                q_molecule_transformed = cast(
-                    QMolecule, problem.molecule_data_transformed
-                )
+                q_molecule_transformed = cast(QMolecule, problem.molecule_data_transformed)
                 num_molecular_orbitals = q_molecule_transformed.num_molecular_orbitals
                 num_particles = (
                     q_molecule_transformed.num_alpha,
@@ -102,9 +95,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
                 )
                 num_spin_orbitals = 2 * num_molecular_orbitals
 
-                initial_state = HartreeFock(
-                    num_spin_orbitals, num_particles, qubit_converter
-                )
+                initial_state = HartreeFock(num_spin_orbitals, num_particles, qubit_converter)
                 ansatz = UCC(
                     qubit_converter=qubit_converter,
                     num_particles=num_particles,
@@ -119,9 +110,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
                 )
                 return vqe
 
-        solver = CustomFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = CustomFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
 
         calc = AdaptVQE(self.qubit_converter, solver)
         res = calc.solve(self.problem)
@@ -143,9 +132,7 @@ class TestAdaptVQE(QiskitNatureTestCase):
                 solver.ansatz.operators = custom_excitation_pool
                 return solver
 
-        solver = CustomFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = CustomFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
         calc = AdaptVQE(self.qubit_converter, solver)
         res = calc.solve(self.problem)
         self.assertAlmostEqual(res.electronic_energies[0], self.expected, places=6)

--- a/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -101,18 +101,14 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
         solver = VQE(
             ansatz=ansatz,
             optimizer=optimizer,
-            quantum_instance=QuantumInstance(
-                backend=BasicAer.get_backend("statevector_simulator")
-            ),
+            quantum_instance=QuantumInstance(backend=BasicAer.get_backend("statevector_simulator")),
         )
 
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
 
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy_pUCCD, places=6
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy_pUCCD, places=6)
 
     @slow_test
     def test_uccsd_hf_qUCCD0(self):
@@ -133,22 +129,16 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
         solver = VQE(
             ansatz=ansatz,
             optimizer=optimizer,
-            quantum_instance=QuantumInstance(
-                backend=BasicAer.get_backend("statevector_simulator")
-            ),
+            quantum_instance=QuantumInstance(backend=BasicAer.get_backend("statevector_simulator")),
         )
 
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
 
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy_UCCD0, places=6
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy_UCCD0, places=6)
 
-    @unittest.skip(
-        "Skip until https://github.com/Qiskit/qiskit-nature/issues/91 is closed."
-    )
+    @unittest.skip("Skip until https://github.com/Qiskit/qiskit-nature/issues/91 is closed.")
     def test_uccsd_hf_qUCCD0full(self):
         """singlet full uccd test"""
         optimizer = SLSQP(maxiter=100)
@@ -168,18 +158,14 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
         solver = VQE(
             ansatz=ansatz,
             optimizer=optimizer,
-            quantum_instance=QuantumInstance(
-                backend=BasicAer.get_backend("statevector_simulator")
-            ),
+            quantum_instance=QuantumInstance(backend=BasicAer.get_backend("statevector_simulator")),
         )
 
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
 
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy_UCCD0full, places=6
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy_UCCD0full, places=6)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -46,9 +46,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
     def setUp(self):
         super().setUp()
-        self.driver = HDF5Driver(
-            self.get_resource_path("test_driver_hdf5.hdf5", "drivers/hdf5d")
-        )
+        self.driver = HDF5Driver(self.get_resource_path("test_driver_hdf5.hdf5", "drivers/hdf5d"))
         self.seed = 56
         algorithm_globals.random_seed = self.seed
 
@@ -77,9 +75,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_vqe_uccsd(self):
         """Test VQE UCCSD case"""
         solver = VQEUCCFactory(
-            quantum_instance=QuantumInstance(
-                BasicAer.get_backend("statevector_simulator")
-            ),
+            quantum_instance=QuantumInstance(BasicAer.get_backend("statevector_simulator")),
             ansatz=UCC(excitations="d"),
         )
         calc = GroundStateEigensolver(self.qubit_converter, solver)
@@ -88,9 +84,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
     def test_vqe_ucc_custom(self):
         """Test custom ansatz in Factory use case"""
-        solver = VQEUCCFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = VQEUCCFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
@@ -109,15 +103,12 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
         _ = calc.solve(self.electronic_structure_problem)
         assert all(
-            frozenset(a.to_list()) == frozenset(b.to_list())
-            for a, b in zip(aux_ops, aux_ops_copy)
+            frozenset(a.to_list()) == frozenset(b.to_list()) for a, b in zip(aux_ops, aux_ops_copy)
         )
 
     def _setup_evaluation_operators(self):
         # first we run a ground state calculation
-        solver = VQEUCCFactory(
-            QuantumInstance(BasicAer.get_backend("statevector_simulator"))
-        )
+        solver = VQEUCCFactory(QuantumInstance(BasicAer.get_backend("statevector_simulator")))
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -228,9 +219,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        ansatz = solver.get_solver(
-            self.electronic_structure_problem, self.qubit_converter
-        ).ansatz
+        ansatz = solver.get_solver(self.electronic_structure_problem, self.qubit_converter).ansatz
         circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
@@ -245,9 +234,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
             backend = Aer.get_backend("qasm_simulator")
         except ImportError as ex:  # pylint: disable=broad-except
-            self.skipTest(
-                "Aer doesn't appear to be installed. Error: '{}'".format(str(ex))
-            )
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
         solver = VQEUCCFactory(
@@ -266,18 +253,14 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
-        ansatz = solver.get_solver(
-            self.electronic_structure_problem, self.qubit_converter
-        ).ansatz
+        ansatz = solver.get_solver(self.electronic_structure_problem, self.qubit_converter).ansatz
         circuit = ansatz.assign_parameters(res_qasm.raw_result.optimal_point)
         mean = calc.evaluate_operators(circuit, qubit_op)
 
         self.assertAlmostEqual(res_qasm.eigenenergies[0], mean[0].real)
 
     def _prepare_uccsd_hf(self, qubit_converter):
-        initial_state = HartreeFock(
-            self.num_spin_orbitals, self.num_particles, qubit_converter
-        )
+        initial_state = HartreeFock(self.num_spin_orbitals, self.num_particles, qubit_converter)
         ansatz = UCCSD(
             qubit_converter,
             self.num_particles,
@@ -303,9 +286,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
         result = gsc.solve(self.electronic_structure_problem)
 
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy, places=6
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy, places=6)
 
     @slow_test
     def test_uccsd_hf_qasm(self):
@@ -340,9 +321,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
             backend = Aer.get_backend("statevector_simulator")
         except ImportError as ex:  # pylint: disable=broad-except
-            self.skipTest(
-                "Aer doesn't appear to be installed. Error: '{}'".format(str(ex))
-            )
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
@@ -357,9 +336,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy, places=6
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy, places=6)
 
     @slow_test
     def test_uccsd_hf_aer_qasm(self):
@@ -370,9 +347,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
             backend = Aer.get_backend("qasm_simulator")
         except ImportError as ex:  # pylint: disable=broad-except
-            self.skipTest(
-                "Aer doesn't appear to be installed. Error: '{}'".format(str(ex))
-            )
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
@@ -403,9 +378,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
             backend = Aer.get_backend("qasm_simulator")
         except ImportError as ex:  # pylint: disable=broad-except
-            self.skipTest(
-                "Aer doesn't appear to be installed. Error: '{}'".format(str(ex))
-            )
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
@@ -421,9 +394,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy, places=3
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy, places=3)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/ground_state_solvers/test_swaprz.py
+++ b/test/algorithms/ground_state_solvers/test_swaprz.py
@@ -47,9 +47,7 @@ class TestExcitationPreserving(QiskitNatureTestCase):
     def test_excitation_preserving(self):
         """Test the excitation preserving wavefunction on a chemistry example."""
 
-        driver = HDF5Driver(
-            self.get_resource_path("test_driver_hdf5.hdf5", "drivers/hdf5d")
-        )
+        driver = HDF5Driver(self.get_resource_path("test_driver_hdf5.hdf5", "drivers/hdf5d"))
 
         converter = QubitConverter(ParityMapper())
 
@@ -84,9 +82,7 @@ class TestExcitationPreserving(QiskitNatureTestCase):
         gsc = GroundStateEigensolver(converter, solver)
 
         result = gsc.solve(problem)
-        self.assertAlmostEqual(
-            result.total_energies[0], self.reference_energy, places=4
-        )
+        self.assertAlmostEqual(result.total_energies[0], self.reference_energy, places=4)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/pes_samplers/potentials/test_potential.py
+++ b/test/algorithms/pes_samplers/potentials/test_potential.py
@@ -172,9 +172,7 @@ class TestPotential(unittest.TestCase):
         wave_number = morse.wave_number()
 
         result = np.array([minimal_energy_distance, minimal_energy, wave_number])
-        benchmark = np.array(
-            [0.8106703001726382, -1.062422610690636, 3800.7855102410026]
-        )
+        benchmark = np.array([0.8106703001726382, -1.062422610690636, 3800.7855102410026])
         np.testing.assert_array_almost_equal(result, benchmark, decimal=4)
 
         radia = np.array([0.5, 1, 1.5, 2])
@@ -330,9 +328,7 @@ class TestPotential(unittest.TestCase):
         wave_number = harmonic.wave_number()
 
         result = np.array([minimal_energy_distance, minimal_energy, wave_number])
-        benchmark = np.array(
-            [0.8792058944654566, -1.0678714520398802, 4670.969897517367]
-        )
+        benchmark = np.array([0.8792058944654566, -1.0678714520398802, 4670.969897517367])
         np.testing.assert_array_almost_equal(result, benchmark)
 
         radia = np.array([0.5, 1, 1.5, 2])

--- a/test/algorithms/pes_samplers/test_bopes_sampler.py
+++ b/test/algorithms/pes_samplers/test_bopes_sampler.py
@@ -102,12 +102,8 @@ class TestBOPES(unittest.TestCase):
         pot = MorsePotential(m)
         pot.fit(res.points, res.energies)
 
-        np.testing.assert_array_almost_equal(
-            [pot.alpha, pot.r_0], [2.235, 0.720], decimal=3
-        )
-        np.testing.assert_array_almost_equal(
-            [pot.d_e, pot.m_shift], [0.2107, -1.1419], decimal=3
-        )
+        np.testing.assert_array_almost_equal([pot.alpha, pot.r_0], [2.235, 0.720], decimal=3)
+        np.testing.assert_array_almost_equal([pot.d_e, pot.m_shift], [0.2107, -1.1419], decimal=3)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/pes_samplers/test_extrapolators.py
+++ b/test/algorithms/pes_samplers/test_extrapolators.py
@@ -221,9 +221,7 @@ class TestExtrapolators(unittest.TestCase):
         """
         self.assertIsInstance(Extrapolator.factory(mode="window"), WindowExtrapolator)
         self.assertIsInstance(Extrapolator.factory(mode="poly"), PolynomialExtrapolator)
-        self.assertIsInstance(
-            Extrapolator.factory(mode="diff_model"), DifferentialExtrapolator
-        )
+        self.assertIsInstance(Extrapolator.factory(mode="diff_model"), DifferentialExtrapolator)
         self.assertIsInstance(Extrapolator.factory(mode="pca"), PCAExtrapolator)
         self.assertIsInstance(Extrapolator.factory(mode="l1"), SieveExtrapolator)
         self.assertRaises(QiskitNatureError, Extrapolator.factory, mode="unknown")
@@ -243,8 +241,7 @@ class TestExtrapolators(unittest.TestCase):
             points=[points], param_dict=PARAM_DICT
         )
         sq_diff = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[points], PARAM_DICT[points])
+            (actual - expected) ** 2 for actual, expected in zip(params[points], PARAM_DICT[points])
         ]
         self.assertLess(sum(sq_diff), 1e-3)
 
@@ -260,24 +257,19 @@ class TestExtrapolators(unittest.TestCase):
         window_extrapolator = Extrapolator.factory(
             "window", extrapolator=PolynomialExtrapolator(degree=1), window=3
         )
-        params = window_extrapolator.extrapolate(
-            points=points_interspersed, param_dict=PARAM_DICT
-        )
+        params = window_extrapolator.extrapolate(points=points_interspersed, param_dict=PARAM_DICT)
         self.assertFalse(params.get(0.3))
         self.assertFalse(params.get(0.5))
         sq_diff_1 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
         ]
         self.assertLess(sum(sq_diff_1), 1e-1)
         sq_diff_2 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
         ]
         self.assertLess(sum(sq_diff_2), 1e-2)
         sq_diff_3 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
+            (actual - expected) ** 2 for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
         ]
         self.assertLess(sum(sq_diff_3), 1e-2)
 
@@ -293,24 +285,19 @@ class TestExtrapolators(unittest.TestCase):
         window_extrapolator = WindowExtrapolator(
             extrapolator=DifferentialExtrapolator(degree=1), window=3
         )
-        params = window_extrapolator.extrapolate(
-            points=points_interspersed, param_dict=PARAM_DICT
-        )
+        params = window_extrapolator.extrapolate(points=points_interspersed, param_dict=PARAM_DICT)
         self.assertFalse(params.get(0.3))
         self.assertFalse(params.get(0.5))
         sq_diff_1 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
         ]
         self.assertLess(sum(sq_diff_1), 1e-2)
         sq_diff_2 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
         ]
         self.assertLess(sum(sq_diff_2), 1e-3)
         sq_diff_3 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
+            (actual - expected) ** 2 for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
         ]
         self.assertLess(sum(sq_diff_3), 1e-3)
 
@@ -327,24 +314,19 @@ class TestExtrapolators(unittest.TestCase):
         window_extrapolator = WindowExtrapolator(
             extrapolator=DifferentialExtrapolator(degree=1, model=model), window=3
         )
-        params = window_extrapolator.extrapolate(
-            points=points_interspersed, param_dict=PARAM_DICT
-        )
+        params = window_extrapolator.extrapolate(points=points_interspersed, param_dict=PARAM_DICT)
         self.assertFalse(params.get(0.3))
         self.assertFalse(params.get(0.5))
         sq_diff_1 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
         ]
         self.assertLess(sum(sq_diff_1), 1e-2)
         sq_diff_2 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
         ]
         self.assertLess(sum(sq_diff_2), 1e-3)
         sq_diff_3 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
+            (actual - expected) ** 2 for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
         ]
         self.assertLess(sum(sq_diff_3), 1e-3)
 
@@ -357,27 +339,20 @@ class TestExtrapolators(unittest.TestCase):
         last three points has a specified error relative to the actual parameter values.
         """
         points_interspersed = [0.3, 0.5, 0.7, 0.8, 1.5]
-        pca_poly_win_ext = PCAExtrapolator(
-            extrapolator=PolynomialExtrapolator(degree=1), window=3
-        )
-        params = pca_poly_win_ext.extrapolate(
-            points=points_interspersed, param_dict=PARAM_DICT
-        )
+        pca_poly_win_ext = PCAExtrapolator(extrapolator=PolynomialExtrapolator(degree=1), window=3)
+        params = pca_poly_win_ext.extrapolate(points=points_interspersed, param_dict=PARAM_DICT)
         self.assertFalse(params.get(0.3))
         self.assertFalse(params.get(0.5))
         sq_diff_1 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
         ]
         self.assertLess(sum(sq_diff_1), 1e-2)
         sq_diff_2 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
         ]
         self.assertLess(sum(sq_diff_2), 1e-2)
         sq_diff_3 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
+            (actual - expected) ** 2 for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
         ]
         self.assertLess(sum(sq_diff_3), 1e-2)
 
@@ -399,18 +374,15 @@ class TestExtrapolators(unittest.TestCase):
         self.assertFalse(params.get(0.3))
         self.assertFalse(params.get(0.5))
         sq_diff_1 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.7], PARAM_DICT[0.7])
         ]
         self.assertLess(sum(sq_diff_1), 1e-1)
         sq_diff_2 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
+            (actual - expected) ** 2 for actual, expected in zip(params[0.8], PARAM_DICT[0.8])
         ]
         self.assertLess(sum(sq_diff_2), 1e-1)
         sq_diff_3 = [
-            (actual - expected) ** 2
-            for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
+            (actual - expected) ** 2 for actual, expected in zip(params[1.5], PARAM_DICT[1.5])
         ]
         self.assertLess(sum(sq_diff_3), 1e-1)
 

--- a/test/circuit/library/ansatzes/test_chc.py
+++ b/test/circuit/library/ansatzes/test_chc.py
@@ -83,12 +83,8 @@ class TestCHCVSCF(QiskitNatureTestCase):
 
         num_qubits = sum(num_modals)
         excitations = []
-        excitations += generate_vibration_excitations(
-            num_excitations=1, num_modals=num_modals
-        )
-        excitations += generate_vibration_excitations(
-            num_excitations=2, num_modals=num_modals
-        )
+        excitations += generate_vibration_excitations(num_excitations=1, num_modals=num_modals)
+        excitations += generate_vibration_excitations(num_excitations=2, num_modals=num_modals)
         chc_ansatz = CHC(
             num_qubits, ladder=False, excitations=excitations, initial_state=init_state
         )

--- a/test/circuit/library/ansatzes/test_uvcc.py
+++ b/test/circuit/library/ansatzes/test_uvcc.py
@@ -64,9 +64,7 @@ class TestUVCC(QiskitNatureTestCase):
         """Tests the UVCC Ansatz."""
         converter = QubitConverter(DirectMapper())
 
-        ansatz = UVCC(
-            qubit_converter=converter, num_modals=num_modals, excitations=excitations
-        )
+        ansatz = UVCC(qubit_converter=converter, num_modals=num_modals, excitations=excitations)
 
         assert_ucc_like_ansatz(self, ansatz, num_modals, expect)
 

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -79,9 +79,7 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
             [((0, 1, 4), (2, 3, 5)), ((0, 1, 4), (2, 3, 6)), ((0, 1, 4), (2, 3, 7))],
         ),
     )
-    def test_generate_excitations(
-        self, num_excitations, num_spin_orbitals, num_particles, expect
-    ):
+    def test_generate_excitations(self, num_excitations, num_spin_orbitals, num_particles, expect):
         """Test standard input arguments."""
         excitations = generate_fermionic_excitations(
             num_excitations, num_spin_orbitals, num_particles
@@ -143,9 +141,7 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
         (1, 6, [1, 1], [((0,), (1,)), ((0,), (2,))]),
         (2, 8, [2, 2], [((0, 1), (2, 3))]),
     )
-    def test_pure_alpha_excitation(
-        self, num_excitations, num_spin_orbitals, num_particles, expect
-    ):
+    def test_pure_alpha_excitation(self, num_excitations, num_spin_orbitals, num_particles, expect):
         """Test disabling beta-spin excitations."""
         excitations = generate_fermionic_excitations(
             num_excitations, num_spin_orbitals, num_particles, beta_spin=False
@@ -158,9 +154,7 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
         (1, 6, [1, 1], [((3,), (4,)), ((3,), (5,))]),
         (2, 8, [2, 2], [((4, 5), (6, 7))]),
     )
-    def test_pure_beta_excitation(
-        self, num_excitations, num_spin_orbitals, num_particles, expect
-    ):
+    def test_pure_beta_excitation(self, num_excitations, num_spin_orbitals, num_particles, expect):
         """Test disabling alpha-spin excitations."""
         excitations = generate_fermionic_excitations(
             num_excitations, num_spin_orbitals, num_particles, alpha_spin=False

--- a/test/circuit/library/initial_states/test_vscf.py
+++ b/test/circuit/library/initial_states/test_vscf.py
@@ -27,9 +27,7 @@ class TestVSCF(QiskitNatureTestCase):
     def test_bitstring(self):
         """Test the vscf_bitstring method."""
         bitstr = vscf_bitstring([2, 2])
-        self.assertTrue(
-            all(bitstr == np.array([True, False, True, False]))
-        )  # big endian
+        self.assertTrue(all(bitstr == np.array([True, False, True, False])))  # big endian
 
     def test_qubits_4(self):
         """Test 2 modes 2 modals."""

--- a/test/drivers/fcidumpd/test_driver_fcidump.py
+++ b/test/drivers/fcidumpd/test_driver_fcidump.py
@@ -57,9 +57,7 @@ class BaseTestDriverFCIDump(ABC):
     def test_driver_inactive_energy(self):
         """driver inactive energy test"""
         self.log.debug(
-            "QMolecule inactive energy is {}".format(
-                self.qmolecule.nuclear_repulsion_energy
-            )
+            "QMolecule inactive energy is {}".format(self.qmolecule.nuclear_repulsion_energy)
         )
         self.assertAlmostEqual(
             self.qmolecule.nuclear_repulsion_energy,
@@ -70,34 +68,24 @@ class BaseTestDriverFCIDump(ABC):
     def test_driver_num_molecular_orbitals(self):
         """driver num orbitals test"""
         self.log.debug(
-            "QMolecule Number of orbitals is {}".format(
-                self.qmolecule.num_molecular_orbitals
-            )
+            "QMolecule Number of orbitals is {}".format(self.qmolecule.num_molecular_orbitals)
         )
-        self.assertEqual(
-            self.qmolecule.num_molecular_orbitals, self.num_molecular_orbitals
-        )
+        self.assertEqual(self.qmolecule.num_molecular_orbitals, self.num_molecular_orbitals)
 
     def test_driver_num_alpha(self):
         """driver num alpha test"""
-        self.log.debug(
-            "QMolecule Number of alpha electrons is {}".format(self.qmolecule.num_alpha)
-        )
+        self.log.debug("QMolecule Number of alpha electrons is {}".format(self.qmolecule.num_alpha))
         self.assertEqual(self.qmolecule.num_alpha, self.num_alpha)
 
     def test_driver_num_beta(self):
         """driver num beta test"""
-        self.log.debug(
-            "QMolecule Number of beta electrons is {}".format(self.qmolecule.num_beta)
-        )
+        self.log.debug("QMolecule Number of beta electrons is {}".format(self.qmolecule.num_beta))
         self.assertEqual(self.qmolecule.num_beta, self.num_beta)
 
     def test_driver_mo_onee_ints(self):
         """driver alpha mo onee ints test"""
         self.log.debug(
-            "QMolecule MO alpha one electron integrals are {}".format(
-                self.qmolecule.mo_onee_ints
-            )
+            "QMolecule MO alpha one electron integrals are {}".format(self.qmolecule.mo_onee_ints)
         )
         self.assertEqual(self.qmolecule.mo_onee_ints.shape, self.mo_onee.shape)
         np.testing.assert_array_almost_equal(
@@ -111,9 +99,7 @@ class BaseTestDriverFCIDump(ABC):
         if self.mo_onee_b is None:
             return
         self.log.debug(
-            "QMolecule MO beta one electron integrals are {}".format(
-                self.qmolecule.mo_onee_ints_b
-            )
+            "QMolecule MO beta one electron integrals are {}".format(self.qmolecule.mo_onee_ints_b)
         )
         self.assertEqual(self.qmolecule.mo_onee_ints_b.shape, self.mo_onee_b.shape)
         np.testing.assert_array_almost_equal(
@@ -201,18 +187,14 @@ class TestDriverFCIDumpLiH(QiskitNatureTestCase, BaseTestDriverFCIDump):
         self.num_molecular_orbitals = 6
         self.num_alpha = 2
         self.num_beta = 2
-        loaded = np.load(
-            self.get_resource_path("test_driver_fcidump_lih.npz", "drivers/fcidumpd")
-        )
+        loaded = np.load(self.get_resource_path("test_driver_fcidump_lih.npz", "drivers/fcidumpd"))
         self.mo_onee = loaded["mo_onee"]
         self.mo_onee_b = None
         self.mo_eri = loaded["mo_eri"]
         self.mo_eri_ba = None
         self.mo_eri_bb = None
         driver = FCIDumpDriver(
-            self.get_resource_path(
-                "test_driver_fcidump_lih.fcidump", "drivers/fcidumpd"
-            )
+            self.get_resource_path("test_driver_fcidump_lih.fcidump", "drivers/fcidumpd")
         )
         self.qmolecule = driver.run()
 
@@ -226,9 +208,7 @@ class TestDriverFCIDumpOH(QiskitNatureTestCase, BaseTestDriverFCIDump):
         self.num_molecular_orbitals = 6
         self.num_alpha = 5
         self.num_beta = 4
-        loaded = np.load(
-            self.get_resource_path("test_driver_fcidump_oh.npz", "drivers/fcidumpd")
-        )
+        loaded = np.load(self.get_resource_path("test_driver_fcidump_oh.npz", "drivers/fcidumpd"))
         self.mo_onee = loaded["mo_onee"]
         self.mo_onee_b = loaded["mo_onee_b"]
         self.mo_eri = loaded["mo_eri"]

--- a/test/drivers/fcidumpd/test_driver_fcidump_dumper.py
+++ b/test/drivers/fcidumpd/test_driver_fcidump_dumper.py
@@ -63,9 +63,7 @@ class BaseTestDriverFCIDumpDumper(ABC):
 
     def test_dumped_num_electrons(self):
         """dumped number of electrons test"""
-        self.log.debug(
-            "Dumped number of electrons is {:d}".format(self.dumped["NELEC"])
-        )
+        self.log.debug("Dumped number of electrons is {:d}".format(self.dumped["NELEC"]))
         self.assertEqual(self.dumped["NELEC"], self.num_electrons)
 
     def test_dumped_spin_number(self):
@@ -75,9 +73,7 @@ class BaseTestDriverFCIDumpDumper(ABC):
 
     def test_dumped_wave_function_sym(self):
         """dumped wave function symmetry test"""
-        self.log.debug(
-            "Dumped wave function symmetry is {:d}".format(self.dumped["ISYM"])
-        )
+        self.log.debug("Dumped wave function symmetry is {:d}".format(self.dumped["ISYM"]))
         self.assertEqual(self.dumped["ISYM"], self.wf_symmetry)
 
     def test_dumped_orbital_syms(self):

--- a/test/drivers/fcidumpd/test_driver_methods_fcidump.py
+++ b/test/drivers/fcidumpd/test_driver_methods_fcidump.py
@@ -27,9 +27,7 @@ class TestDriverMethodsFCIDump(TestDriverMethods):
     def test_lih(self):
         """LiH test"""
         driver = FCIDumpDriver(
-            self.get_resource_path(
-                "test_driver_fcidump_lih.fcidump", "drivers/fcidumpd"
-            )
+            self.get_resource_path("test_driver_fcidump_lih.fcidump", "drivers/fcidumpd")
         )
         result = self._run_driver(driver)
         self._assert_energy(result, "lih")
@@ -46,9 +44,7 @@ class TestDriverMethodsFCIDump(TestDriverMethods):
         """LiH freeze core test"""
         with self.assertLogs("qiskit_nature", level="WARNING") as log:
             driver = FCIDumpDriver(
-                self.get_resource_path(
-                    "test_driver_fcidump_lih.fcidump", "drivers/fcidumpd"
-                )
+                self.get_resource_path("test_driver_fcidump_lih.fcidump", "drivers/fcidumpd")
             )
             result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
             self._assert_energy(result, "lih")
@@ -62,9 +58,7 @@ class TestDriverMethodsFCIDump(TestDriverMethods):
         """OH freeze core test"""
         with self.assertLogs("qiskit_nature", level="WARNING") as log:
             driver = FCIDumpDriver(
-                self.get_resource_path(
-                    "test_driver_fcidump_oh.fcidump", "drivers/fcidumpd"
-                )
+                self.get_resource_path("test_driver_fcidump_oh.fcidump", "drivers/fcidumpd")
             )
             result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
             self._assert_energy(result, "oh")
@@ -77,9 +71,7 @@ class TestDriverMethodsFCIDump(TestDriverMethods):
     def test_lih_with_atoms(self):
         """LiH with num_atoms test"""
         driver = FCIDumpDriver(
-            self.get_resource_path(
-                "test_driver_fcidump_lih.fcidump", "drivers/fcidumpd"
-            ),
+            self.get_resource_path("test_driver_fcidump_lih.fcidump", "drivers/fcidumpd"),
             atoms=["Li", "H"],
         )
         result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
@@ -88,9 +80,7 @@ class TestDriverMethodsFCIDump(TestDriverMethods):
     def test_oh_with_atoms(self):
         """OH with num_atoms test"""
         driver = FCIDumpDriver(
-            self.get_resource_path(
-                "test_driver_fcidump_oh.fcidump", "drivers/fcidumpd"
-            ),
+            self.get_resource_path("test_driver_fcidump_oh.fcidump", "drivers/fcidumpd"),
             atoms=["O", "H"],
         )
         result = self._run_driver(driver, transformers=[FreezeCoreTransformer()])
@@ -111,9 +101,7 @@ class TestFCIDumpDriverQMolecule(QiskitNatureTestCase):
     def test_qmolecule_log_with_atoms(self):
         """Test QMolecule log function."""
         qmolecule = FCIDumpDriver(
-            self.get_resource_path(
-                "test_driver_fcidump_h2.fcidump", "drivers/fcidumpd"
-            ),
+            self.get_resource_path("test_driver_fcidump_h2.fcidump", "drivers/fcidumpd"),
             atoms=["H", "H"],
         ).run()
         with self.assertLogs("qiskit_nature", level="DEBUG") as _:

--- a/test/drivers/gaussiand/test_driver_gaussian_forces.py
+++ b/test/drivers/gaussiand/test_driver_gaussian_forces.py
@@ -71,9 +71,7 @@ class TestDriverGaussianForces(QiskitNatureTestCase):
         """Test the driver works with logfile (Gaussian does not need to be installed)"""
 
         driver = GaussianForcesDriver(
-            logfile=self.get_resource_path(
-                "test_driver_gaussian_log.txt", "drivers/gaussiand"
-            )
+            logfile=self.get_resource_path("test_driver_gaussian_log.txt", "drivers/gaussiand")
         )
 
         result = driver.run()

--- a/test/drivers/gaussiand/test_driver_gaussian_from_mat.py
+++ b/test/drivers/gaussiand/test_driver_gaussian_from_mat.py
@@ -39,9 +39,7 @@ class TestDriverGaussianFromMat(QiskitNatureTestCase, TestDriver):
         # and create a qmolecule from the saved output matrix file. This will test the
         # parsing of it into the qmolecule is correct.
         g16 = GaussianDriver()
-        matfile = self.get_resource_path(
-            "test_driver_gaussian_from_mat.mat", "drivers/gaussiand"
-        )
+        matfile = self.get_resource_path("test_driver_gaussian_from_mat.mat", "drivers/gaussiand")
         try:
             self.qmolecule = g16._parse_matrix_file(matfile)
         except QiskitNatureError:

--- a/test/drivers/gaussiand/test_driver_gaussian_log.py
+++ b/test/drivers/gaussiand/test_driver_gaussian_log.py
@@ -25,9 +25,7 @@ class TestDriverGaussianLog(QiskitNatureTestCase):
 
     def setUp(self):
         super().setUp()
-        self.logfile = self.get_resource_path(
-            "test_driver_gaussian_log.txt", "drivers/gaussiand"
-        )
+        self.logfile = self.get_resource_path("test_driver_gaussian_log.txt", "drivers/gaussiand")
 
     def test_log_driver(self):
         """Test the driver itself creates log and we can get a result"""

--- a/test/drivers/pyscfd/test_driver_methods_pyscf.py
+++ b/test/drivers/pyscfd/test_driver_methods_pyscf.py
@@ -214,9 +214,7 @@ class TestDriverMethodsPySCF(TestDriverMethods):
             basis="sto-3g",
             hf_method=HFMethodType.ROHF,
         )
-        result = self._run_driver(
-            driver, converter=QubitConverter(BravyiKitaevMapper())
-        )
+        result = self._run_driver(driver, converter=QubitConverter(BravyiKitaevMapper()))
         self._assert_energy_and_dipole(result, "oh")
 
     def test_oh_uhf_bk(self):
@@ -229,9 +227,7 @@ class TestDriverMethodsPySCF(TestDriverMethods):
             basis="sto-3g",
             hf_method=HFMethodType.UHF,
         )
-        result = self._run_driver(
-            driver, converter=QubitConverter(BravyiKitaevMapper())
-        )
+        result = self._run_driver(driver, converter=QubitConverter(BravyiKitaevMapper()))
         self._assert_energy_and_dipole(result, "oh")
 
 

--- a/test/drivers/pyscfd/test_driver_pyscf_extra.py
+++ b/test/drivers/pyscfd/test_driver_pyscf_extra.py
@@ -37,18 +37,14 @@ class TestDriverPySCFExtra(QiskitNatureTestCase):
     def test_h3(self):
         """Test for H3 chain, see also issue 1148"""
         atom = "H 0 0 0; H 0 0 1; H 0 0 2"
-        driver = PySCFDriver(
-            atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=1, basis="sto3g"
-        )
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=1, basis="sto3g")
         molecule = driver.run()
         self.assertAlmostEqual(molecule.hf_energy, -1.523996200246108, places=5)
 
     def test_h4(self):
         """Test for H4 chain"""
         atom = "H 0 0 0; H 0 0 1; H 0 0 2; H 0 0 3"
-        driver = PySCFDriver(
-            atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g"
-        )
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g")
         molecule = driver.run()
         self.assertAlmostEqual(molecule.hf_energy, -2.09854593699776, places=5)
 
@@ -60,18 +56,14 @@ class TestDriverPySCFExtra(QiskitNatureTestCase):
     def test_list_atom(self):
         """Check input with list of strings"""
         atom = ["H 0 0 0", "H 0 0 1"]
-        driver = PySCFDriver(
-            atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g"
-        )
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g")
         molecule = driver.run()
         self.assertAlmostEqual(molecule.hf_energy, -1.0661086493179366, places=5)
 
     def test_zmatrix(self):
         """Check z-matrix input"""
         atom = "H; H 1 1.0"
-        driver = PySCFDriver(
-            atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g"
-        )
+        driver = PySCFDriver(atom=atom, unit=UnitsType.ANGSTROM, charge=0, spin=0, basis="sto3g")
         molecule = driver.run()
         self.assertAlmostEqual(molecule.hf_energy, -1.0661086493179366, places=5)
 

--- a/test/drivers/test_driver.py
+++ b/test/drivers/test_driver.py
@@ -54,47 +54,35 @@ class TestDriver(ABC):
     def test_driver_nuclear_repulsion_energy(self):
         """driver nuclear repulsion energy test"""
         self.log.debug(
-            "QMolecule Nuclear repulsion energy: {}".format(
-                self.qmolecule.nuclear_repulsion_energy
-            )
+            "QMolecule Nuclear repulsion energy: {}".format(self.qmolecule.nuclear_repulsion_energy)
         )
         self.assertAlmostEqual(self.qmolecule.nuclear_repulsion_energy, 0.72, places=2)
 
     def test_driver_num_molecular_orbitals(self):
         """driver num molecular orbitals test"""
         self.log.debug(
-            "QMolecule Number of orbitals is {}".format(
-                self.qmolecule.num_molecular_orbitals
-            )
+            "QMolecule Number of orbitals is {}".format(self.qmolecule.num_molecular_orbitals)
         )
         self.assertEqual(self.qmolecule.num_molecular_orbitals, 2)
 
     def test_driver_num_alpha(self):
         """driver num alpha test"""
-        self.log.debug(
-            "QMolecule Number of alpha electrons is {}".format(self.qmolecule.num_alpha)
-        )
+        self.log.debug("QMolecule Number of alpha electrons is {}".format(self.qmolecule.num_alpha))
         self.assertEqual(self.qmolecule.num_alpha, 1)
 
     def test_driver_num_beta(self):
         """driver num beta test"""
-        self.log.debug(
-            "QMolecule Number of beta electrons is {}".format(self.qmolecule.num_beta)
-        )
+        self.log.debug("QMolecule Number of beta electrons is {}".format(self.qmolecule.num_beta))
         self.assertEqual(self.qmolecule.num_beta, 1)
 
     def test_driver_molecular_charge(self):
         """driver molecular charge test"""
-        self.log.debug(
-            "QMolecule molecular charge is {}".format(self.qmolecule.molecular_charge)
-        )
+        self.log.debug("QMolecule molecular charge is {}".format(self.qmolecule.molecular_charge))
         self.assertEqual(self.qmolecule.molecular_charge, 0)
 
     def test_driver_multiplicity(self):
         """driver multiplicity test"""
-        self.log.debug(
-            "QMolecule multiplicity is {}".format(self.qmolecule.multiplicity)
-        )
+        self.log.debug("QMolecule multiplicity is {}".format(self.qmolecule.multiplicity))
         self.assertEqual(self.qmolecule.multiplicity, 1)
 
     def test_driver_num_atoms(self):
@@ -126,18 +114,14 @@ class TestDriver(ABC):
 
     def test_driver_orbital_energies(self):
         """driver orbital energies test"""
-        self.log.debug(
-            "QMolecule orbital energies {}".format(self.qmolecule.orbital_energies)
-        )
+        self.log.debug("QMolecule orbital energies {}".format(self.qmolecule.orbital_energies))
         np.testing.assert_array_almost_equal(
             self.qmolecule.orbital_energies, [-0.5806, 0.6763], decimal=4
         )
 
     def test_driver_mo_onee_ints(self):
         """driver mo onee ints test"""
-        self.log.debug(
-            "QMolecule MO one electron integrals {}".format(self.qmolecule.mo_onee_ints)
-        )
+        self.log.debug("QMolecule MO one electron integrals {}".format(self.qmolecule.mo_onee_ints))
         self.assertEqual(self.qmolecule.mo_onee_ints.shape, (2, 2))
         np.testing.assert_array_almost_equal(
             np.absolute(self.qmolecule.mo_onee_ints),
@@ -147,9 +131,7 @@ class TestDriver(ABC):
 
     def test_driver_mo_eri_ints(self):
         """driver mo eri ints test"""
-        self.log.debug(
-            "QMolecule MO two electron integrals {}".format(self.qmolecule.mo_eri_ints)
-        )
+        self.log.debug("QMolecule MO two electron integrals {}".format(self.qmolecule.mo_eri_ints))
         self.assertEqual(self.qmolecule.mo_eri_ints.shape, (2, 2, 2, 2))
         np.testing.assert_array_almost_equal(
             np.absolute(self.qmolecule.mo_eri_ints),
@@ -163,9 +145,7 @@ class TestDriver(ABC):
     def test_driver_dipole_integrals(self):
         """driver dipole integrals test"""
         self.log.debug(
-            "QMolecule has dipole integrals {}".format(
-                self.qmolecule.has_dipole_integrals()
-            )
+            "QMolecule has dipole integrals {}".format(self.qmolecule.has_dipole_integrals())
         )
         if self.qmolecule.has_dipole_integrals():
             self.assertEqual(self.qmolecule.x_dip_mo_ints.shape, (2, 2))

--- a/test/drivers/test_driver_methods_gsc.py
+++ b/test/drivers/test_driver_methods_gsc.py
@@ -53,15 +53,11 @@ class TestDriverMethods(QiskitNatureTestCase):
         return result
 
     def _assert_energy(self, result, mol):
-        self.assertAlmostEqual(
-            self.ref_energies[mol], result.total_energies[0], places=3
-        )
+        self.assertAlmostEqual(self.ref_energies[mol], result.total_energies[0], places=3)
 
     def _assert_energy_and_dipole(self, result, mol):
         self._assert_energy(result, mol)
-        self.assertAlmostEqual(
-            self.ref_dipoles[mol], result.total_dipole_moment[0], places=3
-        )
+        self.assertAlmostEqual(self.ref_dipoles[mol], result.total_dipole_moment[0], places=3)
 
 
 if __name__ == "__main__":

--- a/test/drivers/test_driver_molecule.py
+++ b/test/drivers/test_driver_molecule.py
@@ -34,9 +34,7 @@ class TestMolecule(QiskitNatureTestCase):
                 degrees_of_freedom=[stretch],
                 masses=[1, 1],
             )
-            self.assertListEqual(
-                mol.geometry, [("H", [0.0, 0.0, 0.0]), ("H", [0.0, 0.0, 1.0])]
-            )
+            self.assertListEqual(mol.geometry, [("H", [0.0, 0.0, 0.0]), ("H", [0.0, 0.0, 1.0])])
             self.assertEqual(mol.multiplicity, 1)
             self.assertEqual(mol.charge, 0)
             self.assertIsNone(mol.perturbations)
@@ -96,9 +94,7 @@ class TestMolecule(QiskitNatureTestCase):
             self.assertListEqual(geom[1][1], [0.0, 0.0, 3.0])
 
         with self.subTest("Reduce stretch"):
-            geom = Molecule.absolute_stretching(
-                atom_pair=(1, 0), perturbation=-0.1, geometry=geom
-            )
+            geom = Molecule.absolute_stretching(atom_pair=(1, 0), perturbation=-0.1, geometry=geom)
             self.assertListEqual(geom[1][1], [0.0, 0.0, 3.0 - 0.1])
 
     def test_bend(self):
@@ -116,17 +112,11 @@ class TestMolecule(QiskitNatureTestCase):
             self.assertListEqual(geom[1][1], [0.0, 1.0, 0.0])
 
         with self.subTest("-pi/4 bend 1-0-2"):
-            geom = Molecule.absolute_bending(
-                atom_trio=(1, 0, 2), bend=-np.pi / 4, geometry=geom
-            )
-            np.testing.assert_array_almost_equal(
-                geom[1][1], [0.0, np.sqrt(2) / 2, np.sqrt(2) / 2]
-            )
+            geom = Molecule.absolute_bending(atom_trio=(1, 0, 2), bend=-np.pi / 4, geometry=geom)
+            np.testing.assert_array_almost_equal(geom[1][1], [0.0, np.sqrt(2) / 2, np.sqrt(2) / 2])
 
         with self.subTest("-pi/4 bend 2-0-1"):
-            geom = Molecule.absolute_bending(
-                atom_trio=(2, 0, 1), bend=-np.pi / 4, geometry=geom
-            )
+            geom = Molecule.absolute_bending(atom_trio=(2, 0, 1), bend=-np.pi / 4, geometry=geom)
             np.testing.assert_array_almost_equal(geom[2][1], [0.0, 0.0, -np.sqrt(2)])
 
         # Test linear case

--- a/test/mappers/second_quantization/test_linear_mapper.py
+++ b/test/mappers/second_quantization/test_linear_mapper.py
@@ -31,9 +31,9 @@ class TestLinearMapper(QiskitNatureTestCase):
     ref_qubit_op1 = (-0.054 + 0.165j) * (I ^ I) + (0.054 - 0.165j) * (Z ^ Z)
 
     spin_op2 = SpinOp([("X_0 Z_0 I_1", -1.139 + 0.083j)], 0.5, 2)
-    ref_qubit_op2 = (0.010375 + 0.142375j) * (I ^ I ^ Y ^ X) + (
-        -0.010375 - 0.142375j
-    ) * (I ^ I ^ X ^ Y)
+    ref_qubit_op2 = (0.010375 + 0.142375j) * (I ^ I ^ Y ^ X) + (-0.010375 - 0.142375j) * (
+        I ^ I ^ X ^ Y
+    )
 
     spin_op3 = SpinOp([("X_0 Y_0^2 Z_0 X_1 Y_1 Y_2 Z_2", -0.18 + 1.204j)], 0.5, 3)
     ref_qubit_op3 = (

--- a/test/nature_test_case.py
+++ b/test/nature_test_case.py
@@ -59,9 +59,8 @@ class QiskitNatureTestCase(unittest.TestCase, ABC):
         # is set.
         if os.getenv("LOG_LEVEL"):
             # Set up formatter.
-            log_fmt = (
-                "{}.%(funcName)s:%(levelname)s:%(asctime)s:"
-                " %(message)s".format(cls.__name__)
+            log_fmt = "{}.%(funcName)s:%(levelname)s:%(asctime)s:" " %(message)s".format(
+                cls.__name__
             )
             formatter = logging.Formatter(log_fmt)
 

--- a/test/operators/second_quantization/test_fermionic_op.py
+++ b/test/operators/second_quantization/test_fermionic_op.py
@@ -27,9 +27,7 @@ from .utils import str2list, str2str, str2tuple
 @lru_cache(3)
 def dense_labels(length):
     """Generate list of fermion labels with given length."""
-    return [
-        "".join(label) for label in product(["I", "+", "-", "N", "E"], repeat=length)
-    ]
+    return ["".join(label) for label in product(["I", "+", "-", "N", "E"], repeat=length)]
 
 
 @lru_cache(3)
@@ -78,9 +76,7 @@ class TestFermionicOp(QiskitNatureTestCase):
     def test_init_sparse_label(self, labels, pre_processing):
         """Test __init__ with sparse label"""
         dense_label, sparse_label = labels
-        fer_op = FermionicOp(
-            pre_processing(sparse_label), register_length=len(dense_label)
-        )
+        fer_op = FermionicOp(pre_processing(sparse_label), register_length=len(dense_label))
         targ = FermionicOp(dense_label)
         self.assertFermionEqual(fer_op, targ)
 

--- a/test/operators/second_quantization/test_qubit_converter.py
+++ b/test/operators/second_quantization/test_qubit_converter.py
@@ -76,9 +76,7 @@ class TestQubitConverter(QiskitNatureTestCase):
         + 0.18093119996471000 * (X ^ X)
     )
 
-    REF_H2_JW_TAPERED = (
-        -1.04109314222921270 * I - 0.79587484566286240 * Z + 0.18093119996470988 * X
-    )
+    REF_H2_JW_TAPERED = -1.04109314222921270 * I - 0.79587484566286240 * Z + 0.18093119996470988 * X
 
     REF_H2_PARITY_2Q_REDUCED_TAPER = (
         -1.04109314222921250 * I - 0.79587484566286300 * Z - 0.18093119996470994 * X
@@ -200,50 +198,36 @@ class TestQubitConverter(QiskitNatureTestCase):
             return z2_sector if not z2_symmetries.is_empty() else None
 
         mapper = ParityMapper()
-        qubit_conv = QubitConverter(
-            mapper, two_qubit_reduction=True, z2symmetry_reduction="auto"
-        )
-        qubit_op = qubit_conv.convert(
-            self.h2_op, self.num_particles, sector_locator=finder
-        )
+        qubit_conv = QubitConverter(mapper, two_qubit_reduction=True, z2symmetry_reduction="auto")
+        qubit_op = qubit_conv.convert(self.h2_op, self.num_particles, sector_locator=finder)
         self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER)
         self.assertEqual(qubit_conv.num_particles, self.num_particles)
         self.assertListEqual(qubit_conv.z2symmetries.tapering_values, z2_sector)
 
         with self.subTest("convert_match()"):
             qubit_op = qubit_conv.convert_match(self.h2_op)
-            self.assertEqual(
-                qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER
-            )
+            self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER)
             self.assertEqual(qubit_conv.num_particles, self.num_particles)
             self.assertListEqual(qubit_conv.z2symmetries.tapering_values, z2_sector)
 
         with self.subTest("Change setting"):
             qubit_conv.z2symmetry_reduction = [1]
             qubit_op = qubit_conv.convert(self.h2_op, self.num_particles)
-            self.assertNotEqual(
-                qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER
-            )
+            self.assertNotEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER)
             qubit_conv.z2symmetry_reduction = [-1]
             qubit_op = qubit_conv.convert(self.h2_op, self.num_particles)
-            self.assertEqual(
-                qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER
-            )
+            self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER)
 
         with self.subTest("Specify sector upfront"):
             qubit_conv = QubitConverter(
                 mapper, two_qubit_reduction=True, z2symmetry_reduction=z2_sector
             )
             qubit_op = qubit_conv.convert(self.h2_op, self.num_particles)
-            self.assertEqual(
-                qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER
-            )
+            self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED_TAPER)
 
         with self.subTest("Specify sector upfront, but invalid content"):
             with self.assertRaises(ValueError):
-                _ = QubitConverter(
-                    mapper, two_qubit_reduction=True, z2symmetry_reduction=[5]
-                )
+                _ = QubitConverter(mapper, two_qubit_reduction=True, z2symmetry_reduction=[5])
 
         with self.subTest("Specify sector upfront, but invalid length"):
             qubit_conv = QubitConverter(
@@ -261,9 +245,7 @@ class TestQubitConverter(QiskitNatureTestCase):
         problem = ElectronicStructureProblem(driver)
 
         mapper = JordanWignerMapper()
-        qubit_conv = QubitConverter(
-            mapper, two_qubit_reduction=True, z2symmetry_reduction="auto"
-        )
+        qubit_conv = QubitConverter(mapper, two_qubit_reduction=True, z2symmetry_reduction="auto")
         qubit_op = qubit_conv.convert(
             problem.second_q_ops()[0],
             self.num_particles,

--- a/test/operators/second_quantization/test_spin_op.py
+++ b/test/operators/second_quantization/test_spin_op.py
@@ -164,9 +164,7 @@ class TestSpinOp(QiskitNatureTestCase):
 
     def test_init_multiple_digits(self):
         """Test __init__ for sparse label with multiple digits"""
-        actual = SpinOp(
-            [("X_10^20", 1 + 2j), ("X_12^34", 56)], Fraction(5, 2), register_length=13
-        )
+        actual = SpinOp([("X_10^20", 1 + 2j), ("X_12^34", 56)], Fraction(5, 2), register_length=13)
         desired = [("X_10^20", 1 + 2j), ("X_12^34", 56)]
         self.assertListEqual(actual.to_list(), desired)
 
@@ -180,9 +178,7 @@ class TestSpinOp(QiskitNatureTestCase):
         """Test __init__ for +_i -_i pattern"""
         with self.subTest("one reg"):
             actual = SpinOp("+_0 -_0", spin=1, register_length=1)
-            expected = SpinOp(
-                [("X_0^2", 1), ("Y_0^2", 1), ("Z_0", 1)], spin=1, register_length=1
-            )
+            expected = SpinOp([("X_0^2", 1), ("Y_0^2", 1), ("Z_0", 1)], spin=1, register_length=1)
             self.assertSpinEqual(actual, expected)
         with self.subTest("two reg"):
             actual = SpinOp("+_1 -_1 +_0 -_0", spin=3 / 2, register_length=2)
@@ -212,26 +208,20 @@ class TestSpinOp(QiskitNatureTestCase):
     def test_mul(self):
         """Test __mul__, and __rmul__"""
         actual = self.heisenberg * 2
-        desired = SpinOp(
-            (self.heisenberg_spin_array, 2 * self.heisenberg_coeffs), spin=1
-        )
+        desired = SpinOp((self.heisenberg_spin_array, 2 * self.heisenberg_coeffs), spin=1)
         self.assertSpinEqual(actual, desired)
 
     def test_div(self):
         """Test __truediv__"""
         actual = self.heisenberg / 3
-        desired = SpinOp(
-            (self.heisenberg_spin_array, self.heisenberg_coeffs / 3), spin=1
-        )
+        desired = SpinOp((self.heisenberg_spin_array, self.heisenberg_coeffs / 3), spin=1)
         self.assertSpinEqual(actual, desired)
 
     def test_add(self):
         """Test __add__"""
         with self.subTest("sum of heisenberg"):
             actual = self.heisenberg + self.heisenberg
-            desired = SpinOp(
-                (self.heisenberg_spin_array, 2 * self.heisenberg_coeffs), spin=1
-            )
+            desired = SpinOp((self.heisenberg_spin_array, 2 * self.heisenberg_coeffs), spin=1)
             self.assertSpinEqual(actual, desired)
 
         with self.subTest("raising operator"):
@@ -310,9 +300,7 @@ class TestSpinOp(QiskitNatureTestCase):
         with self.subTest("nontrivial reduce 3"):
             test_op = SpinOp([("+_0 -_0", 1)], register_length=4)
             actual = test_op.reduce()
-            self.assertListEqual(
-                actual.to_list(), [("Z_0", 1), ("Y_0^2", 1), ("X_0^2", 1)]
-            )
+            self.assertListEqual(actual.to_list(), [("Z_0", 1), ("Y_0^2", 1), ("X_0^2", 1)])
 
     @data(*dense_labels(1))
     def test_to_matrix_single_qutrit(self, label):

--- a/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
@@ -34,9 +34,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
             "problems/second_quantization/" "electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         q_molecule = driver.run()
         fermionic_op = fermionic_op_builder._build_fermionic_op(q_molecule)
         with self.subTest("Check type of fermionic operator"):
@@ -57,9 +55,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
             "problems/second_quantization/" "electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         q_molecule = driver.run()
         fermionic_op = fermionic_op_builder.build_ferm_op_from_ints(
             q_molecule.one_body_integrals, q_molecule.two_body_integrals
@@ -84,13 +80,9 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
 
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         q_molecule = driver.run()
-        fermionic_op = fermionic_op_builder.build_ferm_op_from_ints(
-            q_molecule.one_body_integrals
-        )
+        fermionic_op = fermionic_op_builder.build_ferm_op_from_ints(q_molecule.one_body_integrals)
 
         with self.subTest("Check type of fermionic operator"):
             assert isinstance(fermionic_op, FermionicOp)

--- a/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
@@ -31,7 +31,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
         expected_num_of_terms_ferm_op = 184
         expected_fermionic_op_path = self.get_resource_path(
             "H2_631g_ferm_op_two_ints",
-            "problems/second_quantization/" "electronic/resources",
+            "problems/second_quantization/electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
         driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
@@ -52,7 +52,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
         expected_num_of_terms_ferm_op = 184
         expected_fermionic_op_path = self.get_resource_path(
             "H2_631g_ferm_op_two_ints",
-            "problems/second_quantization/" "electronic/resources",
+            "problems/second_quantization/electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
         driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
@@ -76,7 +76,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
         expected_num_of_terms_ferm_op = 16
         expected_fermionic_op_path = self.get_resource_path(
             "H2_631g_ferm_op_one_int",
-            "problems/second_quantization/" "electronic/resources",
+            "problems/second_quantization/electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
 

--- a/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
@@ -195,7 +195,5 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
             },
         )
 
-        hopping_operators = _build_qeom_hopping_ops(
-            self.q_molecule, self.qubit_converter
-        )
+        hopping_operators = _build_qeom_hopping_ops(self.q_molecule, self.qubit_converter)
         self.assertEqual(hopping_operators, expected_hopping_operators)

--- a/test/problems/second_quantization/electronic/resources/resource_reader.py
+++ b/test/problems/second_quantization/electronic/resources/resource_reader.py
@@ -19,7 +19,5 @@ def read_expected_file(path: str) -> List[Tuple[Union[str, float], ...]]:
     """Reads and parses resource file."""
     types = str, float
     with open(path, "r") as file:
-        expected_fermionic_op = [
-            tuple(t(e) for t, e in zip(types, line.split())) for line in file
-        ]
+        expected_fermionic_op = [tuple(t(e) for t, e in zip(types, line.split())) for line in file]
     return expected_fermionic_op

--- a/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
+++ b/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
@@ -32,7 +32,7 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
         expected_num_of_sec_quant_ops = 7
         expected_fermionic_op_path = self.get_resource_path(
             "H2_631g_ferm_op_two_ints",
-            "problems/second_quantization/" "electronic/resources",
+            "problems/second_quantization/electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
 
@@ -58,7 +58,7 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
         expected_num_of_sec_quant_ops = 7
         expected_fermionic_op_path = self.get_resource_path(
             "H2_631g_ferm_op_active_space",
-            "problems/second_quantization/" "electronic/resources",
+            "problems/second_quantization/electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
         driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))

--- a/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
+++ b/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
@@ -36,16 +36,12 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
 
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         electronic_structure_problem = ElectronicStructureProblem(driver)
 
         second_quantized_ops = electronic_structure_problem.second_q_ops()
         electr_sec_quant_op = second_quantized_ops[0]
-        with self.subTest(
-            "Check expected length of the list of second quantized operators."
-        ):
+        with self.subTest("Check expected length of the list of second quantized operators."):
             assert len(second_quantized_ops) == expected_num_of_sec_quant_ops
         with self.subTest("Check types in the list of second quantized operators."):
             for second_quantized_op in second_quantized_ops:
@@ -65,18 +61,14 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
             "problems/second_quantization/" "electronic/resources",
         )
         expected_fermionic_op = read_expected_file(expected_fermionic_op_path)
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         trafo = ActiveSpaceTransformer(num_electrons=2, num_molecular_orbitals=2)
 
         electronic_structure_problem = ElectronicStructureProblem(driver, [trafo])
         second_quantized_ops = electronic_structure_problem.second_q_ops()
         electr_sec_quant_op = second_quantized_ops[0]
 
-        with self.subTest(
-            "Check expected length of the list of second quantized operators."
-        ):
+        with self.subTest("Check expected length of the list of second quantized operators."):
             assert len(second_quantized_ops) == expected_num_of_sec_quant_ops
         with self.subTest("Check types in the list of second quantized operators."):
             for second_quantized_op in second_quantized_ops:

--- a/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
@@ -194,7 +194,5 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
             },
         )
 
-        hopping_operators = _build_qeom_hopping_ops(
-            self.num_modals, self.qubit_converter
-        )
+        hopping_operators = _build_qeom_hopping_ops(self.num_modals, self.qubit_converter)
         self.assertEqual(hopping_operators, expected_hopping_operators)

--- a/test/problems/second_quantization/vibrational/builders/test_vibrational_op_builder.py
+++ b/test/problems/second_quantization/vibrational/builders/test_vibrational_op_builder.py
@@ -41,9 +41,7 @@ class TestVibrationalOpBuilder(QiskitNatureTestCase):
         num_modals = 2
         truncation_order = 3
 
-        vibrational_op = _build_vibrational_op(
-            watson_hamiltonian, num_modals, truncation_order
-        )
+        vibrational_op = _build_vibrational_op(watson_hamiltonian, num_modals, truncation_order)
 
         assert isinstance(vibrational_op, VibrationalOp)
         labels, coeffs = zip(*vibrational_op.to_list())

--- a/test/problems/second_quantization/vibrational/test_vibrational_problem.py
+++ b/test/problems/second_quantization/vibrational/test_vibrational_problem.py
@@ -35,14 +35,10 @@ class TestVibrationalProblem(QiskitNatureTestCase):
         truncation_order = 3
         num_modes = watson_hamiltonian.num_modes
         num_modals = [num_modals] * num_modes
-        vibrational_problem = VibrationalStructureProblem(
-            driver, num_modals, truncation_order
-        )
+        vibrational_problem = VibrationalStructureProblem(driver, num_modals, truncation_order)
         second_quantized_ops = vibrational_problem.second_q_ops()
         vibrational_op = second_quantized_ops[0]
-        with self.subTest(
-            "Check expected length of the list of second quantized operators."
-        ):
+        with self.subTest("Check expected length of the list of second quantized operators."):
             assert len(second_quantized_ops) == expected_num_of_sec_quant_ops
         with self.subTest("Check types in the list of second quantized operators."):
             assert isinstance(vibrational_op, VibrationalOp)

--- a/test/test_end2end_with_vqe.py
+++ b/test/test_end2end_with_vqe.py
@@ -58,9 +58,7 @@ class TestEnd2End(QiskitNatureTestCase):
         ryrz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
         quantum_instance = QuantumInstance(backend, shots=shots)
         vqe = VQE(ryrz, optimizer=optimizer, quantum_instance=quantum_instance)
-        result = vqe.compute_minimum_eigenvalue(
-            self.qubit_op, aux_operators=self.aux_ops
-        )
+        result = vqe.compute_minimum_eigenvalue(self.qubit_op, aux_operators=self.aux_ops)
         self.assertAlmostEqual(result.eigenvalue.real, self.reference_energy, places=4)
 
 

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -42,9 +42,7 @@ class TestReadmeSample(QiskitNatureTestCase):
 
             _ = Aer.get_backend("statevector_simulator")
         except ImportError as ex:  # pylint: disable=broad-except
-            self.skipTest(
-                "Aer doesn't appear to be installed. Error: '{}'".format(str(ex))
-            )
+            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
 
     def test_readme_sample(self):

--- a/test/transformers/test_active_space_transformer.py
+++ b/test/transformers/test_active_space_transformer.py
@@ -31,13 +31,9 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
     def assertQMolecule(self, q_molecule, expected, dict_key="ActiveSpaceTransformer"):
         """Asserts that the two `QMolecule object's relevant fields are equivalent."""
         with self.subTest("MO 1-electron integrals"):
-            np.testing.assert_array_almost_equal(
-                q_molecule.mo_onee_ints, expected.mo_onee_ints
-            )
+            np.testing.assert_array_almost_equal(q_molecule.mo_onee_ints, expected.mo_onee_ints)
         with self.subTest("MO 2-electron integrals"):
-            np.testing.assert_array_almost_equal(
-                q_molecule.mo_eri_ints, expected.mo_eri_ints
-            )
+            np.testing.assert_array_almost_equal(q_molecule.mo_eri_ints, expected.mo_eri_ints)
         with self.subTest("Inactive energy"):
             self.assertAlmostEqual(
                 q_molecule.energy_shift[dict_key],
@@ -45,27 +41,21 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
             )
 
         with self.subTest("MO 1-electron x dipole integrals"):
-            np.testing.assert_array_almost_equal(
-                q_molecule.x_dip_mo_ints, expected.x_dip_mo_ints
-            )
+            np.testing.assert_array_almost_equal(q_molecule.x_dip_mo_ints, expected.x_dip_mo_ints)
         with self.subTest("X dipole energy shift"):
             self.assertAlmostEqual(
                 q_molecule.x_dip_energy_shift[dict_key],
                 expected.x_dip_energy_shift["ActiveSpaceTransformer"],
             )
         with self.subTest("MO 1-electron y dipole integrals"):
-            np.testing.assert_array_almost_equal(
-                q_molecule.y_dip_mo_ints, expected.y_dip_mo_ints
-            )
+            np.testing.assert_array_almost_equal(q_molecule.y_dip_mo_ints, expected.y_dip_mo_ints)
         with self.subTest("Y dipole energy shift"):
             self.assertAlmostEqual(
                 q_molecule.y_dip_energy_shift[dict_key],
                 expected.y_dip_energy_shift["ActiveSpaceTransformer"],
             )
         with self.subTest("MO 1-electron z dipole integrals"):
-            np.testing.assert_array_almost_equal(
-                q_molecule.z_dip_mo_ints, expected.z_dip_mo_ints
-            )
+            np.testing.assert_array_almost_equal(q_molecule.z_dip_mo_ints, expected.z_dip_mo_ints)
         with self.subTest("Z dipole energy shift"):
             self.assertAlmostEqual(
                 q_molecule.z_dip_energy_shift[dict_key],
@@ -79,9 +69,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
     )
     def test_full_active_space(self, kwargs):
         """Test that transformer has no effect when all orbitals are active."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         q_molecule.energy_shift["ActiveSpaceTransformer"] = 0.0
@@ -96,9 +84,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
     def test_minimal_active_space(self):
         """Test a minimal active space manually."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         trafo = ActiveSpaceTransformer(num_electrons=2, num_molecular_orbitals=2)
@@ -121,9 +107,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
         expected.x_dip_mo_ints = np.zeros((2, 2))
         expected.y_dip_mo_ints = np.zeros((2, 2))
-        expected.z_dip_mo_ints = np.asarray(
-            [[0.69447435, -1.01418298], [-1.01418298, 0.69447435]]
-        )
+        expected.z_dip_mo_ints = np.asarray([[0.69447435, -1.01418298], [-1.01418298, 0.69447435]])
 
         expected.energy_shift["ActiveSpaceTransformer"] = 0.0
         expected.x_dip_energy_shift["ActiveSpaceTransformer"] = 0.0
@@ -134,9 +118,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
     def test_unpaired_electron_active_space(self):
         """Test an active space with an unpaired electron."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("BeH_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("BeH_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         trafo = ActiveSpaceTransformer(num_electrons=(2, 1), num_molecular_orbitals=3)
@@ -150,9 +132,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
     def test_arbitrary_active_orbitals(self):
         """Test manual selection of active orbital indices."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_631g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         trafo = ActiveSpaceTransformer(
@@ -161,9 +141,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         q_molecule_reduced = trafo.transform(q_molecule)
 
         expected = QMolecule()
-        expected.mo_onee_ints = np.asarray(
-            [[-1.24943841, -0.16790838], [-0.16790838, -0.18307469]]
-        )
+        expected.mo_onee_ints = np.asarray([[-1.24943841, -0.16790838], [-0.16790838, -0.18307469]])
         expected.mo_eri_ints = np.asarray(
             [
                 [
@@ -198,13 +176,9 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         ]
     )
     @unpack
-    def test_error_raising(
-        self, num_electrons, num_molecular_orbitals, active_orbitals, message
-    ):
+    def test_error_raising(self, num_electrons, num_molecular_orbitals, active_orbitals, message):
         """Test errors are being raised in certain scenarios."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         with self.assertRaises(QiskitNatureError, msg=message):
@@ -216,9 +190,7 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
     def test_active_space_for_q_molecule_v2(self):
         """Test based on QMolecule v2 (mo_occ not available)."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_sto3g_v2.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_sto3g_v2.hdf5", "transformers"))
         q_molecule = driver.run()
 
         q_molecule.energy_shift["ActiveSpaceTransformer"] = 0.0

--- a/test/transformers/test_freeze_core_transformer.py
+++ b/test/transformers/test_freeze_core_transformer.py
@@ -33,9 +33,7 @@ class TestFreezeCoreTransformer(TestActiveSpaceTransformer):
     )
     def test_full_active_space(self, kwargs):
         """Test that transformer has no effect when all orbitals are active."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("H2_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         # The references which we compare too were produced by the `ActiveSpaceTransformer` and,
@@ -48,15 +46,11 @@ class TestFreezeCoreTransformer(TestActiveSpaceTransformer):
         trafo = FreezeCoreTransformer(**kwargs)
         q_molecule_reduced = trafo.transform(q_molecule)
 
-        self.assertQMolecule(
-            q_molecule_reduced, q_molecule, dict_key="FreezeCoreTransformer"
-        )
+        self.assertQMolecule(q_molecule_reduced, q_molecule, dict_key="FreezeCoreTransformer")
 
     def test_freeze_core(self):
         """Test the `freeze_core` convenience argument."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("LiH_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("LiH_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         trafo = FreezeCoreTransformer(freeze_core=True)
@@ -66,15 +60,11 @@ class TestFreezeCoreTransformer(TestActiveSpaceTransformer):
             hdf5_input=self.get_resource_path("LiH_sto3g_reduced.hdf5", "transformers")
         ).run()
 
-        self.assertQMolecule(
-            q_molecule_reduced, expected, dict_key="FreezeCoreTransformer"
-        )
+        self.assertQMolecule(q_molecule_reduced, expected, dict_key="FreezeCoreTransformer")
 
     def test_freeze_core_with_remove_orbitals(self):
         """Test the `freeze_core` convenience argument in combination with `remove_orbitals`."""
-        driver = HDF5Driver(
-            hdf5_input=self.get_resource_path("BeH_sto3g.hdf5", "transformers")
-        )
+        driver = HDF5Driver(hdf5_input=self.get_resource_path("BeH_sto3g.hdf5", "transformers"))
         q_molecule = driver.run()
 
         trafo = FreezeCoreTransformer(freeze_core=True, remove_orbitals=[4, 5])
@@ -84,9 +74,7 @@ class TestFreezeCoreTransformer(TestActiveSpaceTransformer):
             hdf5_input=self.get_resource_path("BeH_sto3g_reduced.hdf5", "transformers")
         ).run()
 
-        self.assertQMolecule(
-            q_molecule_reduced, expected, dict_key="FreezeCoreTransformer"
-        )
+        self.assertQMolecule(q_molecule_reduced, expected, dict_key="FreezeCoreTransformer")
 
 
 if __name__ == "__main__":

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -32,9 +32,7 @@ class CopyrightChecker:
 
     @staticmethod
     def _exception_to_string(excp: Exception) -> str:
-        stack = traceback.extract_stack()[:-3] + traceback.extract_tb(
-            excp.__traceback__
-        )
+        stack = traceback.extract_stack()[:-3] + traceback.extract_tb(excp.__traceback__)
         pretty = traceback.format_list(stack)
         return "".join(pretty) + "\n  {} {}".format(excp.__class__, excp)
 
@@ -53,9 +51,7 @@ class CopyrightChecker:
         year = CopyrightChecker._get_year_from_date(out_str)
         return year, err_str
 
-    def _process_file_last_year(
-        self, relative_path: str
-    ) -> Tuple[int, Union[None, str]]:
+    def _process_file_last_year(self, relative_path: str) -> Tuple[int, Union[None, str]]:
         # construct minimal environment
         env = {}
         for k in ["SYSTEMROOT", "PATH"]:
@@ -195,9 +191,7 @@ def check_path(path):
 
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser(description="Nature Check Copyright Tool")
-    PARSER.add_argument(
-        "-path", type=check_path, metavar="path", help="Root path of project."
-    )
+    PARSER.add_argument("-path", type=check_path, metavar="path", help="Root path of project.")
 
     ARGS = PARSER.parse_args()
     if not ARGS.path:
@@ -206,10 +200,6 @@ if __name__ == "__main__":
     ARGS.path = os.path.abspath(os.path.realpath(os.path.expanduser(ARGS.path)))
     INVALID_UTF8, INVALID_YEAR, HAS_HEADER = CopyrightChecker(ARGS.path).check()
     print("{} files have utf8 headers.".format(INVALID_UTF8))
-    print(
-        "{} of {} files with copyright header have wrong years.".format(
-            INVALID_YEAR, HAS_HEADER
-        )
-    )
+    print("{} of {} files with copyright header have wrong years.".format(INVALID_YEAR, HAS_HEADER))
 
     sys.exit(os.EX_OK if INVALID_UTF8 == 0 and INVALID_YEAR == 0 else os.EX_SOFTWARE)

--- a/tools/extract_deprecation.py
+++ b/tools/extract_deprecation.py
@@ -82,9 +82,7 @@ def _check_file(path) -> str:
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Qiskit Extract Deprecation Messages Tool"
-    )
+    PARSER = argparse.ArgumentParser(description="Qiskit Extract Deprecation Messages Tool")
     PARSER.add_argument(
         "-file", type=_check_file, required=True, metavar="file", help="Input file."
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds the missing `pyproject.toml` file.

### Details and comments

The reason for many of the "odd" reformattings part of #171 is the missing configuration file.
Most notable, the missing settings for the line-length! `black` defaults to a line-length of 88 which obviously caused many changes in our code-base (which uses a line-length of 100).
