### PR TITLE
Fix mapper

### DIFF
--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -120,17 +120,23 @@ class QubitMapper(ABC):
             # save the respective Pauli string in the pauli_str list.
             for position, char in enumerate(label):
                 if char == "+":
-                    ret_op &= times_creation_op(position, pauli_table)
+                    ret_op = ret_op.compose(times_creation_op(position, pauli_table), front=True)
                 elif char == "-":
-                    ret_op &= times_annihilation_op(position, pauli_table)
+                    ret_op = ret_op.compose(
+                        times_annihilation_op(position, pauli_table), front=True
+                    )
                 elif char == "N":
                     # The occupation number operator N is given by `+-`.
-                    ret_op &= times_annihilation_op(position, pauli_table)
-                    ret_op &= times_creation_op(position, pauli_table)
+                    ret_op = ret_op.compose(times_creation_op(position, pauli_table), front=True)
+                    ret_op = ret_op.compose(
+                        times_annihilation_op(position, pauli_table), front=True
+                    )
                 elif char == "E":
                     # The `emptiness number` operator E is given by `-+` = (I - N).
-                    ret_op &= times_creation_op(position, pauli_table)
-                    ret_op &= times_annihilation_op(position, pauli_table)
+                    ret_op = ret_op.compose(
+                        times_annihilation_op(position, pauli_table), front=True
+                    )
+                    ret_op = ret_op.compose(times_creation_op(position, pauli_table), front=True)
                 elif char == "I":
                     continue
 

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -87,16 +87,16 @@ class QubitMapper(ABC):
             # 0. Some utilities
 
         def times_creation_op(position, pauli_table):
-            # The creation operator is given by 0.5*(X + 1j*Y)
+            # The creation operator is given by 0.5*(X - 1j*Y)
             real_part = SparsePauliOp(pauli_table[position][0], coeffs=[0.5])
-            imag_part = SparsePauliOp(pauli_table[position][1], coeffs=[0.5j])
+            imag_part = SparsePauliOp(pauli_table[position][1], coeffs=[-0.5j])
 
             return real_part + imag_part
 
         def times_annihilation_op(position, pauli_table):
-            # The annihilation operator is given by 0.5*(X - 1j*Y)
+            # The annihilation operator is given by 0.5*(X + 1j*Y)
             real_part = SparsePauliOp(pauli_table[position][0], coeffs=[0.5])
-            imag_part = SparsePauliOp(pauli_table[position][1], coeffs=[-0.5j])
+            imag_part = SparsePauliOp(pauli_table[position][1], coeffs=[0.5j])
 
             return real_part + imag_part
 

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -125,12 +125,12 @@ class QubitMapper(ABC):
                     ret_op &= times_annihilation_op(position, pauli_table)
                 elif char == "N":
                     # The occupation number operator N is given by `+-`.
-                    ret_op &= times_creation_op(position, pauli_table)
                     ret_op &= times_annihilation_op(position, pauli_table)
+                    ret_op &= times_creation_op(position, pauli_table)
                 elif char == "E":
                     # The `emptiness number` operator E is given by `-+` = (I - N).
-                    ret_op &= times_annihilation_op(position, pauli_table)
                     ret_op &= times_creation_op(position, pauli_table)
+                    ret_op &= times_annihilation_op(position, pauli_table)
                 elif char == "I":
                     continue
 

--- a/releasenotes/notes/fix-mapper-bug-8eba9d219595b8e1.yaml
+++ b/releasenotes/notes/fix-mapper-bug-8eba9d219595b8e1.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+fixes:
   - |
     Fixed an issue where the existing Mapper was incorrectly mapping the creation operator :math:`+`
     and the annihilation operator :math:`-`. It used to be that :math:`+` was mapped to

--- a/releasenotes/notes/fix-mapper-bug-8eba9d219595b8e1.yaml
+++ b/releasenotes/notes/fix-mapper-bug-8eba9d219595b8e1.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Fixed an issue where the existing Mapper was incorrectly mapping the creation operator :math:`+`
+    and the annihilation operator :math:`-`. It used to be that :math:`+` was mapped to
+    :math:`\sigma_+` and :math:`-` was mapped to :math:`\sigma_-`, but it is correct that
+    :math:`+` is mapped to :math:`\sigma_-` and :math:`-` is mapped to :math`\sigma_+`.

