### PR TITLE
get_real_part_properties: fix issue with round of complex values

### DIFF
--- a/qiskit_nature/results/electronic_structure_result.py
+++ b/qiskit_nature/results/electronic_structure_result.py
@@ -282,17 +282,17 @@ class ElectronicStructureResult(EigenstateResult):
         lines.append("=== GROUND STATE ENERGY ===")
         lines.append(" ")
         lines.append(
-            f"* Electronic ground state energy (Hartree): {round(self.electronic_energies[0], 12)}"
+            f"* Electronic ground state energy (Hartree): {round(self.electronic_energies[0].real, 12)}"
         )
         lines.append(f"  - computed part:      {round(self.computed_energies[0], 12)}")
         for name, value in self.extracted_transformer_energies.items():
-            lines.append(f"  - {name} extracted energy part: {round(value, 12)}")
+            lines.append(f"  - {name} extracted energy part: {round(value.real, 12)}")
         if self.nuclear_repulsion_energy is not None:
             lines.append(
                 f"~ Nuclear repulsion energy (Hartree): { round(self.nuclear_repulsion_energy, 12)}"
             )
             lines.append(
-                f"> Total ground state energy (Hartree): {round(self.total_energies[0], 12)}"
+                f"> Total ground state energy (Hartree): {round(self.total_energies[0].real, 12)}"
             )
 
         if len(self.computed_energies) > 1:
@@ -304,9 +304,11 @@ class ElectronicStructureResult(EigenstateResult):
             ):
                 lines.append(f"{(idx + 1): 3d}: ")
                 lines.append(
-                    f"* Electronic excited state energy (Hartree): {round(elec_energy, 12)}"
+                    f"* Electronic excited state energy (Hartree): {round(elec_energy.real, 12)}"
                 )
-                lines.append(f"> Total excited state energy (Hartree): {round(total_energy, 12)}")
+                lines.append(
+                    f"> Total excited state energy (Hartree): {round(total_energy.real, 12)}"
+                )
 
         if self.has_observables():
             lines.append(" ")
@@ -383,7 +385,7 @@ def _element_add(x: Optional[float], y: Optional[float]):
 
 
 def _dipole_to_string(dipole: DipoleTuple):
-    dips = [round(x, 8) if x is not None else x for x in dipole]
+    dips = [round(x.real, 8) if x is not None else x for x in dipole]
     value = "["
     for i, _ in enumerate(dips):
         value += _float_to_string(dips[i]) if dips[i] is not None else "None"
@@ -395,4 +397,6 @@ def _float_to_string(value: Optional[float], precision: int = 8) -> str:
     if value is None:
         return "None"
     else:
-        return "0.0" if value == 0 else ("{:." + str(precision) + "f}").format(value).rstrip("0")
+        return (
+            "0.0" if value == 0 else ("{:." + str(precision) + "f}").format(value.real).rstrip("0")
+        )


### PR DESCRIPTION
-------

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
-->

### Information

- **Qiskit Nature version**: latest `main` development branches
- **Python version**: 3.9.7
- **Operating system**: Linux

### What is the current behavior?
When transformers are used the formatted method of `electronic_structurer:esult` fails:

``` shell
/home/castanedamedina/.pyenv/versions/qiskit_src/lib/python3.9/site-packages/qiskit_nature/results/electronic_structure_result.py:285: DeprecationWarning: The Python built-in `round` is dep
recated for complex scalars, and will raise a `TypeError` in a future release. Use `np.round` or `scalar.round` instead.
  f"* Electronic ground state energy (Hartree): {round(self.electronic_energies[0], 12)}"
Traceback (most recent call last):
  File "/home/castanedamedina/Work/Development/ITWM/IBMQ/src/ibmq_src/qiskit-nature/docs/tutorials/07_leveraging_qiskit_runtime.py", line 90, in <module>
    print(np_result)
  File "/home/castanedamedina/.pyenv/versions/qiskit_src/lib/python3.9/site-packages/qiskit_nature/results/electronic_structure_result.py", line 277, in __str__
    return "\n".join(self.formatted())
  File "/home/castanedamedina/.pyenv/versions/qiskit_src/lib/python3.9/site-packages/qiskit_nature/results/electronic_structure_result.py", line 289, in formatted
    lines.append(f"  - {name} extracted energy part: {round(value, 12)}")
TypeError: type complex doesn't define __round__ method
```

