### PR TITLE
Pin H5Py

### DIFF
--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -433,8 +433,8 @@ class QEOM(ExcitedStatesSolver):
             2-D array storing the X and Y expansion coefficients
         """
         logger.debug("Diagonalizing qeom matrices for excited states...")
-        a_mat = np.bmat([[m_mat, q_mat], [q_mat.T.conj(), m_mat.T.conj()]])
-        b_mat = np.bmat([[v_mat, w_mat], [-w_mat.T.conj(), -v_mat.T.conj()]])
+        a_mat = np.bmat([[m_mat, q_mat], [q_mat.T.conj(), m_mat.T.conj()]])  # type: ignore
+        b_mat = np.bmat([[v_mat, w_mat], [-w_mat.T.conj(), -v_mat.T.conj()]])  # type: ignore
         # pylint: disable=too-many-function-args
         res = linalg.eig(a_mat, b_mat)
         # convert nan value into 0

--- a/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
@@ -165,7 +165,7 @@ class HarmonicBasis(BosonicBasis):
 
         for entry in self._watson.data:  # Entry is coeff (float) followed by indices (ints)
             coeff0 = cast(float, entry[0])
-            indices = cast(List[int], entry[1:])
+            indices = np.asarray(entry[1:], dtype=int)
 
             kinetic_term = False
 

--- a/qiskit_nature/drivers/second_quantization/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/second_quantization/bosonic_bases/harmonic_basis.py
@@ -157,7 +157,7 @@ class HarmonicBasis(BosonicBasis):
 
         for entry in self._watson.data:  # Entry is coeff (float) followed by indices (ints)
             coeff0 = cast(float, entry[0])
-            indices = cast(List[int], entry[1:])
+            indices = np.asarray(entry[1:], dtype=int)
 
             kinetic_term = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy>=1.17
 psutil>=5
 scikit-learn>=0.20.0
 setuptools>=40.1.0
-h5py
+h5py<3.3


### PR DESCRIPTION
### Summary

H5Py v3.3.0 finally removed support for the deprecated default file
modes. Unfortunately, PySCF has not yet put out a release respecting
this change. In the meantime, we can pin H5Py below 3.3 to ensure our
development can continue until PySCF catches up.
