### PR TITLE
Fix #434

### DIFF
--- a/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
+++ b/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
@@ -335,7 +335,12 @@ class ActiveSpaceTransformer(BaseTransformer):
                 )
             if max(self._active_orbitals) >= particle_number._num_spin_orbitals // 2:
                 raise QiskitNatureError("More orbitals requested than available.")
-            if sum(self._mo_occ_total[self._active_orbitals]) != self._num_electrons:
+            expected_num_electrons = (
+                self._num_electrons
+                if isinstance(self._num_electrons, int)
+                else sum(self._num_electrons)
+            )
+            if sum(self._mo_occ_total[self._active_orbitals]) != expected_num_electrons:
                 raise QiskitNatureError(
                     "The number of electrons in the selected active orbitals "
                     "does not match the specified number of active electrons."

--- a/releasenotes/notes/fix-active-space-transformer-non-singlet-manual-selection-d022bdbfaccc7e65.yaml
+++ b/releasenotes/notes/fix-active-space-transformer-non-singlet-manual-selection-d022bdbfaccc7e65.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the manual active orbital selection when specifying the active number
+    of electrons as a tuple rather than an integer.

--- a/test/transformers/second_quantization/electronic/test_active_space_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_active_space_transformer.py
@@ -320,6 +320,88 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
 
         self.assertDriverResult(driver_result_reduced, driver_result)
 
+    def test_tuple_num_electrons_with_manual_orbitals(self):
+        """Regression test against https://github.com/Qiskit/qiskit-nature/issues/434."""
+        driver = HDF5Driver(
+            hdf5_input=self.get_resource_path(
+                "H2_631g.hdf5", "transformers/second_quantization/electronic"
+            )
+        )
+        driver_result = driver.run()
+
+        trafo = ActiveSpaceTransformer(
+            num_electrons=(1, 1),
+            num_molecular_orbitals=2,
+            active_orbitals=[0, 1],
+        )
+        driver_result_reduced = trafo.transform(driver_result)
+
+        expected = ElectronicStructureDriverResult()
+        expected.add_property(
+            ElectronicEnergy(
+                [
+                    OneBodyElectronicIntegrals(
+                        ElectronicBasis.MO,
+                        (np.asarray([[-1.24943841, 0.0], [0.0, -0.547816138]]), None),
+                    ),
+                    TwoBodyElectronicIntegrals(
+                        ElectronicBasis.MO,
+                        (
+                            np.asarray(
+                                [
+                                    [
+                                        [[0.652098466, 0.0], [0.0, 0.433536565]],
+                                        [[0.0, 0.0794483182], [0.0794483182, 0.0]],
+                                    ],
+                                    [
+                                        [[0.0, 0.0794483182], [0.0794483182, 0.0]],
+                                        [[0.433536565, 0.0], [0.0, 0.385524695]],
+                                    ],
+                                ]
+                            ),
+                            None,
+                            None,
+                            None,
+                        ),
+                    ),
+                ],
+                energy_shift={"ActiveSpaceTransformer": 0.0},
+            )
+        )
+        expected.add_property(
+            ElectronicDipoleMoment(
+                [
+                    DipoleMoment(
+                        "x",
+                        [OneBodyElectronicIntegrals(ElectronicBasis.MO, (np.zeros((2, 2)), None))],
+                        shift={"ActiveSpaceTransformer": 0.0},
+                    ),
+                    DipoleMoment(
+                        "y",
+                        [OneBodyElectronicIntegrals(ElectronicBasis.MO, (np.zeros((2, 2)), None))],
+                        shift={"ActiveSpaceTransformer": 0.0},
+                    ),
+                    DipoleMoment(
+                        "z",
+                        [
+                            OneBodyElectronicIntegrals(
+                                ElectronicBasis.MO,
+                                (
+                                    np.asarray(
+                                        [[0.69447435, -1.01418298], [-1.01418298, 0.69447435]]
+                                    ),
+                                    None,
+                                ),
+                            )
+                        ],
+                        shift={"ActiveSpaceTransformer": 0.0},
+                    ),
+                ]
+            )
+        )
+
+        self.assertDriverResult(driver_result_reduced, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The manual orbital selection of the `ActiveSpaceTransformer` was broken
when specifying the number of active electrons as a tuple instead of an
integer. This commit fixes that.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #434 

### Details and comments

When specifying a non-singlet number of electrons (i.e. using a tuple for `num_electrons`) in combination with a manual active space selection, the transformer would not pass a self-imposed test. This PR fixes that.