### PR TITLE
Bump Terra requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.18.0
+qiskit-terra>=0.19.0
 scipy>=1.4
 numpy>=1.17
 psutil>=5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The Terra 0.18 SparsePauliOp.table property was deprecated in Terra 0.19 and changed to SparsePauliOp.paulis.
Nature uses the new property now and needs Terra 0.19 to work,

### Details and comments


