### PR TITLE
Fix copyright

### DIFF
--- a/qiskit_nature/properties/second_quantization/electronic/particle_number.py
+++ b/qiskit_nature/properties/second_quantization/electronic/particle_number.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/properties/second_quantization/electronic/test_particle_number.py
+++ b/test/properties/second_quantization/electronic/test_particle_number.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Merging a PR from 2021 resulted in the copyright checks only starting to fail now because during PR review the file modification dates were still from 2021. However, through the merge in 2022 these modifications dates or now in 2022, causing the copyright CI check to fail on `main`.

### Details and comments


