### PR TITLE
Move warning about skipping 2-qubit reduction

### DIFF
--- a/qiskit_nature/converters/second_quantization/qubit_converter.py
+++ b/qiskit_nature/converters/second_quantization/qubit_converter.py
@@ -316,16 +316,16 @@ class QubitConverter:
     ) -> PauliSumOp:
         reduced_op = qubit_op
 
-        if qubit_op.num_qubits <= 2:
-            logger.warning(
-                "The original qubit operator only contains %s qubits! Skipping the requested "
-                "two-qubit reduction!",
-                qubit_op.num_qubits,
-            )
-            return reduced_op
-
         if num_particles is not None:
             if self._two_qubit_reduction and self._mapper.allows_two_qubit_reduction:
+                if qubit_op.num_qubits <= 2:
+                    logger.warning(
+                        "The original qubit operator only contains %s qubits! Skipping the requested "
+                        "two-qubit reduction!",
+                        qubit_op.num_qubits,
+                    )
+                    return reduced_op
+
                 two_q_reducer = TwoQubitReduction(num_particles)
                 reduced_op = cast(PauliSumOp, two_q_reducer.convert(qubit_op))
 

--- a/test/converters/second_quantization/test_qubit_converter.py
+++ b/test/converters/second_quantization/test_qubit_converter.py
@@ -169,12 +169,13 @@ class TestQubitConverter(QiskitNatureTestCase):
 
         # Regression test against https://github.com/Qiskit/qiskit-nature/issues/271
         with self.subTest("Two qubit reduction skipped when operator too small"):
+            qubit_conv.two_qubit_reduction = True
             small_op = FermionicOp(
                 [("N_0", 1.0), ("E_1", 1.0)], register_length=2, display_format="sparse"
             )
             expected_op = 1.0 * (I ^ I) - 0.5 * (I ^ Z) + 0.5 * (Z ^ Z)
             with contextlib.redirect_stderr(io.StringIO()) as out:
-                qubit_op = qubit_conv.convert(small_op)
+                qubit_op = qubit_conv.convert(small_op, num_particles=self.num_particles)
             self.assertEqual(qubit_op, expected_op)
             self.assertTrue(
                 out.getvalue()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `QubitConverter` now warns about skipping the 2-qubit reduction only if the reduction is requested, if it is supported by the mapper and if the number of qubits is less than or equal to 2. 
Previously, the warning was shown in all cases where the number of qubits is less than or equal to 2.
I also updated the corresponding test.

### Details and comments
Fixes #404

