### PR TITLE
Fix occupation computation of non-singlet states

### DIFF
--- a/qiskit_nature/properties/second_quantization/electronic/particle_number.py
+++ b/qiskit_nature/properties/second_quantization/electronic/particle_number.py
@@ -78,8 +78,8 @@ class ParticleNumber(ElectronicProperty):
             self._occupation_beta = [1.0 for _ in range(self._num_beta)]
             self._occupation_beta += [0.0] * (num_spin_orbitals // 2 - len(self._occupation_beta))
         elif occupation_beta is None:
-            self._occupation_alpha = [o / 2.0 for o in occupation]
-            self._occupation_beta = [o / 2.0 for o in occupation]
+            self._occupation_alpha = [np.ceil(o / 2) for o in occupation]
+            self._occupation_beta = [np.floor(o / 2) for o in occupation]
         else:
             self._occupation_alpha = occupation  # type: ignore
             self._occupation_beta = occupation_beta  # type: ignore

--- a/releasenotes/notes/fix-non-singlet-occupation-computation-f2ff44b144b53732.yaml
+++ b/releasenotes/notes/fix-non-singlet-occupation-computation-f2ff44b144b53732.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the computation of the spin orbital occupation in a non-singlet state.
+    Previously, a singly occupied MO would result in SO occupations of `0.5` for each spin.
+    Now, the alpha SO will be fully occupied and the beta SO unoccupied.

--- a/test/properties/second_quantization/electronic/test_particle_number.py
+++ b/test/properties/second_quantization/electronic/test_particle_number.py
@@ -15,6 +15,8 @@
 import warnings
 from test import QiskitNatureTestCase
 
+import numpy as np
+
 from qiskit_nature.drivers import QMolecule
 from qiskit_nature.properties.second_quantization.electronic import ParticleNumber
 
@@ -48,3 +50,9 @@ class TestParticleNumber(QiskitNatureTestCase):
             "+_7 -_7",
         ]
         self.assertEqual([l for l, _ in ops[0].to_list()], expected)
+
+    def test_non_singlet_occupation(self):
+        """Regression test against occupation computation of non-singlet state."""
+        prop = ParticleNumber(4, (2, 1), [2.0, 1.0])
+        self.assertTrue(np.allclose(prop.occupation_alpha, [1.0, 1.0]))
+        self.assertTrue(np.allclose(prop.occupation_beta, [1.0, 0.0]))


### PR DESCRIPTION
Prior to this fix, the `ParticleNumber` property would incorrectly
compute the alpha and beta occupations:
```python
    prop = ParticleNumber(4, (2, 1), [2.0, 1.0])
    # >>> [1.0, 0.5]
    print(prop.occupation_alpha)
    # >>> [1.0, 0.5]
    print(prop.occupation_beta)
```

After this fix, the computation is corrected to return:
```python
    prop = ParticleNumber(4, (2, 1), [2.0, 1.0])
    # >>> [1.0, 1.0]
    print(prop.occupation_alpha)
    # >>> [1.0, 0.0]
    print(prop.occupation_beta)
```
