### PR TITLE
Fix #345

### DIFF
--- a/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
@@ -83,6 +83,10 @@ class ElectronicStructureProblem(BaseProblem):
                 )
 
             else:
+                if not self.transformers:
+                    # if no transformers are supplied, we can still provide
+                    # `molecule_data_transformed` as a copy of `molecule_data`
+                    self._molecule_data_transformed = self._molecule_data
                 self._grouped_property_transformed = self._transform(self._grouped_property)
 
         else:

--- a/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
+++ b/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
@@ -144,8 +144,8 @@ class TestElectronicStructureProblemLegacyDrivers(QiskitNatureTestCase):
                 warnings.filterwarnings("ignore", category=DeprecationWarning)
                 # legacy driver used, molecule_data should not be None
                 self.assertIsNotNone(electronic_structure_problem.molecule_data)
-                # no transformer used, molecule_data_transformed should be None
-                self.assertIsNone(electronic_structure_problem.molecule_data_transformed)
+                # no transformer used, molecule_data_transformed should be set to molecule_data
+                self.assertIsNotNone(electronic_structure_problem.molecule_data_transformed)
             # converted properties should never be None
             self.assertIsNotNone(electronic_structure_problem.grouped_property)
             self.assertIsNotNone(electronic_structure_problem.grouped_property_transformed)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If not transformers are supplied, we can provide `molecular_data_transformed` even in the non-legacy case because it is simply a copy of `molecular_data`.

Closes #345
