### PR TITLE
Support generalized fermionic excitations

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -273,6 +273,7 @@ num
 numpy
 numpyeigensolver
 observables
+occupancies
 ok
 ollitrault
 onee

--- a/qiskit_nature/circuit/library/ansatzes/puccd.py
+++ b/qiskit_nature/circuit/library/ansatzes/puccd.py
@@ -15,7 +15,6 @@ The paired-UCCD Ansatz.
 
 from typing import List, Optional, Tuple
 
-import itertools
 import logging
 
 from qiskit.circuit import QuantumCircuit
@@ -23,7 +22,10 @@ from qiskit_nature import QiskitNatureError
 from qiskit_nature.converters.second_quantization import QubitConverter
 
 from .ucc import UCC
-from .utils.fermionic_excitation_generator import generate_fermionic_excitations
+from .utils.fermionic_excitation_generator import (
+    generate_fermionic_excitations,
+    get_alpha_excitations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,7 @@ class PUCCD(UCC):
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
         include_singles: Tuple[bool, bool] = (False, False),
+        generalized: bool = False,
     ):
         """
 
@@ -65,6 +68,10 @@ class PUCCD(UCC):
             reps: The number of times to repeat the evolved operators.
             initial_state: A `QuantumCircuit` object to prepend to the circuit.
             include_singles: enables the inclusion of single excitations per spin species.
+            generalized: boolean flag whether or not to use generalized excitations, which ignore
+                the occupation of the spin orbitals. As such, the set of generalized excitations is
+                only determined from the number of spin orbitals and independent from the number of
+                particles.
 
         Raises:
             QiskitNatureError: if the number of alpha and beta electrons is not equal.
@@ -79,6 +86,7 @@ class PUCCD(UCC):
             alpha_spin=True,
             beta_spin=True,
             max_spin_excitation=None,
+            generalized=generalized,
             reps=reps,
             initial_state=initial_state,
         )
@@ -128,10 +136,9 @@ class PUCCD(UCC):
         beta_index_shift = num_spin_orbitals // 2
 
         # generate alpha-spin orbital indices for occupied and unoccupied ones
-        alpha_occ = list(range(num_electrons))
-        alpha_unocc = list(range(num_electrons, beta_index_shift))
-        # the Cartesian product of these lists gives all possible single alpha-spin excitations
-        alpha_excitations = list(itertools.product(alpha_occ, alpha_unocc))
+        alpha_excitations = get_alpha_excitations(
+            num_electrons, num_spin_orbitals, self._generalized
+        )
         logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
 
         for alpha_exc in alpha_excitations:

--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -123,6 +123,7 @@ class UCC(EvolvedOperatorAnsatz):
         alpha_spin: bool = True,
         beta_spin: bool = True,
         max_spin_excitation: Optional[int] = None,
+        generalized: bool = False,
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
     ):
@@ -156,6 +157,10 @@ class UCC(EvolvedOperatorAnsatz):
                 this to 1 and `num_excitations` to 2 in order to obtain only mixed-spin double
                 excitations (alpha,beta) but no pure-spin double excitations (alpha,alpha or
                 beta,beta).
+            generalized: boolean flag whether or not to use generalized excitations, which ignore
+                the occupation of the spin orbitals. As such, the set of generalized excitations is
+                only determined from the number of spin orbitals and independent from the number of
+                particles.
             reps: The number of times to repeat the evolved operators.
             initial_state: A `QuantumCircuit` object to prepend to the circuit.
         """
@@ -166,6 +171,7 @@ class UCC(EvolvedOperatorAnsatz):
         self._alpha_spin = alpha_spin
         self._beta_spin = beta_spin
         self._max_spin_excitation = max_spin_excitation
+        self._generalized = generalized
 
         super().__init__(reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state)
 
@@ -314,6 +320,7 @@ class UCC(EvolvedOperatorAnsatz):
             "alpha_spin": self._alpha_spin,
             "beta_spin": self._beta_spin,
             "max_spin_excitation": self._max_spin_excitation,
+            "generalized": self._generalized,
         }
 
         if isinstance(self.excitations, str):

--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -124,7 +124,7 @@ class UCC(EvolvedOperatorAnsatz):
         beta_spin: bool = True,
         max_spin_excitation: Optional[int] = None,
         generalized: bool = False,
