### PR TITLE
Insert actual path to source when generating docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,15 +23,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 """
 Sphinx documentation builder
 """
 
-import os
 import qiskit_sphinx_theme
 import qiskit_nature
 # Set env flag so that we can doc functions that may otherwise not be loaded


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This inserts the actual path to the `qiskit_nature` source at the beginning of `sys.path`.
This is a common configuration to do in Sphinx setups as can be seen by the fact that the code was basically just uncommented and the path fixed for our case.

### Details and comments

The reason why I would like to apply this change is the following: I am trying out a new workflow involving [git worktrees](https://git-scm.com/docs/git-worktree).
**Disclaimer:** this change does *NOT* affect the common workflow!

In my usecase I have a project structure like the following:
```
qiskit-nature/
    COMMIT_EDITMSG
    FETCH_HEAD
    HEAD
    ORIG_HEAD
    branches
    config
    description
    feature/
        <feature branch worktrees>
    hooks
    index
    info
    logs
    main/ <main branch worktree>
    objects
    packed-refs
    refs
    worktrees
```
As you can see, this means I have a bare clone of the qiskit-nature repo with different worktrees for the branches I am currently working on. This is very useful because it allows rapid switching between multiple branches without having to stash or commit all my WIP changes all the time.
It also essentially allows me to have multiple versions of qiskit-nature installed at the same time, because I can create virtual environments which derive of the main one.

To be more concrete, my main virtual environment contains an editable install pointing to `.../qiskit-nature/main`.
In my feature branches I then have virtual environments which derive of the main one and only update the editable install path of Qiskit Nature to `../qiskit-nature/feature/some_branch`.
In this way I never have to reinstall everything and can simply source the environment of the feature which I want to test.

Now with all that said, sphinx is the only problem because its path is the following **prior** to my change (please excuse the absolute paths):
```
['/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```
After my change, it looks like the following (when in `qiskit-nature/main`):
```
['/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```
and like the following in one of the feature worktrees:
```
['/home/oss/Files/Qiskit/src/qiskit-nature/feature/sphinx-conf-upgrade', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```

With the first path pointing to the actual source I am interested in, the docs get generated correctly and not always for the "installed" source.