### PR TITLE
Initialize ``Lattice``s from ``networkx.Graph``s

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -259,6 +259,7 @@ mol
 morse
 mpl
 mul
+multigraph
 multinomial
 mypy
 namelist
@@ -268,6 +269,7 @@ natom
 nd
 ndarray
 nelec
+networkx
 neuropeptide
 nicholas
 nielsen

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
@@ -15,11 +15,10 @@
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from typing import Callable, List, Optional, Sequence, Tuple, Union
+import numbers
 
 import numpy as np
 import networkx as nx
-import numbers
-
 from retworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
 from retworkx.visualization import mpl_draw
 

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
@@ -18,7 +18,11 @@ from typing import Callable, List, Optional, Sequence, Tuple, Union
 import numbers
 
 import numpy as np
-import networkx as nx
+try:
+    import networkx as nx
+    HAS_NX = True
+except ImportError:
+    HAS_NX = False
 from retworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
 from retworkx.visualization import mpl_draw
 
@@ -121,7 +125,7 @@ class Lattice:
             ValueError: If the input graph is a multigraph.
             ValueError: If the graph edges are non-numeric.
         """
-        if isinstance(graph, nx.Graph):
+        if HAS_NX and isinstance(graph, nx.Graph):
             graph = networkx_converter(graph)
 
         if graph.multigraph:
@@ -131,7 +135,7 @@ class Lattice:
             )
 
         # validate the edge weights
-        for edge_index, weight in enumerate(graph.edges()):
+        for edge_index, weight in graph.edge_index_map().items():
             if weight is None or weight == {}:
                 # None or {} is updated to be 1
                 graph.update_edge_by_index(edge_index, 1)

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
@@ -18,11 +18,14 @@ from typing import Callable, List, Optional, Sequence, Tuple, Union
 import numbers
 
 import numpy as np
+
 try:
     import networkx as nx
+
     HAS_NX = True
 except ImportError:
     HAS_NX = False
+
 from retworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
 from retworkx.visualization import mpl_draw
 
@@ -135,7 +138,8 @@ class Lattice:
             )
 
         # validate the edge weights
-        for edge_index, weight in graph.edge_index_map().items():
+        for edge_index, edge in graph.edge_index_map().items():
+            weight = edge[2]
             if weight is None or weight == {}:
                 # None or {} is updated to be 1
                 graph.update_edge_by_index(edge_index, 1)

--- a/releasenotes/notes/lattice-from-networkx-20c7c8119af77f36.yaml
+++ b/releasenotes/notes/lattice-from-networkx-20c7c8119af77f36.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Add the option to initialize a :class:`~qiskit_nature.problems.second_quantization.lattice.Lattice`
+    from a ``networkx.Graph`` object, which will be internally converted to a ``retworkx.PyGraph``
+    for performance. 
+
+    For example, you can now construct a lattice as
+
+    .. code-block:: python
+
+        import networkx as nx
+        from qiskit_nature.problems.second_quantization.lattice import Lattice
+
+        # 3-regular random graph on 6 nodes
+        graph = nx.generators.random_graphs.random_regular_graph(3, n=6)
+        lattice = Lattice(graph)

--- a/test/problems/second_quantization/lattice/lattices/test_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_lattice.py
@@ -158,3 +158,20 @@ class TestLattice(QiskitNatureTestCase):
 
         with self.assertRaises(ValueError):
             _ = Lattice(graph)
+
+    def test_edges_removed(self):
+        """Test the initialization with a graph where edges have been removed."""
+        graph = PyGraph(multigraph=False)
+        graph.add_nodes_from(range(3))
+        graph.add_edges_from([(0, 1, 1), (1, 2, 1)])
+        graph.remove_edge_from_index(0)
+
+        lattice = Lattice(graph)
+
+        target_graph = PyGraph(multigraph=False)
+        target_graph.add_nodes_from(range(3))
+        target_graph.add_edges_from([(1, 2, 1)])
+
+        self.assertTrue(
+            is_isomorphic(lattice.graph, target_graph, edge_matcher=lambda x, y: x == y)
+        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #465: Support the initialization of lattices from networkx graphs. 
Fixes #466: Allow only numerical values for edge weights.

### Details and comments

Now we can for instance construct lattices as
```python
import networkx as nx
from qiskit_nature.problems.second_quantization.lattice import Lattice
# 3-regular random graph on 6 nodes
graph = nx.generators.random_graphs.random_regular_graph(3, n=6)
lattice = Lattice(graph)
```
