### PR TITLE
Fix to random unit test method failure

### DIFF
--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -339,7 +339,6 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         result = gsc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(result.total_energies[0], self.reference_energy, places=6)
 
-    @slow_test
     def test_uccsd_hf_aer_qasm(self):
         """uccsd hf test with Aer qasm simulator."""
         try:
@@ -357,7 +356,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         solver = VQE(
             ansatz=ansatz,
             optimizer=optimizer,
-            expectation=PauliExpectation(),
+            expectation=PauliExpectation(group_paulis=False),
             quantum_instance=QuantumInstance(
                 backend=backend,
                 seed_simulator=algorithm_globals.random_seed,
@@ -368,7 +367,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
 
         result = gsc.solve(self.electronic_structure_problem)
-        self.assertAlmostEqual(result.total_energies[0], -1.138, places=2)
+        self.assertAlmostEqual(result.total_energies[0], -1.131, places=2)
 
     @slow_test
     def test_uccsd_hf_aer_qasm_snapshot(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Removed the slow_test decorator for now so we are 100% sure it won't happen again.


### Details and comments
I fixed the code by choosing combination `Aer+PauliExpectation(group_paulis=False)` however there is some random problem happening with  `Aer+PauliExpectation(group_paulis=True)/AbelianGrouper`. Limiting Aer/Terra to single thread doesn’t solve. Trying to change to networkx in AbelianGrouper is not evident as there are methods that only exist in retworkx. I created a simple script that can be run locally with the following results:
```
Aer: aer_simulator (
 PauliExpectation(group_paulis=True) -- Reference energy: -1.1330296151782657
    Test: 1 Energy: -1.1385301420812395 Diff: -0.005500526902973757 ------> Failed
    Test: 2 Energy: -1.1330296151782657 Diff: 0.0 ------> Success
    Test: 3 Energy: -1.1330296151782657 Diff: 0.0 ------> Success
    Test: 4 Energy: -1.1330296151782653 Diff: 4.440892098500626e-16 ------> Success
    Test: 5 Energy: -1.1330296151782653 Diff: 4.440892098500626e-16 ------> Success
    Test: 6 Energy: -1.1332106501265757 Diff: -0.00018103494831001044 ------> Success
    Test: 7 Energy: -1.1332106501265757 Diff: -0.00018103494831001044 ------> Success
    Test: 8 Energy: -1.1332106501265757 Diff: -0.00018103494831001044 ------> Success
    Test: 9 Energy: -1.1330296151782653 Diff: 4.440892098500626e-16 ------> Success
    Test: 10 Energy: -1.1332106501265757 Diff: -0.00018103494831001044 ------> Success
    Test: 11 Energy: -1.1330296151782653 Diff: 4.440892098500626e-16 ------> Success
    Test: 12 Energy: -1.1330296151782657 Diff: 0.0 ------> Success
    Test: 13 Energy: -1.1330296151782653 Diff: 4.440892098500626e-16 ------> Success
    Test: 14 Energy: -1.1330296151782657 Diff: 0.0 ------> Success
    Test: 15 Energy: -1.1385301420812395 Diff: -0.005500526902973757 ------> Failed

 PauliExpectation(group_paulis=False) -- Reference energy: -1.1314599754596433
    Test: 1 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 2 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 3 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 4 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 5 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 6 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 7 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 8 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 9 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 10 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 11 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 12 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 13 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 14 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
    Test: 15 Energy: -1.1314599754596433 Diff: 0.0 ------> Success
)
BasicAer: qasm_simulator (
 PauliExpectation(group_paulis=True) -- Reference energy: -1.140442111571582
    Test: 1 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 2 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 3 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 4 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 5 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 6 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 7 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 8 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 9 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 10 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 11 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 12 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 13 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 14 Energy: -1.140442111571582 Diff: 0.0 ------> Success
    Test: 15 Energy: -1.140442111571582 Diff: 0.0 ------> Success

 PauliExpectation(group_paulis=False) -- Reference energy: -1.140442111571582
    Test: 1 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 2 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 3 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 4 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 5 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 6 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 7 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 8 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 9 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 10 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 11 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 12 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 13 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 14 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
    Test: 15 Energy: -1.1404421115715828 Diff: -8.881784197001252e-16 ------> Success
)
```
Aer+PauliExpectation(group_paulis=True)  fails randomly. All other combinations work. The script used to print those results is:
```
""" uccsd_hf_qasm """

import math

from qiskit import BasicAer, Aer
from qiskit.algorithms import VQE
from qiskit.algorithms.optimizers import SPSA
from qiskit.opflow import PauliExpectation
from qiskit.utils import QuantumInstance, algorithm_globals

from qiskit_nature.algorithms import GroundStateEigensolver
from qiskit_nature.circuit.library import HartreeFock, UCCSD
from qiskit_nature.drivers import PySCFDriver, UnitsType
from qiskit_nature.mappers.second_quantization import JordanWignerMapper
from qiskit_nature.converters.second_quantization import QubitConverter
from qiskit_nature.problems.second_quantization import ElectronicStructureProblem


def uccsd_hf_qasm():
    """uccsd hf with qasm simulator."""

    num_spin_orbitals = 4
    num_particles = (1, 1)

    repetitions = 15
    backends = [
        ("aer_simulator", [(True, -1.1330296151782657), (False, -1.1319118924271379)]),
        ("qasm_simulator", [(True, -1.140442111571582), (False, -1.140442111571582)]),
    ]

    print("\n")
    for backend_name, expectations in backends:
        backend_simulator = "Aer" if backend_name == "aer_simulator" else "BasicAer"
        print(f"{backend_simulator}: {backend_name} (")
        for expectation in expectations:
            group_paulis = expectation[0]
            reference_energy = expectation[1]
            print(f" PauliExpectation(group_paulis={group_paulis}) -- Reference energy: {reference_energy}")
            for test_number in range(repetitions):
                algorithm_globals.random_seed = 56
                backend = (
                    Aer.get_backend(backend_name)
                    if backend_name == "aer_simulator"
                    else BasicAer.get_backend(backend_name)
                )
                expectation = PauliExpectation(group_paulis=group_paulis)
                qubit_converter = QubitConverter(JordanWignerMapper())
                ansatz = UCCSD(
                    qubit_converter,
                    num_particles,
                    num_spin_orbitals,
                    initial_state=HartreeFock(num_spin_orbitals, num_particles, qubit_converter),
                )
                optimizer = SPSA(maxiter=200, last_avg=5)
                solver = VQE(
                    ansatz=ansatz,
                    optimizer=optimizer,
                    expectation=expectation,
                    quantum_instance=QuantumInstance(
                        backend=backend,
                        seed_simulator=algorithm_globals.random_seed,
                        seed_transpiler=algorithm_globals.random_seed,
                    ),
                )
                driver = PySCFDriver(
                    atom="H .0 .0 .0; H .0 .0 0.735", unit=UnitsType.ANGSTROM, basis="sto3g"
                )
                gsc = GroundStateEigensolver(qubit_converter, solver)
                electronic_structure_problem = ElectronicStructureProblem(driver)
                result = gsc.solve(electronic_structure_problem)
                are_close = math.isclose(result.total_energies[0], reference_energy, abs_tol=0.001)
                status = "Success" if are_close else "Failed"
                print(
                    f"    Test: {test_number+1} "
                    f"Energy: {result.total_energies[0]} "
                    f"Diff: {result.total_energies[0] - reference_energy}"
                    f" ------> {status}"
                )
            print("\n")
        print(")\n")


if __name__ == "__main__":
    uccsd_hf_qasm()
```


