### PR TITLE
Duck-type VQE interim results

### DIFF
--- a/qiskit_nature/runtime/vqe_program.py
+++ b/qiskit_nature/runtime/vqe_program.py
@@ -209,15 +209,16 @@ class VQEProgram(MinimumEigensolver):
     def _wrap_vqe_callback(self) -> Optional[Callable]:
         """Wraps and returns the given callback to match the signature of the runtime callback."""
 
-        def wrapped_callback(*args):
+        def wrapped_callback(*args) -> None:
             _, data = args  # first element is the job id
             if isinstance(data, dict):
-                return # not expected params. skip
+                return  # not expected params. skip
             iteration_count = data[0]
             params = data[1]
             mean = data[2]
             sigma = data[3]
-            return self._callback(iteration_count, params, mean, sigma)
+            self._callback(iteration_count, params, mean, sigma)
+            return
 
         # if callback is set, return wrapped callback, else return None
         if self._callback:

--- a/qiskit_nature/runtime/vqe_program.py
+++ b/qiskit_nature/runtime/vqe_program.py
@@ -211,6 +211,8 @@ class VQEProgram(MinimumEigensolver):
 
         def wrapped_callback(*args):
             _, data = args  # first element is the job id
+            if isinstance(data, dict):
+                return # not expected params. skip
             iteration_count = data[0]
             params = data[1]
             mean = data[2]

--- a/qiskit_nature/runtime/vqe_program.py
+++ b/qiskit_nature/runtime/vqe_program.py
@@ -197,16 +197,16 @@ class VQEProgram(MinimumEigensolver):
         self._store_intermediate = store
 
     @property
-    def callback(self) -> Callable:
+    def callback(self) -> Callable[[int, np.ndarray, float, float], None]:
         """Returns the callback."""
         return self._callback
 
     @callback.setter
-    def callback(self, callback: Callable) -> None:
+    def callback(self, callback: Callable[[int, np.ndarray, float, float], None]) -> None:
         """Set the callback."""
         self._callback = callback
 
-    def _wrap_vqe_callback(self) -> Optional[Callable]:
+    def _wrap_vqe_callback(self) -> Optional[Callable[[int, np.ndarray, float, float], None]]:
         """Wraps and returns the given callback to match the signature of the runtime callback."""
 
         def wrapped_callback(*args) -> None:


### PR DESCRIPTION
### Summary

Add a check for the type of data expected in the callback wraper in VQEProgram. This will allow us to close Qiskit-Partners/qiskit-runtime#38

### Details and comments

Anticipating changes in the Qiskit Runtime API which will start emitting final results in the WebSocket stream. When that happens, if we don't duck-type in the VQE callback wrapper receiving the interim results, it will get a ValueError exception.