--- a/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
+++ b/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
@@ -13,13 +13,13 @@
 """ Test Bravyi-Kitaev Mapper """
 
 import unittest
-
 from test import QiskitNatureTestCase
 
-from qiskit.opflow import X, Z, I
+from qiskit.opflow import I, PauliSumOp, X, Z
 
 from qiskit_nature.drivers.second_quantization import HDF5Driver
 from qiskit_nature.mappers.second_quantization import BravyiKitaevMapper
+from qiskit_nature.operators.second_quantization import FermionicOp
 
 
 class TestBravyiKitaevMapper(QiskitNatureTestCase):
@@ -66,6 +66,33 @@ class TestBravyiKitaevMapper(QiskitNatureTestCase):
         """Test this returns False for this mapper"""
         mapper = BravyiKitaevMapper()
         self.assertFalse(mapper.allows_two_qubit_reduction)
+
+    def test_mapping_for_single_op(self):
+        """Test for single register operator."""
+        with self.subTest("test +"):
+            op = FermionicOp("+")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
+            self.assertEqual(BravyiKitaevMapper().map(op), expected)
+
+        with self.subTest("test -"):
+            op = FermionicOp("-")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
+            self.assertEqual(BravyiKitaevMapper().map(op), expected)
+
+        with self.subTest("test N"):
+            op = FermionicOp("N")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
+            self.assertEqual(BravyiKitaevMapper().map(op), expected)
+
+        with self.subTest("test E"):
+            op = FermionicOp("E")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
+            self.assertEqual(BravyiKitaevMapper().map(op), expected)
+
+        with self.subTest("test I"):
+            op = FermionicOp("I")
+            expected = PauliSumOp.from_list([("I", 1)])
+            self.assertEqual(BravyiKitaevMapper().map(op), expected)
 
 
 if __name__ == "__main__":

--- a/test/mappers/second_quantization/test_jordan_wigner_mapper.py
+++ b/test/mappers/second_quantization/test_jordan_wigner_mapper.py
@@ -13,13 +13,13 @@
 """ Test Jordan Wigner Mapper """
 
 import unittest
-
 from test import QiskitNatureTestCase
 
-from qiskit.opflow import X, Y, Z, I
+from qiskit.opflow import I, PauliSumOp, X, Y, Z
 
 from qiskit_nature.drivers.second_quantization import HDF5Driver
 from qiskit_nature.mappers.second_quantization import JordanWignerMapper
+from qiskit_nature.operators.second_quantization import FermionicOp
 
 
 class TestJordanWignerMapper(QiskitNatureTestCase):
