### PR TITLE
`VQEProgram` should state it supports aux ops

### DIFF
--- a/qiskit_nature/runtime/vqe_program.py
+++ b/qiskit_nature/runtime/vqe_program.py
@@ -107,7 +107,8 @@ class VQEProgram(MinimumEigensolver):
         """Return the program ID."""
         return self._program_id
 
-    def supports_aux_operators(self) -> bool:
+    @classmethod
+    def supports_aux_operators(cls) -> bool:
         return True
 
     @property

--- a/qiskit_nature/runtime/vqe_program.py
+++ b/qiskit_nature/runtime/vqe_program.py
@@ -107,6 +107,9 @@ class VQEProgram(MinimumEigensolver):
         """Return the program ID."""
         return self._program_id
 
+    def supports_aux_operators(self) -> bool:
+        return True
+
     @property
     def ansatz(self) -> QuantumCircuit:
         """Return the ansatz."""

--- a/releasenotes/notes/vqeprogram-aux-operators-9db380d8e20b1f1d.yaml
+++ b/releasenotes/notes/vqeprogram-aux-operators-9db380d8e20b1f1d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The :class:`~qiskit_nature.runtime.VQEProgram` does support the evaluation of auxiliary 
+    operators at the final state, but the 
+    :meth:`qiskit_nature.runtime.VQEProgram.supports_aux_operators` method previously returned 
+    `False` instead of `True`.

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -106,5 +106,6 @@ class TestUCCSD(QiskitNatureTestCase):
             num_particles=num_particles,
             num_spin_orbitals=num_spin_orbitals,
         )
+        print(ansatz.draw())
 
         assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -106,6 +106,5 @@ class TestUCCSD(QiskitNatureTestCase):
             num_particles=num_particles,
             num_spin_orbitals=num_spin_orbitals,
         )
-        print(ansatz.draw())
 
         assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/runtime/test_vqeprogram.py
+++ b/test/runtime/test_vqeprogram.py
@@ -40,6 +40,7 @@ class TestVQEProgram(QiskitNatureTestCase):
         self.provider = FakeRuntimeProvider()
 
     def get_standard_program(self):
+        """Get a standard VQEProgram and operator to find the ground state of."""
         circuit = RealAmplitudes(3)
         operator = Z ^ I ^ Z
         initial_point = np.random.random(circuit.num_parameters)

--- a/test/runtime/test_vqeprogram.py
+++ b/test/runtime/test_vqeprogram.py
@@ -23,6 +23,9 @@ from qiskit.algorithms.optimizers import SPSA
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.opflow import I, Z
 
+from qiskit_nature.algorithms.ground_state_solvers import GroundStateEigensolver
+from qiskit_nature.converters.second_quantization import QubitConverter
+from qiskit_nature.mappers.second_quantization import JordanWignerMapper
 from qiskit_nature.runtime import VQEProgram
 
 from .fake_vqeruntime import FakeRuntimeProvider
@@ -36,9 +39,7 @@ class TestVQEProgram(QiskitNatureTestCase):
         super().setUp()
         self.provider = FakeRuntimeProvider()
 
-    @data({"name": "SPSA", "maxiter": 100}, SPSA(maxiter=100))
-    def test_standard_case(self, optimizer):
-        """Test a standard use case."""
+    def get_standard_program(self):
         circuit = RealAmplitudes(3)
         operator = Z ^ I ^ Z
         initial_point = np.random.random(circuit.num_parameters)
@@ -46,14 +47,33 @@ class TestVQEProgram(QiskitNatureTestCase):
 
         vqe = VQEProgram(
             ansatz=circuit,
-            optimizer=optimizer,
+            optimizer=SPSA(),
             initial_point=initial_point,
             backend=backend,
             provider=self.provider,
         )
+        return vqe, operator
+
+    @data({"name": "SPSA", "maxiter": 100}, SPSA(maxiter=100))
+    def test_standard_case(self, optimizer):
+        """Test a standard use case."""
+        vqe, operator = self.get_standard_program()
+        vqe.optimizer = optimizer
         result = vqe.compute_minimum_eigenvalue(operator)
 
         self.assertIsInstance(result, VQEResult)
+
+    def test_supports_aux_ops(self):
+        """Test the VQEProgram says it supports aux operators."""
+        vqe, _ = self.get_standard_program()
+        self.assertTrue(vqe.supports_aux_operators)
+
+    def test_return_groundstate(self):
+        """Test the VQEProgram yields a ground state solver that returns the ground state."""
+        vqe, _ = self.get_standard_program()
+        qubit_converter = QubitConverter(JordanWignerMapper())
+        gss = GroundStateEigensolver(qubit_converter, vqe)
+        self.assertTrue(gss.returns_groundstate)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `VQEProgram` does support the evaluation of auxiliary operators at the final state, but the 
`supports_aux_operators` method previously returned `False` instead of `True`.

### Details and comments

Also refactored the tests minimally to avoid code duplication.

