### PR TITLE
Revert "Pin sphinxcontrib-spelling due to bug on latest version (#486)"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ Sphinx>=1.8.3,!=3.1.0
 sphinx-panels
 sphinx-gallery
 sphinx-autodoc-typehints
-sphinxcontrib-spelling<7.3.1
+sphinxcontrib-spelling!=7.3.1
 jupyter-sphinx
 discover
 qiskit-aer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The release of sphinxcontrib-spelling 7.3.2 fixed the bug on 7.3.1.
Avoid 7.3.1 in requirements-dev.txt

### Details and comments


