### PR TITLE
Fix FermionicOp Warning msg format

### DIFF
--- a/qiskit_nature/operators/second_quantization/fermionic_op.py
+++ b/qiskit_nature/operators/second_quantization/fermionic_op.py
@@ -250,8 +250,8 @@ class FermionicOp(SecondQuantizedOp):
             if FermionicOp._display_format_warn:
                 FermionicOp._display_format_warn = False
                 warnings.warn(
-                    "The default value for `display_format` will be changed from 'dense'"
-                    "to 'sparse' in version 0.3.0. Once that happens, you must specify"
+                    "The default value for `display_format` will be changed from 'dense' "
+                    "to 'sparse' in version 0.3.0. Once that happens, you must specify "
                     "display_format='dense' directly.",
                     stacklevel=2,
                 )


### PR DESCRIPTION
Strings in a warning message that was added were missing blank spaces (I put at end of lines) so words like 'dense' and to, specify and display_format have space between them when the strings are concatenated - below is how it is prior to the spaces being added.

> The default value for `display_format` will be changed from 'dense'to 'sparse' in version 0.3.0. Once that happens, you must specifydisplay_format='dense' directly.
