### PR TITLE
Correct spelling of Boltzmann

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -22,7 +22,6 @@ bergholm
 berlin
 bitstring
 bohr
-boltzman
 boltzmann
 bool
 boolean

--- a/docs/tutorials/06_calculating_thermodynamic_observables.ipynb
+++ b/docs/tutorials/06_calculating_thermodynamic_observables.ipynb
@@ -373,7 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now plot the constant volume heat capacity (of the rotational part) demonstrating how we can call directly the functions in the 'thermodynamics' module, providing a callable object for the partition function (or in this case its rotational component). Note that in the plot we normalize the plot dividing by the universal gas constant R (Avogadro's number times Boltzman's constant) and we use crossed to compare with experimental data found in literature."
+    "We will now plot the constant volume heat capacity (of the rotational part) demonstrating how we can call directly the functions in the 'thermodynamics' module, providing a callable object for the partition function (or in this case its rotational component). Note that in the plot we normalize the plot dividing by the universal gas constant R (Avogadro's number times Boltzmann's constant) and we use crossed to compare with experimental data found in literature."
    ]
   },
   {


### PR DESCRIPTION
"Boltzmann" is misspelled in a tutorial.
