### PR TITLE
Fix #343

### DIFF
--- a/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
@@ -13,7 +13,6 @@
 """The Bravyi-Kitaev Mapper."""
 
 import numpy as np
-
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators import Pauli
 
@@ -154,5 +153,11 @@ class BravyiKitaevMapper(FermionicMapper):  # pylint: disable=missing-class-docs
                     remainder_pauli[j] & y_j & update_pauli[j],
                 )
             )
+
+        # PauliList has the phase information unlike deprecated PauliTable.
+        # Here, phase is unnecessary, so the following removes phase.
+        for pauli1, pauli2 in pauli_table:
+            pauli1.phase = 0
+            pauli2.phase = 0
 
         return QubitMapper.mode_based_mapping(second_q_op, pauli_table)

--- a/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
@@ -12,14 +12,14 @@
 
 """Tests Hopping Operators builder."""
 from test import QiskitNatureTestCase, requires_extra_library
+
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import SparsePauliOp
 from qiskit.utils import algorithm_globals
 
+from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.drivers import UnitsType
 from qiskit_nature.drivers.second_quantization import PySCFDriver
 from qiskit_nature.mappers.second_quantization import JordanWignerMapper
-from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.problems.second_quantization import ElectronicStructureProblem
 from qiskit_nature.problems.second_quantization.electronic.builders.hopping_ops_builder import (
     _build_qeom_hopping_ops,
@@ -55,135 +55,57 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         # TODO extract it somewhere
         expected_hopping_operators = (
             {
-                "E_0": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, False, False, False, False, False, False],
-                            [True, True, False, False, False, True, False, False],
-                            [True, True, False, False, True, False, False, False],
-                            [True, True, False, False, True, True, False, False],
-                        ],
-                        coeffs=[1.0 + 0.0j, 0.0 - 1.0j, 0.0 + 1.0j, 1.0 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "E_0": PauliSumOp.from_list(
+                    [("IIXX", 1), ("IIYX", -1j), ("IIXY", 1j), ("IIYY", 1)]
                 ),
-                "Edag_0": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, False, False, False, False, False, False],
-                            [True, True, False, False, False, True, False, False],
-                            [True, True, False, False, True, False, False, False],
-                            [True, True, False, False, True, True, False, False],
-                        ],
-                        coeffs=[-1.0 + 0.0j, 0.0 - 1.0j, 0.0 + 1.0j, -1.0 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "Edag_0": PauliSumOp.from_list(
+                    [("IIXX", -1), ("IIYX", -1j), ("IIXY", 1j), ("IIYY", -1)]
                 ),
-                "E_1": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [False, False, True, True, False, False, False, False],
-                            [False, False, True, True, False, False, False, True],
-                            [False, False, True, True, False, False, True, False],
-                            [False, False, True, True, False, False, True, True],
-                        ],
-                        coeffs=[1.0 + 0.0j, 0.0 - 1.0j, 0.0 + 1.0j, 1.0 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "E_1": PauliSumOp.from_list(
+                    [("XXII", 1), ("YXII", -1j), ("XYII", 1j), ("YYII", 1)]
                 ),
-                "Edag_1": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [False, False, True, True, False, False, False, False],
-                            [False, False, True, True, False, False, False, True],
-                            [False, False, True, True, False, False, True, False],
-                            [False, False, True, True, False, False, True, True],
-                        ],
-                        coeffs=[-1.0 + 0.0j, 0.0 - 1.0j, 0.0 + 1.0j, -1.0 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "Edag_1": PauliSumOp.from_list(
+                    [("XXII", -1), ("YXII", -1j), ("XYII", 1j), ("YYII", -1)]
                 ),
-                "E_2": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, True, True, False, False, False, False],
-                            [True, True, True, True, False, False, False, True],
-                            [True, True, True, True, False, False, True, False],
-                            [True, True, True, True, False, False, True, True],
-                            [True, True, True, True, False, True, False, False],
-                            [True, True, True, True, False, True, False, True],
-                            [True, True, True, True, False, True, True, False],
-                            [True, True, True, True, False, True, True, True],
-                            [True, True, True, True, True, False, False, False],
-                            [True, True, True, True, True, False, False, True],
-                            [True, True, True, True, True, False, True, False],
-                            [True, True, True, True, True, False, True, True],
-                            [True, True, True, True, True, True, False, False],
-                            [True, True, True, True, True, True, False, True],
-                            [True, True, True, True, True, True, True, False],
-                            [True, True, True, True, True, True, True, True],
-                        ],
-                        coeffs=[
-                            1.0 + 0.0j,
-                            0.0 - 1.0j,
-                            0.0 + 1.0j,
-                            1.0 + 0.0j,
-                            0.0 - 1.0j,
-                            -1.0 + 0.0j,
-                            1.0 + 0.0j,
-                            0.0 - 1.0j,
-                            0.0 + 1.0j,
-                            1.0 + 0.0j,
-                            -1.0 + 0.0j,
-                            0.0 + 1.0j,
-                            1.0 + 0.0j,
-                            0.0 - 1.0j,
-                            0.0 + 1.0j,
-                            1.0 + 0.0j,
-                        ],
-                    ),
-                    coeff=1.0,
+                "E_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 1),
+                        ("YXXX", -1j),
+                        ("XYXX", 1j),
+                        ("YYXX", 1),
+                        ("XXYX", -1j),
+                        ("YXYX", -1),
+                        ("XYYX", 1),
+                        ("YYYX", -1j),
+                        ("XXXY", 1j),
+                        ("YXXY", 1),
+                        ("XYXY", -1),
+                        ("YYXY", 1j),
+                        ("XXYY", 1),
+                        ("YXYY", -1j),
+                        ("XYYY", 1j),
+                        ("YYYY", 1),
+                    ]
                 ),
