### PR TITLE
Fixes issue #159

### DIFF
--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -229,8 +229,6 @@ class QEOM(ExcitedStatesSolver):
                     all_matrix_operators["v_{}_{}".format(m_u, n_u)] = v_mat_op
 
         try:
-            # The next step only works in the case of the FermionicTransformation. Thus, it is done
-            # in a try-except block. However, mypy doesn't detect this and thus we ignore it.
             z2_symmetries = self._gsc.qubit_converter.z2symmetries  # type: ignore
         except AttributeError:
             z2_symmetries = Z2Symmetries([], [], [])

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/minimum_eigensolver_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/minimum_eigensolver_factory.py
@@ -35,8 +35,7 @@ class MinimumEigensolverFactory(ABC):
                              according to a mapper it is initialized with.
 
         Returns:
-            A minimum eigensolver suitable to compute the ground state of the molecule transformed
-            by ``transformation``.
+            A minimum eigensolver suitable to compute the ground state of the molecule.
         """
         raise NotImplementedError
 

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/numpy_minimum_eigensolver_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/numpy_minimum_eigensolver_factory.py
@@ -75,15 +75,14 @@ class NumPyMinimumEigensolverFactory(MinimumEigensolverFactory):
         self, problem: BaseProblem, qubit_converter: QubitConverter
     ) -> MinimumEigensolver:
         """Returns a NumPyMinimumEigensolver which possibly uses the default filter criterion
-        provided by the ``transformation``.
+        provided by the ``problem``.
 
         Args:
             problem: a class encoding a problem to be solved.
             qubit_converter: a class that converts second quantized operator to qubit operator
                              according to a mapper it is initialized with.
         Returns:
-            A NumPyMinimumEigensolver suitable to compute the ground state of the molecule
-            transformed by ``transformation``.
+            A NumPyMinimumEigensolver suitable to compute the ground state of the molecule.
         """
         filter_criterion = self._filter_criterion
         if not filter_criterion and self._use_default_filter_criterion:

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
@@ -178,8 +178,7 @@ class VQEUCCFactory(MinimumEigensolverFactory):
         problem: ElectronicStructureProblem,
         qubit_converter: QubitConverter,
     ) -> MinimumEigensolver:
-        """Returns a VQE with a UCCSD wavefunction ansatz, based on ``transformation``.
-        This works only with a ``FermionicTransformation``.
+        """Returns a VQE with a UCCSD wavefunction ansatz, based on ``qubit_converter``.
 
         Args:
             problem: a class encoding a problem to be solved.
@@ -187,8 +186,7 @@ class VQEUCCFactory(MinimumEigensolverFactory):
                              according to a mapper it is initialized with.
 
         Returns:
-            A VQE suitable to compute the ground state of the molecule transformed
-            by ``transformation``.
+            A VQE suitable to compute the ground state of the molecule.
         """
         driver_result = problem.properties_transformed
         particle_number = cast(ParticleNumber, driver_result.get_property(ParticleNumber))

--- a/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
@@ -178,8 +178,7 @@ class VQEUVCCFactory(MinimumEigensolverFactory):
         problem: VibrationalStructureProblem,
         qubit_converter: QubitConverter,
     ) -> MinimumEigensolver:
-        """Returns a VQE with a UVCCSD wavefunction ansatz, based on ``transformation``.
-        This works only with a ``BosonicTransformation``.
+        """Returns a VQE with a UVCCSD wavefunction ansatz, based on ``qubit_converter``.
 
         Args:
             problem: a class encoding a problem to be solved.
@@ -187,8 +186,7 @@ class VQEUVCCFactory(MinimumEigensolverFactory):
                              according to a mapper it is initialized with.
 
         Returns:
-            A VQE suitable to compute the ground state of the molecule transformed
-            by ``transformation``.
+            A VQE suitable to compute the ground state of the molecule.
         """
 
         basis = cast(VibrationalStructureDriverResult, problem.properties_transformed).basis


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes #159 (edited so that github will auto-link/close the issue)

### Details and comments

References to the old `FermionicTransformer` and `BosonicTransformer` were deleted in the docs of `vqe_ucc_factory.py` and `vqe_ucc_factory.py`.
Further, two more references to the old transformers in `numpy_mimimum_eigensolver_factory.py` and `mimimum_eigensolver_factory.py` were adapted.

