### PR TITLE
Unpin PySCF to allow latest 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.17
 psutil>=5
 scikit-learn>=0.20.0
 setuptools>=40.1.0
-h5py<3.3
+h5py
 dataclasses; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.6",
     extras_require={
-        'pyscf': ["pyscf<2.0.0; sys_platform != 'win32'"],
+        'pyscf': ["pyscf; sys_platform != 'win32'"],
     },
     zip_safe=False
 )


### PR DESCRIPTION
PySCF was released recently and wheels for Linux and Mac were added incrementally and during this time PySCF was pinned as otherwise attempts were made to compile it from the source tar.gz package.

I also unpinned h5py since the newer PySCF was fixed in regards of the deprecation issue (as far as I recall seeing before).

I am not sure if this will pass or not since before I had pinned it I had seen notebook kernel crash and other crashes. But this PR will let us view across CI what the outcome is and see how we might proceed in regards of this new version. One possibility might be to allow but pin CI to 1.7.6 if we have some failures but otherwise allow it for users as maybe it works in general. Lets see what happens with CI etc...