-                "Edag_2": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, True, True, False, False, False, False],
-                            [True, True, True, True, False, False, False, True],
-                            [True, True, True, True, False, False, True, False],
-                            [True, True, True, True, False, False, True, True],
-                            [True, True, True, True, False, True, False, False],
-                            [True, True, True, True, False, True, False, True],
-                            [True, True, True, True, False, True, True, False],
-                            [True, True, True, True, False, True, True, True],
-                            [True, True, True, True, True, False, False, False],
-                            [True, True, True, True, True, False, False, True],
-                            [True, True, True, True, True, False, True, False],
-                            [True, True, True, True, True, False, True, True],
-                            [True, True, True, True, True, True, False, False],
-                            [True, True, True, True, True, True, False, True],
-                            [True, True, True, True, True, True, True, False],
-                            [True, True, True, True, True, True, True, True],
-                        ],
-                        coeffs=[
-                            1.0 + 0.0j,
-                            0.0 + 1.0j,
-                            0.0 - 1.0j,
-                            1.0 + 0.0j,
-                            0.0 + 1.0j,
-                            -1.0 + 0.0j,
-                            1.0 + 0.0j,
-                            0.0 + 1.0j,
-                            0.0 - 1.0j,
-                            1.0 + 0.0j,
-                            -1.0 + 0.0j,
-                            0.0 - 1.0j,
-                            1.0 + 0.0j,
-                            0.0 + 1.0j,
-                            0.0 - 1.0j,
-                            1.0 + 0.0j,
-                        ],
-                    ),
-                    coeff=1.0,
+                "Edag_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 1),
+                        ("YXXX", 1j),
+                        ("XYXX", -1j),
+                        ("YYXX", 1),
+                        ("XXYX", 1j),
+                        ("YXYX", -1),
+                        ("XYYX", 1),
+                        ("YYYX", 1j),
+                        ("XXXY", -1j),
+                        ("YXXY", 1),
+                        ("XYXY", -1),
+                        ("YYXY", -1j),
+                        ("XXYY", 1),
+                        ("YXYY", 1j),
+                        ("XYYY", -1j),
+                        ("YYYY", 1),
+                    ]
                 ),
             },
             {"E_0": [], "Edag_0": [], "E_1": [], "Edag_1": [], "E_2": [], "Edag_2": []},

--- a/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
@@ -12,15 +12,13 @@
 
 """Tests Hopping Operators builder."""
 from test import QiskitNatureTestCase