-        spin_flip: bool = False,
+        preserve_spin: bool = True,
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
     ):
@@ -162,7 +162,7 @@ class UCC(EvolvedOperatorAnsatz):
                 the occupation of the spin orbitals. As such, the set of generalized excitations is
                 only determined from the number of spin orbitals and independent from the number of
                 particles.
-            spin_flip: boolean flag whether or not to allow spin flips to occur.
+            preserve_spin: boolean flag whether or not to preserve the particle spins.
             reps: The number of times to repeat the evolved operators.
             initial_state: A `QuantumCircuit` object to prepend to the circuit.
         """
@@ -174,7 +174,7 @@ class UCC(EvolvedOperatorAnsatz):
         self._beta_spin = beta_spin
         self._max_spin_excitation = max_spin_excitation
         self._generalized = generalized
-        self._spin_flip = spin_flip
+        self._preserve_spin = preserve_spin
 
         super().__init__(reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state)
 
@@ -324,7 +324,7 @@ class UCC(EvolvedOperatorAnsatz):
             "beta_spin": self._beta_spin,
             "max_spin_excitation": self._max_spin_excitation,
             "generalized": self._generalized,
-            "spin_flip": self._spin_flip,
+            "preserve_spin": self._preserve_spin,
         }
 
         if isinstance(self.excitations, str):

--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -124,6 +124,7 @@ class UCC(EvolvedOperatorAnsatz):
         beta_spin: bool = True,
         max_spin_excitation: Optional[int] = None,
         generalized: bool = False,
+        spin_flip: bool = False,
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
     ):
@@ -161,6 +162,7 @@ class UCC(EvolvedOperatorAnsatz):
                 the occupation of the spin orbitals. As such, the set of generalized excitations is
                 only determined from the number of spin orbitals and independent from the number of
                 particles.
+            spin_flip: boolean flag whether or not to allow spin flips to occur.
             reps: The number of times to repeat the evolved operators.
             initial_state: A `QuantumCircuit` object to prepend to the circuit.
         """
@@ -172,6 +174,7 @@ class UCC(EvolvedOperatorAnsatz):
         self._beta_spin = beta_spin
         self._max_spin_excitation = max_spin_excitation
         self._generalized = generalized
+        self._spin_flip = spin_flip
 
         super().__init__(reps=reps, evolution=PauliTrotterEvolution(), initial_state=initial_state)
 
@@ -321,6 +324,7 @@ class UCC(EvolvedOperatorAnsatz):
             "beta_spin": self._beta_spin,
             "max_spin_excitation": self._max_spin_excitation,
             "generalized": self._generalized,
+            "spin_flip": self._spin_flip,
         }
 
         if isinstance(self.excitations, str):

--- a/qiskit_nature/circuit/library/ansatzes/uccsd.py
+++ b/qiskit_nature/circuit/library/ansatzes/uccsd.py
@@ -34,7 +34,7 @@ class UCCSD(UCC):
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
         generalized: bool = False,
-        spin_flip: bool = False,
+        preserve_spin: bool = True,
     ):
         """
         Args:
@@ -49,7 +49,7 @@ class UCCSD(UCC):
                 the occupation of the spin orbitals. As such, the set of generalized excitations is
                 only determined from the number of spin orbitals and independent from the number of
                 particles.
-            spin_flip: boolean flag whether or not to allow spin flips to occur.
+        preserve_spin: boolean flag whether or not to preserve the particle spins.
         """
         super().__init__(
             qubit_converter=qubit_converter,
@@ -60,7 +60,7 @@ class UCCSD(UCC):
             beta_spin=True,
             max_spin_excitation=None,
             generalized=generalized,
-            spin_flip=spin_flip,
+            preserve_spin=preserve_spin,
             reps=reps,
             initial_state=initial_state,
         )

--- a/qiskit_nature/circuit/library/ansatzes/uccsd.py
+++ b/qiskit_nature/circuit/library/ansatzes/uccsd.py
@@ -34,6 +34,7 @@ class UCCSD(UCC):
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
         generalized: bool = False,