This happens for lines 289 and 386

### Steps to reproduce the problem
From a snippet of one tutorial:
```python

from qiskit_nature.drivers import UnitsType, Molecule
from qiskit_nature.drivers.second_quantization import (
    ElectronicStructureDriverType,
    ElectronicStructureMoleculeDriver,
)
from qiskit_nature.problems.second_quantization.electronic import ElectronicStructureProblem
from qiskit_nature.converters.second_quantization import QubitConverter
from qiskit_nature.mappers.second_quantization import ParityMapper
from qiskit_nature.properties.second_quantization.electronic import ParticleNumber
from qiskit_nature.transformers.second_quantization.electronic import ActiveSpaceTransformer

bond_distance = 2.5  # in Angstrom

# define molecule
molecule = Molecule(
    geometry=[["Li", [0.0, 0.0, 0.0]], ["H", [0.0, 0.0, bond_distance]]], charge=0, multiplicity=1
)

# specify driver
driver = ElectronicStructureMoleculeDriver(
    molecule, basis="sto3g", driver_type=ElectronicStructureDriverType.PYSCF
)
properties = driver.run()

particle_number = properties.get_property(ParticleNumber)

# specify active space transformation
active_space_trafo = ActiveSpaceTransformer(
    num_electrons=particle_number.num_particles, num_molecular_orbitals=3
)

# define electronic structure problem
problem = ElectronicStructureProblem(driver, transformers=[active_space_trafo])

# construct qubit converter (parity mapping + 2-qubit reduction)
qubit_converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)


# ## Classical reference solution

# As a reference solution we can solve this system classically with the `NumPyEigensolver`.

from qiskit.algorithms import NumPyMinimumEigensolver
from qiskit_nature.algorithms.ground_state_solvers import GroundStateEigensolver

np_solver = NumPyMinimumEigensolver()
np_groundstate_solver = GroundStateEigensolver(qubit_converter, np_solver)

np_result = np_groundstate_solver.solve(problem)

import numpy as np

target_energy = np.real(np_result.eigenenergies + np_result.nuclear_repulsion_energy)[0]
print(np_result)
print("Energy:", target_energy)


# ## VQE
#
# To run the VQE we need to select a parameterized quantum circuit acting as ansatz and a classical optimizer. Here we'll choose a heuristic, hardware efficient ansatz and the SPSA optimizer.

from qiskit.circuit.library import EfficientSU2

ansatz = EfficientSU2(num_qubits=4, reps=1, entanglement="linear", insert_barriers=True)
ansatz.draw("mpl", style="iqx")

from qiskit.algorithms.optimizers import SPSA

optimizer = SPSA(maxiter=100)

np.random.seed(5)  # fix seed for reproducibility
initial_point = np.random.random(ansatz.num_parameters)


# Before executing the VQE in the cloud using Qiskit Runtime, let's execute a local VQE first.

from qiskit.providers.basicaer import QasmSimulatorPy  # local simulator
from qiskit.algorithms import VQE

local_vqe = VQE(
    ansatz=ansatz,
    optimizer=optimizer,
    initial_point=initial_point,
    quantum_instance=QasmSimulatorPy(),
)

local_vqe_groundstate_solver = GroundStateEigensolver(qubit_converter, local_vqe)

local_vqe_result = local_vqe_groundstate_solver.solve(problem)

print(local_vqe_result)
print(
    "Energy:",
    np.real(local_vqe_result.eigenenergies + local_vqe_result.nuclear_repulsion_energy)[0],
)

```

### What is the expected behavior?
The printing should work without any problems.


### Suggested solutions
Although going from `round` to `np.round` (as suggests the
`Deprecationwarning`) solves the issue, it would be nice to print only
the real part of the energy/dipole components. On the other hand, for
consistency not only the above lines are considered but also other
quantities printed by the `formatted` method.