### PR TITLE
Add link to repo tutorial on html tutorial prolog

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,17 +63,18 @@ rst_prolog = """
 nbsphinx_prolog = """
 {% set docname = env.doc2path(env.docname, base=None) %}
 .. only:: html
-
+    
     .. role:: raw-html(raw)
         :format: html
-
-    .. raw:: html
-
-        <br><br><br>
-
+    
     .. note::
-        Run interactively in jupyter notebook.
-"""
+        This page was generated from `docs/{{ docname }}`__.
+        
+        __"""
+
+vers = version.split(".")
+link_str = f" https://github.com/Qiskit/qiskit-nature/blob/stable/{vers[0]}.{vers[1]}/docs/"
+nbsphinx_prolog += link_str + "{{ docname }}"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
When building the tutorial html, create a prolog with the link back to the tutorial in github.
This link will always point to the stable branch so if building from the main branch, the link will be broken.
That should not be a problem as we always upload docs from stable.


### Details and comments


