### PR TITLE
Resolve CI deprecation messages

### DIFF
--- a/qiskit_nature/mappers/second_quantization/bksf.py
+++ b/qiskit_nature/mappers/second_quantization/bksf.py
@@ -217,7 +217,7 @@ def _coulomb_exchange(  # pylint: disable=invalid-name
     b_p = _edge_operator_bi(edge_list, p)
     b_q = _edge_operator_bi(edge_list, q)
     id_op = _pauli_id(edge_list.shape[1])
-    qubit_op = (id_op - b_p) * (id_op - b_q)
+    qubit_op = (id_op - b_p).dot((id_op - b_q))
     if p == s:  # two commutations to order as two number operators.
         final_coeff = 0.25
     else:  # one commutation
@@ -276,15 +276,18 @@ def _double_excitation(  # pylint: disable=invalid-name
     a_rs = -a_rs if s < r else a_rs
 
     id_op = _pauli_id(edge_list.shape[1])
-    qubit_op = (a_pq * a_rs) * (
-        -id_op
-        - b_p * b_q
-        + b_p * b_r
-        + b_p * b_s
-        + b_q * b_r
-        + b_q * b_s
-        - b_r * b_s
-        + b_p * b_q * b_r * b_s  ## Agrees with SW2018 eq 37 and OpenFermion. Aqua had `-`.
+    qubit_op = (a_pq.dot(a_rs)).dot(
+        (
+            -id_op
+            - b_p.dot(b_q)
+            + b_p.dot(b_r)
+            + b_p.dot(b_s)
+            + b_q.dot(b_r)
+            + b_q.dot(b_s)
+            - b_r.dot(b_s)
+            # Agrees with SW2018 eq 37 and OpenFermion. Aqua had `-`.
+            + b_p.dot(b_q.dot(b_r.dot(b_s)))
+        )
     )
     final_coeff = 0.125
     return (final_coeff * h2_pqrs) * qubit_op

--- a/test/circuit/library/ansatzes/test_evolved_op_ansatz.py
+++ b/test/circuit/library/ansatzes/test_evolved_op_ansatz.py
@@ -12,6 +12,7 @@
 
 """Test the evolved operator ansatz."""
 
+import warnings
 from test import QiskitNatureTestCase
 
 from qiskit.circuit import QuantumCircuit
@@ -30,7 +31,9 @@ class TestEvolvedOperatorAnsatz(QiskitNatureTestCase):
         ops = [Z ^ num_qubits, Y ^ num_qubits, X ^ num_qubits]
         strings = ["z" * num_qubits, "y" * num_qubits, "x" * num_qubits] * 2
 
-        evo = EvolvedOperatorAnsatz(ops, 2)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            evo = EvolvedOperatorAnsatz(ops, 2)
         evo._build()  # fixed by speedup parameter binds PR
 
         reference = QuantumCircuit(num_qubits)
@@ -45,7 +48,9 @@ class TestEvolvedOperatorAnsatz(QiskitNatureTestCase):
 
         op = X ^ I ^ Z
         matrix = op.to_matrix()
-        evo = EvolvedOperatorAnsatz(op, evolution=MatrixEvolution())
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            evo = EvolvedOperatorAnsatz(op, evolution=MatrixEvolution())
         evo._build()
 
         parameters = evo.parameters
@@ -58,7 +63,9 @@ class TestEvolvedOperatorAnsatz(QiskitNatureTestCase):
         """Test rebuilding after the operators changed."""
 
         ops = [X, Y, Z]
-        evo = EvolvedOperatorAnsatz(ops)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            evo = EvolvedOperatorAnsatz(ops)
         evo.operators = [X, Y]
         evo._build()
 
@@ -77,7 +84,9 @@ class TestEvolvedOperatorAnsatz(QiskitNatureTestCase):
 
     def test_insert_barriers(self):
         """Test using insert_barriers."""
-        evo = EvolvedOperatorAnsatz(Z, reps=4, insert_barriers=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            evo = EvolvedOperatorAnsatz(Z, reps=4, insert_barriers=True)
         evo._build()
         ref = QuantumCircuit(1)
         for parameter in evo.parameters:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The CI gathers all deprecation warnings. Besides those triggered by external libraries, there should be none.
This PR resolves all deprecation messages.

### Details and comments

Based on [this scheduled CI run](https://github.com/Qiskit/qiskit-nature/runs/3336248034?check_suite_focus=true), I resolved the warnings raised by BKSF (resolves #320) and from testing the deprecated `EvolvedOpAnsatz`.
The warnings raised from using `QMolecule` and `WatsonHamiltonian` as part of `test_second_quantized_property.py` get removed as part of #303.
