### PR TITLE
Allow sparse FermionicOp input to BKSF mapper

### DIFF
--- a/qiskit_nature/mappers/second_quantization/bksf.py
+++ b/qiskit_nature/mappers/second_quantization/bksf.py
@@ -42,6 +42,11 @@ class BravyiKitaevSuperFastMapper(FermionicMapper):
         if not isinstance(second_q_op, FermionicOp):
             raise TypeError("Type ", type(second_q_op), " not supported.")
 
+        if second_q_op.display_format == "sparse":
+            second_q_op = FermionicOp(
+                second_q_op.to_normal_order()._to_dense_label_data(), display_format="dense"
+            )
+
         edge_list = _bksf_edge_list_fermionic_op(second_q_op)
         sparse_pauli = _convert_operator(second_q_op, edge_list)
 

--- a/test/mappers/second_quantization/test_bksf_mapper.py
+++ b/test/mappers/second_quantization/test_bksf_mapper.py
@@ -155,6 +155,12 @@ class TestBravyiKitaevSuperFastMapper(QiskitNatureTestCase):
         with self.subTest("Map H2 frome sto3g basis result"):
             self.assertEqual(op1, op2)
 
+        with self.subTest("Sparse FermionicOp input"):
+            h2_fop_sparse = h2_fop.to_normal_order()
+            pauli_sum_op_from_sparse = BravyiKitaevSuperFastMapper().map(h2_fop_sparse)
+            op2_from_sparse = _sort_simplify(pauli_sum_op_from_sparse.primitive)
+            self.assertEqual(op1, op2_from_sparse)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR allows the input to `BravyiKitaevSuperFastMapper.map` to be a `FermionicOp` with sparse storage format.
Prior to this PR, attempting to call `map` with sparse storage format caused an ungraceful exception.

This PR has the `map` method convert the sparse-storage input to dense storage before mapping.

Closes #385