### PR TITLE
Improve Windows compatibility (pathlib) for psi4

### DIFF
--- a/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
@@ -121,7 +121,7 @@ class PSI4Driver(FermionicDriver):
 
         input_text = cfg + "\n"
         input_text += "import sys\n"
-        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','" 
+        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','"
         syspath += "','".join(p.replace("\\", "/") for p in sys.path) + "']"
 
         input_text += "sys.path = " + syspath + " + sys.path\n"

--- a/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
@@ -121,12 +121,17 @@ class PSI4Driver(FermionicDriver):
 
         input_text = cfg + "\n"
         input_text += "import sys\n"
-        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','"
-        syspath += "','".join(p.replace("\\", "/") for p in sys.path) + "']"
+        syspath = (
+            "['"
+            + qiskit_nature_directory.as_posix()
+            + "','"
+            + "','".join(Path(p).as_posix() for p in sys.path)
+            + "']"
+        )
 
         input_text += "sys.path = " + syspath + " + sys.path\n"
-        input_text += "from qiskit_nature.drivers.second_quantization.qmolecule import QMolecule\n"
-        input_text += '_q_molecule = QMolecule("{0}")\n'.format(molecule.filename.replace("\\", "/"))
+        input_text += "from qiskit_nature.drivers.qmolecule import QMolecule\n"
+        input_text += '_q_molecule = QMolecule("{0}")\n'.format(Path(molecule.filename).as_posix())
 
         with open(template_file, "r") as file:
             input_text += file.read()

--- a/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from shutil import which
 from typing import Union, List, Optional
 
@@ -112,19 +113,19 @@ class PSI4Driver(FermionicDriver):
         else:
             cfg = self._config
 
-        psi4d_directory = os.path.dirname(os.path.realpath(__file__))
-        template_file = psi4d_directory + "/_template.txt"
-        qiskit_nature_directory = os.path.abspath(os.path.join(psi4d_directory, "../.."))
+        psi4d_directory = Path(__file__).resolve().parent
+        template_file = psi4d_directory.joinpath("_template.txt")
+        qiskit_nature_directory = psi4d_directory.parent.parent
 
         molecule = QMolecule()
 
         input_text = cfg + "\n"
         input_text += "import sys\n"
-        syspath = "['" + qiskit_nature_directory + "','" + "','".join(sys.path) + "']"
+        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','" + "','".join(p.replace("\\", "/") for p in sys.path) + "']"
 
         input_text += "sys.path = " + syspath + " + sys.path\n"
         input_text += "from qiskit_nature.drivers.second_quantization.qmolecule import QMolecule\n"
-        input_text += '_q_molecule = QMolecule("{0}")\n'.format(molecule.filename)
+        input_text += '_q_molecule = QMolecule("{0}")\n'.format(molecule.filename.replace("\\", "/"))
 
         with open(template_file, "r") as file:
             input_text += file.read()

--- a/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
@@ -130,7 +130,7 @@ class PSI4Driver(FermionicDriver):
         )
 
         input_text += "sys.path = " + syspath + " + sys.path\n"
-        input_text += "from qiskit_nature.drivers.qmolecule import QMolecule\n"
+        input_text += "from qiskit_nature.drivers.second_quantization.qmolecule import QMolecule\n"
         input_text += '_q_molecule = QMolecule("{0}")\n'.format(Path(molecule.filename).as_posix())
 
         with open(template_file, "r") as file:

--- a/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
+++ b/qiskit_nature/drivers/second_quantization/psi4d/psi4driver.py
@@ -121,7 +121,8 @@ class PSI4Driver(FermionicDriver):
 
         input_text = cfg + "\n"
         input_text += "import sys\n"
-        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','" + "','".join(p.replace("\\", "/") for p in sys.path) + "']"
+        syspath = "['" + str(qiskit_nature_directory).replace("\\", "/") + "','" 
+        syspath += "','".join(p.replace("\\", "/") for p in sys.path) + "']"
 
         input_text += "sys.path = " + syspath + " + sys.path\n"
         input_text += "from qiskit_nature.drivers.second_quantization.qmolecule import QMolecule\n"


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #260

Due to difficulties with backslashes in Windows path strings psi4 raised an Unicode Error, which is fixed by this approach. 

### Details and comments

The bug with the backslashes was fixed via replacing all backslashes in Windows path strings by forward slashes.
psi4, to which the string is sent for execution, can handle the forward slashes in Windows paths. So, compatibility for both Unix and Windows paths is ensured.
Switching to pathlib objects wasn't directly necessary to fix this bug, but makes things more consistent and easier for future Windows/Unix path issues.