-from test.algorithms.excited_state_solvers.test_bosonic_esc_calculation import (
-    _DummyBosonicDriver,
-)
+from test.algorithms.excited_state_solvers.test_bosonic_esc_calculation import _DummyBosonicDriver
+
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import SparsePauliOp
 from qiskit.utils import algorithm_globals
 
-from qiskit_nature.mappers.second_quantization import DirectMapper
 from qiskit_nature.converters.second_quantization import QubitConverter
+from qiskit_nature.mappers.second_quantization import DirectMapper
 from qiskit_nature.problems.second_quantization import VibrationalStructureProblem
 from qiskit_nature.problems.second_quantization.vibrational.builders.hopping_ops_builder import (
     _build_qeom_hopping_ops,
@@ -52,135 +50,57 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         # TODO extract it somewhere
         expected_hopping_operators = (
             {
-                "E_0": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, False, False, False, False, False, False],
-                            [True, True, False, False, False, True, False, False],
-                            [True, True, False, False, True, False, False, False],
-                            [True, True, False, False, True, True, False, False],
-                        ],
-                        coeffs=[0.25 + 0.0j, 0.0 - 0.25j, 0.0 + 0.25j, 0.25 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "E_0": PauliSumOp.from_list(
+                    [("IIXX", 0.25), ("IIYX", -0.25j), ("IIXY", 0.25j), ("IIYY", 0.25)]
                 ),
-                "Edag_0": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, False, False, False, False, False, False],
-                            [True, True, False, False, False, True, False, False],
-                            [True, True, False, False, True, False, False, False],
-                            [True, True, False, False, True, True, False, False],
-                        ],
-                        coeffs=[0.25 + 0.0j, 0.0 + 0.25j, 0.0 - 0.25j, 0.25 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "Edag_0": PauliSumOp.from_list(
+                    [("IIXX", 0.25), ("IIYX", 0.25j), ("IIXY", -0.25j), ("IIYY", 0.25)]
                 ),
-                "E_1": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [False, False, True, True, False, False, False, False],
-                            [False, False, True, True, False, False, False, True],
-                            [False, False, True, True, False, False, True, False],
-                            [False, False, True, True, False, False, True, True],
-                        ],
-                        coeffs=[0.25 + 0.0j, 0.0 - 0.25j, 0.0 + 0.25j, 0.25 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "E_1": PauliSumOp.from_list(
+                    [("XXII", 0.25), ("YXII", -0.25j), ("XYII", 0.25j), ("YYII", 0.25)]
                 ),
-                "Edag_1": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [False, False, True, True, False, False, False, False],
-                            [False, False, True, True, False, False, False, True],
-                            [False, False, True, True, False, False, True, False],
-                            [False, False, True, True, False, False, True, True],
-                        ],
-                        coeffs=[0.25 + 0.0j, 0.0 + 0.25j, 0.0 - 0.25j, 0.25 + 0.0j],
-                    ),
-                    coeff=1.0,
+                "Edag_1": PauliSumOp.from_list(
+                    [("XXII", 0.25), ("YXII", 0.25j), ("XYII", -0.25j), ("YYII", 0.25)]
                 ),