@@ -27,13 +27,13 @@ class TestJordanWignerMapper(QiskitNatureTestCase):
 
     REF_H2 = (
         -0.81054798160031430 * (I ^ I ^ I ^ I)
-        - 0.22575349071287365 * (Z ^ I ^ I ^ I)
-        + 0.17218393211855787 * (I ^ Z ^ I ^ I)
+        + 0.22575349071287365 * (Z ^ I ^ I ^ I)
+        - 0.17218393211855787 * (I ^ Z ^ I ^ I)
         + 0.12091263243164174 * (Z ^ Z ^ I ^ I)
-        - 0.22575349071287362 * (I ^ I ^ Z ^ I)
+        + 0.22575349071287362 * (I ^ I ^ Z ^ I)
         + 0.17464343053355980 * (Z ^ I ^ Z ^ I)
         + 0.16614543242281926 * (I ^ Z ^ Z ^ I)
-        + 0.17218393211855818 * (I ^ I ^ I ^ Z)
+        - 0.17218393211855818 * (I ^ I ^ I ^ Z)
         + 0.16614543242281926 * (Z ^ I ^ I ^ Z)
         + 0.16892753854646372 * (I ^ Z ^ I ^ Z)
         + 0.12091263243164174 * (I ^ I ^ Z ^ Z)
@@ -66,6 +66,33 @@ class TestJordanWignerMapper(QiskitNatureTestCase):
         """Test this returns False for this mapper"""
         mapper = JordanWignerMapper()
         self.assertFalse(mapper.allows_two_qubit_reduction)
+
+    def test_mapping_for_single_op(self):
+        """Test for single register operator."""
+        with self.subTest("test +"):
+            op = FermionicOp("+")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
+            self.assertEqual(JordanWignerMapper().map(op), expected)
+
+        with self.subTest("test -"):
+            op = FermionicOp("-")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
+            self.assertEqual(JordanWignerMapper().map(op), expected)
+
+        with self.subTest("test N"):
+            op = FermionicOp("N")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
+            self.assertEqual(JordanWignerMapper().map(op), expected)
+
+        with self.subTest("test E"):
+            op = FermionicOp("E")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
+            self.assertEqual(JordanWignerMapper().map(op), expected)
+
+        with self.subTest("test I"):
+            op = FermionicOp("I")
+            expected = PauliSumOp.from_list([("I", 1)])
+            self.assertEqual(JordanWignerMapper().map(op), expected)
 
 
 if __name__ == "__main__":

--- a/test/mappers/second_quantization/test_jordan_wigner_mapper.py
+++ b/test/mappers/second_quantization/test_jordan_wigner_mapper.py
@@ -27,13 +27,13 @@ class TestJordanWignerMapper(QiskitNatureTestCase):
 
     REF_H2 = (
         -0.81054798160031430 * (I ^ I ^ I ^ I)
-        + 0.22575349071287365 * (Z ^ I ^ I ^ I)
-        - 0.17218393211855787 * (I ^ Z ^ I ^ I)
+        - 0.22575349071287365 * (Z ^ I ^ I ^ I)
+        + 0.17218393211855787 * (I ^ Z ^ I ^ I)
         + 0.12091263243164174 * (Z ^ Z ^ I ^ I)
-        + 0.22575349071287362 * (I ^ I ^ Z ^ I)
+        - 0.22575349071287362 * (I ^ I ^ Z ^ I)
         + 0.17464343053355980 * (Z ^ I ^ Z ^ I)
         + 0.16614543242281926 * (I ^ Z ^ Z ^ I)
-        - 0.17218393211855818 * (I ^ I ^ I ^ Z)
+        + 0.17218393211855818 * (I ^ I ^ I ^ Z)
         + 0.16614543242281926 * (Z ^ I ^ I ^ Z)
         + 0.16892753854646372 * (I ^ Z ^ I ^ Z)
         + 0.12091263243164174 * (I ^ I ^ Z ^ Z)
@@ -71,22 +71,22 @@ class TestJordanWignerMapper(QiskitNatureTestCase):
         """Test for single register operator."""
         with self.subTest("test +"):
             op = FermionicOp("+")
-            expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
             self.assertEqual(JordanWignerMapper().map(op), expected)
 
         with self.subTest("test -"):
             op = FermionicOp("-")
-            expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
             self.assertEqual(JordanWignerMapper().map(op), expected)
 
         with self.subTest("test N"):
             op = FermionicOp("N")
-            expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
             self.assertEqual(JordanWignerMapper().map(op), expected)
 
         with self.subTest("test E"):
             op = FermionicOp("E")
-            expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
             self.assertEqual(JordanWignerMapper().map(op), expected)
 
         with self.subTest("test I"):

--- a/test/mappers/second_quantization/test_parity_mapper.py
+++ b/test/mappers/second_quantization/test_parity_mapper.py
@@ -13,13 +13,13 @@
 """ Test Parity Mapper """
 
 import unittest
-
 from test import QiskitNatureTestCase
 
-from qiskit.opflow import X, Z, I
+from qiskit.opflow import I, PauliSumOp, X, Z
 
 from qiskit_nature.drivers.second_quantization import HDF5Driver
 from qiskit_nature.mappers.second_quantization import ParityMapper
+from qiskit_nature.operators.second_quantization import FermionicOp
 
 
 class TestParityMapper(QiskitNatureTestCase):
@@ -66,6 +66,33 @@ class TestParityMapper(QiskitNatureTestCase):
         """Test this returns True for this mapper"""
         mapper = ParityMapper()
         self.assertTrue(mapper.allows_two_qubit_reduction)
+
+    def test_mapping_for_single_op(self):
+        """Test for single register operator."""
+        with self.subTest("test +"):
+            op = FermionicOp("+")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
+            self.assertEqual(ParityMapper().map(op), expected)
+
+        with self.subTest("test -"):
+            op = FermionicOp("-")
+            expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
+            self.assertEqual(ParityMapper().map(op), expected)
+
+        with self.subTest("test N"):
+            op = FermionicOp("N")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
+            self.assertEqual(ParityMapper().map(op), expected)
+
+        with self.subTest("test E"):
+            op = FermionicOp("E")
+            expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
+            self.assertEqual(ParityMapper().map(op), expected)
+
+        with self.subTest("test I"):
+            op = FermionicOp("I")
+            expected = PauliSumOp.from_list([("I", 1)])
+            self.assertEqual(ParityMapper().map(op), expected)
 
 
 if __name__ == "__main__":

--- a/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_hopping_ops_builder.py
@@ -56,38 +56,18 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         expected_hopping_operators = (
             {
                 "E_0": PauliSumOp.from_list(
-                    [("IIXX", 1), ("IIYX", -1j), ("IIXY", 1j), ("IIYY", 1)]
+                    [("IIXX", 1), ("IIYX", 1j), ("IIXY", -1j), ("IIYY", 1)]
                 ),
                 "Edag_0": PauliSumOp.from_list(
-                    [("IIXX", -1), ("IIYX", -1j), ("IIXY", 1j), ("IIYY", -1)]
+                    [("IIXX", -1), ("IIYX", 1j), ("IIXY", -1j), ("IIYY", -1)]
                 ),
                 "E_1": PauliSumOp.from_list(
-                    [("XXII", 1), ("YXII", -1j), ("XYII", 1j), ("YYII", 1)]
+                    [("XXII", 1), ("YXII", 1j), ("XYII", -1j), ("YYII", 1)]
                 ),
                 "Edag_1": PauliSumOp.from_list(
-                    [("XXII", -1), ("YXII", -1j), ("XYII", 1j), ("YYII", -1)]
+                    [("XXII", -1), ("YXII", 1j), ("XYII", -1j), ("YYII", -1)]
                 ),
                 "E_2": PauliSumOp.from_list(
-                    [
-                        ("XXXX", 1),
-                        ("YXXX", -1j),
-                        ("XYXX", 1j),
-                        ("YYXX", 1),
-                        ("XXYX", -1j),
-                        ("YXYX", -1),
-                        ("XYYX", 1),
-                        ("YYYX", -1j),
-                        ("XXXY", 1j),
-                        ("YXXY", 1),
-                        ("XYXY", -1),
-                        ("YYXY", 1j),
-                        ("XXYY", 1),
-                        ("YXYY", -1j),
-                        ("XYYY", 1j),
-                        ("YYYY", 1),
-                    ]
-                ),
-                "Edag_2": PauliSumOp.from_list(
                     [
                         ("XXXX", 1),
                         ("YXXX", 1j),
@@ -104,6 +84,26 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
                         ("XXYY", 1),
                         ("YXYY", 1j),
                         ("XYYY", -1j),
+                        ("YYYY", 1),
+                    ]
+                ),
+                "Edag_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 1),
+                        ("YXXX", -1j),
+                        ("XYXX", 1j),
+                        ("YYXX", 1),
+                        ("XXYX", -1j),
+                        ("YXYX", -1),
+                        ("XYYX", 1),
+                        ("YYYX", -1j),
+                        ("XXXY", 1j),
+                        ("YXXY", 1),
+                        ("XYXY", -1),
+                        ("YYXY", 1j),
+                        ("XXYY", 1),
+                        ("YXYY", -1j),
+                        ("XYYY", 1j),
                         ("YYYY", 1),
                     ]
                 ),

--- a/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
+++ b/test/problems/second_quantization/vibrational/builders/test_hopping_ops_builder.py
@@ -51,38 +51,18 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         expected_hopping_operators = (
             {
                 "E_0": PauliSumOp.from_list(
-                    [("IIXX", 0.25), ("IIYX", -0.25j), ("IIXY", 0.25j), ("IIYY", 0.25)]
-                ),
-                "Edag_0": PauliSumOp.from_list(
                     [("IIXX", 0.25), ("IIYX", 0.25j), ("IIXY", -0.25j), ("IIYY", 0.25)]
                 ),
-                "E_1": PauliSumOp.from_list(
-                    [("XXII", 0.25), ("YXII", -0.25j), ("XYII", 0.25j), ("YYII", 0.25)]
+                "Edag_0": PauliSumOp.from_list(
+                    [("IIXX", 0.25), ("IIYX", -0.25j), ("IIXY", 0.25j), ("IIYY", 0.25)]
                 ),
-                "Edag_1": PauliSumOp.from_list(
+                "E_1": PauliSumOp.from_list(
                     [("XXII", 0.25), ("YXII", 0.25j), ("XYII", -0.25j), ("YYII", 0.25)]
                 ),
-                "E_2": PauliSumOp.from_list(
-                    [
-                        ("XXXX", 0.0625),
-                        ("YXXX", -0.0625j),
-                        ("XYXX", 0.0625j),
-                        ("YYXX", 0.0625),
-                        ("XXYX", -0.0625j),
-                        ("YXYX", -0.0625),
-                        ("XYYX", 0.0625),
-                        ("YYYX", -0.0625j),
-                        ("XXXY", 0.0625j),
-                        ("YXXY", 0.0625),
-                        ("XYXY", -0.0625),
-                        ("YYXY", 0.0625j),
-                        ("XXYY", 0.0625),
-                        ("YXYY", -0.0625j),
-                        ("XYYY", 0.0625j),
-                        ("YYYY", 0.0625),
-                    ]
+                "Edag_1": PauliSumOp.from_list(
+                    [("XXII", 0.25), ("YXII", -0.25j), ("XYII", 0.25j), ("YYII", 0.25)]
                 ),
-                "Edag_2": PauliSumOp.from_list(
+                "E_2": PauliSumOp.from_list(
                     [
                         ("XXXX", 0.0625),
                         ("YXXX", 0.0625j),
@@ -99,6 +79,26 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
                         ("XXYY", 0.0625),
                         ("YXYY", 0.0625j),
                         ("XYYY", -0.0625j),
+                        ("YYYY", 0.0625),
+                    ]
+                ),
+                "Edag_2": PauliSumOp.from_list(
+                    [
+                        ("XXXX", 0.0625),
+                        ("YXXX", -0.0625j),
+                        ("XYXX", 0.0625j),
+                        ("YYXX", 0.0625),
+                        ("XXYX", -0.0625j),
+                        ("YXYX", -0.0625),
+                        ("XYYX", 0.0625),
+                        ("YYYX", -0.0625j),
+                        ("XXXY", 0.0625j),
+                        ("YXXY", 0.0625),
+                        ("XYXY", -0.0625),
+                        ("YYXY", 0.0625j),
+                        ("XXYY", 0.0625),
+                        ("YXYY", -0.0625j),
+                        ("XYYY", 0.0625j),
                         ("YYYY", 0.0625),
                     ]
                 ),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I'm not 100% sure, but I think the mapper is wrong. Please double check. How it's wrong is reflected in the [test cases](https://github.com/Qiskit/qiskit-nature/pull/357/files#diff-d92db51c4ee6797461b0113b4412281634076b2ce14ac06ab6f1819bc0df2a6aR72-R95). I don't have all the tests to go through now. If this fix is correct, I'll pass them.

### Details and comments

The point here is that the & operator is left-acting, which is the opposite of the normal order of operations.


```python
from qiskit_nature.mappers.second_quantization import JordanWignerMapper
from qiskit_nature.operators.second_quantization import FermionicOp

mapping = JordanWignerMapper().map
plus = FermionicOp("+")
minus = FermionicOp("-")
print((mapping(plus) @ mapping(minus)).reduce())
print((mapping(plus @ minus)).reduce())
```
The outputs should be the same. but now different