+        spin_flip: bool = False,
     ):
         """
         Args:
@@ -48,6 +49,7 @@ class UCCSD(UCC):
                 the occupation of the spin orbitals. As such, the set of generalized excitations is
                 only determined from the number of spin orbitals and independent from the number of
                 particles.
+            spin_flip: boolean flag whether or not to allow spin flips to occur.
         """
         super().__init__(
             qubit_converter=qubit_converter,
@@ -58,6 +60,7 @@ class UCCSD(UCC):
             beta_spin=True,
             max_spin_excitation=None,
             generalized=generalized,
+            spin_flip=spin_flip,
             reps=reps,
             initial_state=initial_state,
         )

--- a/qiskit_nature/circuit/library/ansatzes/uccsd.py
+++ b/qiskit_nature/circuit/library/ansatzes/uccsd.py
@@ -33,6 +33,7 @@ class UCCSD(UCC):
         num_spin_orbitals: Optional[int] = None,
         reps: int = 1,
         initial_state: Optional[QuantumCircuit] = None,
+        generalized: bool = False,
     ):
         """
         Args:
@@ -43,6 +44,10 @@ class UCCSD(UCC):
             num_spin_orbitals: the number of spin orbitals.
             reps: The number of times to repeat the evolved operators.
             initial_state: A `QuantumCircuit` object to prepend to the circuit.
+            generalized: boolean flag whether or not to use generalized excitations, which ignore
+                the occupation of the spin orbitals. As such, the set of generalized excitations is
+                only determined from the number of spin orbitals and independent from the number of
+                particles.
         """
         super().__init__(
             qubit_converter=qubit_converter,
@@ -52,6 +57,7 @@ class UCCSD(UCC):
             alpha_spin=True,
             beta_spin=True,
             max_spin_excitation=None,
+            generalized=generalized,
             reps=reps,
             initial_state=initial_state,
         )