-                "E_2": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, True, True, False, False, False, False],
-                            [True, True, True, True, False, False, False, True],
-                            [True, True, True, True, False, False, True, False],
-                            [True, True, True, True, False, False, True, True],
-                            [True, True, True, True, False, True, False, False],
-                            [True, True, True, True, False, True, False, True],
-                            [True, True, True, True, False, True, True, False],
-                            [True, True, True, True, False, True, True, True],
-                            [True, True, True, True, True, False, False, False],
-                            [True, True, True, True, True, False, False, True],
-                            [True, True, True, True, True, False, True, False],
-                            [True, True, True, True, True, False, True, True],
-                            [True, True, True, True, True, True, False, False],
-                            [True, True, True, True, True, True, False, True],
-                            [True, True, True, True, True, True, True, False],
-                            [True, True, True, True, True, True, True, True],
-                        ],
-                        coeffs=[
-                            0.0625 + 0.0j,
-                            0.0 - 0.0625j,
-                            0.0 + 0.0625j,
-                            0.0625 + 0.0j,
-                            0.0 - 0.0625j,
-                            -0.0625 + 0.0j,
-                            0.0625 + 0.0j,
-                            0.0 - 0.0625j,
-                            0.0 + 0.0625j,
-                            0.0625 + 0.0j,
-                            -0.0625 + 0.0j,
-                            0.0 + 0.0625j,
-                            0.0625 + 0.0j,
-                            0.0 - 0.0625j,
-                            0.0 + 0.0625j,
-                            0.0625 + 0.0j,
-                        ],
-                    ),
-                    coeff=1.0,
+                "E_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 0.0625),
+                        ("YXXX", -0.0625j),
+                        ("XYXX", 0.0625j),
+                        ("YYXX", 0.0625),
+                        ("XXYX", -0.0625j),
+                        ("YXYX", -0.0625),
+                        ("XYYX", 0.0625),
+                        ("YYYX", -0.0625j),
+                        ("XXXY", 0.0625j),
+                        ("YXXY", 0.0625),
+                        ("XYXY", -0.0625),
+                        ("YYXY", 0.0625j),
+                        ("XXYY", 0.0625),
+                        ("YXYY", -0.0625j),
+                        ("XYYY", 0.0625j),
+                        ("YYYY", 0.0625),
+                    ]
                 ),
-                "Edag_2": PauliSumOp(
-                    SparsePauliOp(
-                        [
-                            [True, True, True, True, False, False, False, False],
-                            [True, True, True, True, False, False, False, True],
-                            [True, True, True, True, False, False, True, False],
-                            [True, True, True, True, False, False, True, True],
-                            [True, True, True, True, False, True, False, False],
-                            [True, True, True, True, False, True, False, True],
-                            [True, True, True, True, False, True, True, False],
-                            [True, True, True, True, False, True, True, True],
-                            [True, True, True, True, True, False, False, False],
-                            [True, True, True, True, True, False, False, True],
-                            [True, True, True, True, True, False, True, False],
-                            [True, True, True, True, True, False, True, True],
-                            [True, True, True, True, True, True, False, False],
-                            [True, True, True, True, True, True, False, True],
-                            [True, True, True, True, True, True, True, False],
-                            [True, True, True, True, True, True, True, True],
-                        ],
-                        coeffs=[
-                            0.0625 + 0.0j,
-                            0.0 + 0.0625j,
-                            0.0 - 0.0625j,
-                            0.0625 + 0.0j,
-                            0.0 + 0.0625j,
-                            -0.0625 + 0.0j,
-                            0.0625 + 0.0j,
-                            0.0 + 0.0625j,
-                            0.0 - 0.0625j,
-                            0.0625 + 0.0j,
-                            -0.0625 + 0.0j,
-                            0.0 - 0.0625j,
-                            0.0625 + 0.0j,
-                            0.0 + 0.0625j,
-                            0.0 - 0.0625j,
-                            0.0625 + 0.0j,
-                        ],
-                    ),
-                    coeff=1.0,
+                "Edag_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 0.0625),
+                        ("YXXX", 0.0625j),
+                        ("XYXX", -0.0625j),
+                        ("YYXX", 0.0625),
+                        ("XXYX", 0.0625j),
+                        ("YXYX", -0.0625),
+                        ("XYYX", 0.0625),
+                        ("YYYX", 0.0625j),
+                        ("XXXY", -0.0625j),
+                        ("YXXY", 0.0625),
+                        ("XYXY", -0.0625),
+                        ("YYXY", -0.0625j),
+                        ("XXYY", 0.0625),
+                        ("YXYY", 0.0625j),
+                        ("XYYY", -0.0625j),
+                        ("YYYY", 0.0625),
+                    ]
                 ),
             },
             {},


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #343.

### Details and comments

There are two reasons: first, SparsePauliOp had been constructed by the way not officially supported (i.e. `SparsePauliOp(boolean array)` is not supported and `SparsePauliOp(PauliTable(boolean array ))` is correct). The second is that I modified the bug https://github.com/Qiskit/qiskit-terra/issues/6815, but originally nature use a specification where this phase was ignored.
