### PR TITLE
Fix docs for Sphinx 4

### DIFF
--- a/qiskit_nature/algorithms/__init__.py
+++ b/qiskit_nature/algorithms/__init__.py
@@ -91,7 +91,7 @@ Algorithms that can compute potential energy surfaces.
    :toctree: ../stubs/
    :nosignatures:
 
-   BOPESSampler
+   ~pes_samplers.BOPESSampler
 
 The samplers include extrapolators to facilitate convergence across a set of points and support
 of various potentials. More detail may be found in the sub-module linked below

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
 reno>=3.2.0
-Sphinx>=1.8.3,!=3.1.0,<4
+Sphinx>=1.8.3,!=3.1.0
 sphinx-panels
 sphinx-gallery
 sphinx-autodoc-typehints


### PR DESCRIPTION
As we allow `BopesSampler` to be imported from `algorithms` or from `pes_samplers` under algorithms, I found a way to leave it in both places. (The tutorial imports it from pes_samplers - tests import from algorithms which is often where we roll these up to). It being in pes_samplers has it with the other related code API refs, in algorithms its in with the rest of the algorithms where we allow it to be imported (and other algorithms) without needing to know/include in the import any sub-folder(s) where the code may actually be.

Fixes #188