--- a/qiskit_nature/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
+++ b/qiskit_nature/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
@@ -101,7 +101,7 @@ def generate_fermionic_excitations(
     beta_spin: bool = True,
     max_spin_excitation: Optional[int] = None,
     generalized: bool = False,
-    spin_flip: bool = False,
+    preserve_spin: bool = True,
 ) -> List[Tuple[Tuple[int, ...], Tuple[int, ...]]]:
     """Generates all possible excitations with the given number of excitations for the specified
     number of particles distributed among the given number of spin orbitals.
@@ -122,7 +122,7 @@ def generate_fermionic_excitations(
             occupation of the spin orbitals. As such, the set of generalized excitations is only
             determined from the number of spin orbitals and independent from the number of
             particles.
-        spin_flip: boolean flag whether or not to allow spin flips to occur.
+        preserve_spin: boolean flag whether or not to preserve the particle spins.
 
     Returns:
         The list of excitations encoded as tuples of tuples. Each tuple in the list is a pair. The
@@ -132,7 +132,20 @@ def generate_fermionic_excitations(
     alpha_excitations: List[Tuple[int, int]] = []
     beta_excitations: List[Tuple[int, int]] = []
 
-    if spin_flip:
+    if preserve_spin:
+        if alpha_spin:
+            alpha_excitations = get_alpha_excitations(
+                num_particles[0], num_spin_orbitals, generalized
+            )
+            logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
+
+        if beta_spin:
+            beta_excitations = get_beta_excitations(
+                num_particles[1], num_spin_orbitals, generalized
+            )
+            logger.debug("Generated list of single beta excitations: %s", beta_excitations)
+
+    else:
         # We can reuse our existing implementation for the scenario involving spin flips by
         # generating the single excitations of an _interleaved_ spin orbital system.
         # For this, we can reuse the alpha single excitation generator in a system of double the
@@ -160,19 +173,6 @@ def generate_fermionic_excitations(
         # NOTE: we sort the lists to ensure that non-spin flipped variants take higher precedence
         alpha_excitations = sorted(alpha_excitations)
         beta_excitations = sorted(beta_excitations)
-
-    else:
-        if alpha_spin:
-            alpha_excitations = get_alpha_excitations(
-                num_particles[0], num_spin_orbitals, generalized
-            )
-            logger.debug("Generated list of single alpha excitations: %s", alpha_excitations)
-
-        if beta_spin:
-            beta_excitations = get_beta_excitations(
-                num_particles[1], num_spin_orbitals, generalized
-            )
-            logger.debug("Generated list of single beta excitations: %s", beta_excitations)
 
     if not alpha_excitations and not beta_excitations:
         # nothing to do, let's return early

--- a/releasenotes/notes/generalized-fermionic-excitations-1d345d179e097896.yaml
+++ b/releasenotes/notes/generalized-fermionic-excitations-1d345d179e097896.yaml
@@ -4,3 +4,5 @@ features:
     Support was added for generalized fermionic excitations. These kinds of
     excitations are effectively ignoring the orbital occupancies and instead
     yield all possible excitations within a spin species.
+    Furthermore, another option was added which can be used to enabled spin-
+    flipped excitations.

--- a/releasenotes/notes/generalized-fermionic-excitations-1d345d179e097896.yaml
+++ b/releasenotes/notes/generalized-fermionic-excitations-1d345d179e097896.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Support was added for generalized fermionic excitations. These kinds of
+    excitations are effectively ignoring the orbital occupancies and instead
+    yield all possible excitations within a spin species.

--- a/test/circuit/library/ansatzes/test_puccd.py
+++ b/test/circuit/library/ansatzes/test_puccd.py
@@ -104,3 +104,37 @@ class TestPUCC(QiskitNatureTestCase):
         """Test an error is raised when the number of alpha and beta electrons differ."""
         with self.assertRaises(QiskitNatureError):
             PUCCD(num_particles=(2, 1))
+
+    @unpack
+    @data(
+        (
+            6,
+            (1, 1),
+            [
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("I+-I+-", 1j), ("I-+I-+", -1j)], display_format="dense"),
+            ],
+        ),
+        (
+            6,
+            (2, 2),
+            [
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("I+-I+-", 1j), ("I-+I-+", -1j)], display_format="dense"),
+            ],
+        ),
+    )
+    def test_puccd_ansatz_generalized(self, num_spin_orbitals, num_particles, expect):
+        """Tests the generalized PUCCD Ansatz."""
+        converter = QubitConverter(JordanWignerMapper())
+
+        ansatz = PUCCD(
+            qubit_converter=converter,
+            num_particles=num_particles,
+            num_spin_orbitals=num_spin_orbitals,
+            generalized=True,
+        )
+
+        assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/test_succd.py
+++ b/test/circuit/library/ansatzes/test_succd.py
@@ -110,3 +110,43 @@ class TestSUCCD(QiskitNatureTestCase):
         """Test an error is raised when the number of alpha and beta electrons differ."""
         with self.assertRaises(QiskitNatureError):
             SUCCD(num_particles=(2, 1))
+
+    @unpack
+    @data(
+        (
+            6,
+            (1, 1),
+            [
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+-I+I-", 1j), ("-+I-I+", -1j)], display_format="dense"),
+                FermionicOp([("+-II+-", 1j), ("-+II-+", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("+I-I+-", 1j), ("-I+I-+", -1j)], display_format="dense"),
+                FermionicOp([("I+-I+-", 1j), ("I-+I-+", -1j)], display_format="dense"),
+            ],
+        ),
+        (
+            6,
+            (2, 2),
+            [
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+-I+I-", 1j), ("-+I-I+", -1j)], display_format="dense"),
+                FermionicOp([("+-II+-", 1j), ("-+II-+", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("+I-I+-", 1j), ("-I+I-+", -1j)], display_format="dense"),
+                FermionicOp([("I+-I+-", 1j), ("I-+I-+", -1j)], display_format="dense"),
+            ],
+        ),
+    )
+    def test_puccd_ansatz_generalized(self, num_spin_orbitals, num_particles, expect):
+        """Tests the generalized SUCCD Ansatz."""
+        converter = QubitConverter(JordanWignerMapper())
+
+        ansatz = SUCCD(
+            qubit_converter=converter,
+            num_particles=num_particles,
+            num_spin_orbitals=num_spin_orbitals,
+            generalized=True,
+        )
+
+        assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -145,3 +145,50 @@ class TestUCCSD(QiskitNatureTestCase):
         )
 
         assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)
+
+    @unpack
+    @data(
+        (
+            4,
+            (1, 1),
+            [
+                FermionicOp([("+-II", 1j), ("-+II", 1j)], display_format="dense"),
+                FermionicOp([("+II-", 1j), ("-II+", 1j)], display_format="dense"),
+                FermionicOp([("I-+I", 1j), ("I+-I", 1j)], display_format="dense"),
+                FermionicOp([("II+-", 1j), ("II-+", 1j)], display_format="dense"),
+                FermionicOp([("+-+-", 1j), ("-+-+", -1j)], display_format="dense"),
+            ],
+        ),
+        (
+            6,
+            (1, 1),
+            [
+                FermionicOp([("+-IIII", 1j), ("-+IIII", 1j)], display_format="dense"),
+                FermionicOp([("+I-III", 1j), ("-I+III", 1j)], display_format="dense"),
+                FermionicOp([("+III-I", 1j), ("-III+I", 1j)], display_format="dense"),
+                FermionicOp([("+IIII-", 1j), ("-IIII+", 1j)], display_format="dense"),
+                FermionicOp([("I-I+II", 1j), ("I+I-II", 1j)], display_format="dense"),
+                FermionicOp([("II-+II", 1j), ("II+-II", 1j)], display_format="dense"),
+                FermionicOp([("III+-I", 1j), ("III-+I", 1j)], display_format="dense"),
+                FermionicOp([("III+I-", 1j), ("III-I+", 1j)], display_format="dense"),
+                FermionicOp([("+--+II", 1j), ("-++-II", -1j)], display_format="dense"),
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+-I+I-", 1j), ("-+I-I+", -1j)], display_format="dense"),
+                FermionicOp([("+I-+-I", 1j), ("-I+-+I", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("+II+--", 1j), ("-II-++", -1j)], display_format="dense"),
+            ],
+        ),
+    )
+    def test_uccsd_ansatz_spin_flip(self, num_spin_orbitals, num_particles, expect):
+        """Tests UCCSD Ansatz with spin flips."""
+        converter = QubitConverter(JordanWignerMapper())
+
+        ansatz = UCCSD(
+            qubit_converter=converter,
+            num_particles=num_particles,
+            num_spin_orbitals=num_spin_orbitals,
+            spin_flip=True,
+        )
+
+        assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -180,7 +180,7 @@ class TestUCCSD(QiskitNatureTestCase):
             ],
         ),
     )
-    def test_uccsd_ansatz_spin_flip(self, num_spin_orbitals, num_particles, expect):
+    def test_uccsd_ansatz_preserve_spin(self, num_spin_orbitals, num_particles, expect):
         """Tests UCCSD Ansatz with spin flips."""
         converter = QubitConverter(JordanWignerMapper())
 
@@ -188,7 +188,7 @@ class TestUCCSD(QiskitNatureTestCase):
             qubit_converter=converter,
             num_particles=num_particles,
             num_spin_orbitals=num_spin_orbitals,
-            spin_flip=True,
+            preserve_spin=False,
         )
 
         assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -108,3 +108,40 @@ class TestUCCSD(QiskitNatureTestCase):
         )
 
         assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)
+
+    @unpack
+    @data(
+        (
+            6,
+            (1, 1),
+            [
+                FermionicOp([("+-IIII", 1j), ("-+IIII", 1j)], display_format="dense"),
+                FermionicOp([("+I-III", 1j), ("-I+III", 1j)], display_format="dense"),
+                FermionicOp([("I+-III", 1j), ("I-+III", 1j)], display_format="dense"),
+                FermionicOp([("III+-I", 1j), ("III-+I", 1j)], display_format="dense"),
+                FermionicOp([("III+I-", 1j), ("III-I+", 1j)], display_format="dense"),
+                FermionicOp([("IIII+-", 1j), ("IIII-+", 1j)], display_format="dense"),
+                FermionicOp([("+-I+-I", 1j), ("-+I-+I", -1j)], display_format="dense"),
+                FermionicOp([("+-I+I-", 1j), ("-+I-I+", -1j)], display_format="dense"),
+                FermionicOp([("+-II+-", 1j), ("-+II-+", -1j)], display_format="dense"),
+                FermionicOp([("+I-+-I", 1j), ("-I+-+I", -1j)], display_format="dense"),
+                FermionicOp([("+I-+I-", 1j), ("-I+-I+", -1j)], display_format="dense"),
+                FermionicOp([("+I-I+-", 1j), ("-I+I-+", -1j)], display_format="dense"),
+                FermionicOp([("I+-+-I", 1j), ("I-+-+I", -1j)], display_format="dense"),
+                FermionicOp([("I+-+I-", 1j), ("I-+-I+", -1j)], display_format="dense"),
+                FermionicOp([("I+-I+-", 1j), ("I-+I-+", -1j)], display_format="dense"),
+            ],
+        ),
+    )
+    def test_uccsd_ansatz_generalized(self, num_spin_orbitals, num_particles, expect):
+        """Tests the generalized UCCSD Ansatz."""
+        converter = QubitConverter(JordanWignerMapper())
+
+        ansatz = UCCSD(
+            qubit_converter=converter,
+            num_particles=num_particles,
+            num_spin_orbitals=num_spin_orbitals,
+            generalized=True,
+        )
+
+        assert_ucc_like_ansatz(self, ansatz, num_spin_orbitals, expect)

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -160,3 +160,19 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
             num_excitations, num_spin_orbitals, num_particles, alpha_spin=False
         )
         self.assertEqual(excitations, expect)
+
+    @unpack
+    @data(
+        (1, 4, [0, 0], [((0,), (1,)), ((2,), (3,))]),
+        (1, 4, [1, 0], [((0,), (1,)), ((2,), (3,))]),
+        (1, 4, [1, 1], [((0,), (1,)), ((2,), (3,))]),
+        (2, 4, [0, 0], [((0, 2), (1, 3))]),
+    )
+    def test_generalized_excitations(
+        self, num_excitations, num_spin_orbitals, num_particles, expect
+    ):
+        """Test generalized excitations."""
+        excitations = generate_fermionic_excitations(
+            num_excitations, num_spin_orbitals, num_particles, generalized=True
+        )
+        self.assertEqual(excitations, expect)

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -176,3 +176,28 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
             num_excitations, num_spin_orbitals, num_particles, generalized=True
         )
         self.assertEqual(excitations, expect)
+
+    @unpack
+    @data(
+        (1, 4, [1, 1], [((0,), (1,)), ((0,), (3,)), ((2,), (1,)), ((2,), (3,))]),
+        (2, 4, [1, 1], [((0, 2), (1, 3))]),
+        (
+            2,
+            6,
+            [1, 1],
+            [
+                ((0, 3), (1, 2)),
+                ((0, 3), (1, 4)),
+                ((0, 3), (1, 5)),
+                ((0, 3), (2, 4)),
+                ((0, 3), (2, 5)),
+                ((0, 3), (4, 5)),
+            ],
+        ),
+    )
+    def test_spin_flip_excitations(self, num_excitations, num_spin_orbitals, num_particles, expect):
+        """Test allowing spin-flipped excitations."""
+        excitations = generate_fermionic_excitations(
+            num_excitations, num_spin_orbitals, num_particles, spin_flip=True
+        )
+        self.assertEqual(excitations, expect)

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -195,9 +195,11 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
             ],
         ),
     )
-    def test_spin_flip_excitations(self, num_excitations, num_spin_orbitals, num_particles, expect):
+    def test_preserve_spin_excitations(
+        self, num_excitations, num_spin_orbitals, num_particles, expect
+    ):
         """Test allowing spin-flipped excitations."""
         excitations = generate_fermionic_excitations(
-            num_excitations, num_spin_orbitals, num_particles, spin_flip=True
+            num_excitations, num_spin_orbitals, num_particles, preserve_spin=False
         )
         self.assertEqual(excitations, expect)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds a new keyword argument to the fermionic excitation generator
method and the UCC class (and subclasses) which permits the use of
generalized excitations. Such excitation sets effectively ignore the
number of particles and instead permit all possible excitations between
all spin orbitals of a kind.

### Details and comments

A few weeks ago I was presented with a suggestion to support generalized fermionic excitations as proposed in this PR.
I never got around to opening an issue for this, hence this PR comes a little bit ouf of the blue..
