### PR TITLE
Pylint: enabled useless suppression warning

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -47,7 +47,7 @@ confidence=
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-#enable=
+enable=useless-suppression
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this

--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -400,7 +400,6 @@ class QEOM(ExcitedStatesSolver):
             )
 
         # these matrices are numpy arrays and therefore have the ``shape`` attribute
-        # pylint: disable=unsubscriptable-object
         q_mat = q_mat + q_mat.T - np.identity(q_mat.shape[0]) * q_mat
         w_mat = w_mat + w_mat.T - np.identity(w_mat.shape[0]) * w_mat
         m_mat = m_mat + m_mat.T - np.identity(m_mat.shape[0]) * m_mat
@@ -442,7 +441,6 @@ class QEOM(ExcitedStatesSolver):
         logger.debug("Diagonalizing qeom matrices for excited states...")
         a_mat = np.matrixlib.bmat([[m_mat, q_mat], [q_mat.T.conj(), m_mat.T.conj()]])
         b_mat = np.matrixlib.bmat([[v_mat, w_mat], [-w_mat.T.conj(), -v_mat.T.conj()]])
-        # pylint: disable=too-many-function-args
         res = linalg.eig(a_mat, b_mat)
         # convert nan value into 0
         res[0][np.where(np.isnan(res[0]))] = 0.0

--- a/qiskit_nature/circuit/library/ansatzes/chc.py
+++ b/qiskit_nature/circuit/library/ansatzes/chc.py
@@ -215,7 +215,7 @@ class CHC(BlueprintCircuit):
                     i = occ[0]
                     r = unocc[0]
                     j = occ[1]
-                    s = unocc[1]  # pylint: disable=locally-disabled, invalid-name
+                    s = unocc[1]  # pylint: disable=invalid-name
 
                     self.sdg(q[r])
 

--- a/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
+++ b/qiskit_nature/drivers/bosonic_bases/harmonic_basis.py
@@ -241,7 +241,7 @@ class HarmonicBasis(BosonicBasis):
                                     index_dict[modes[1]],
                                     kinetic_term=kinetic_term,
                                 )
-                                # pylint: disable=locally-disabled, invalid-name
+                                # pylint: disable=invalid-name
                                 for p in range(num_modals):
                                     for q in range(p + 1):
                                         coeff = coeff2 * self._harmonic_integrals(

--- a/qiskit_nature/drivers/fcidumpd/dumper.py
+++ b/qiskit_nature/drivers/fcidumpd/dumper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/fcidumpd/dumper.py
+++ b/qiskit_nature/drivers/fcidumpd/dumper.py
@@ -28,7 +28,6 @@ def dump(
     orbsym: Optional[List[str]] = None,
     isym: int = 1,
 ) -> None:
-    # pylint: disable=wrong-spelling-in-docstring
     """Generates a FCIDump output.
 
     Args:
@@ -100,7 +99,6 @@ def _dump_2e_ints(
     for b in range(beta):
         idx_offsets[1 - b] += len(mos)
     hijkl_elements = set()
-    # pylint: disable=invalid-name
     for elem in itertools.product(mos, repeat=4):
         if np.isclose(hijkl[elem], 0.0, atol=1e-14):
             continue

--- a/qiskit_nature/drivers/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/fcidumpd/parser.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/fcidumpd/parser.py
@@ -21,7 +21,6 @@ from qiskit_nature import QiskitNatureError
 
 
 def parse(fcidump: str) -> Dict[str, Any]:
-    # pylint: disable=wrong-spelling-in-comment
     """Parses a FCIDump output.
 
     Args:
@@ -127,7 +126,7 @@ def parse(fcidump: str) -> Dict[str, Any]:
         x = float(orbital.split()[0])
         # Note: differing naming than ijkl due to E741 and this iajb is inline with this:
         # https://hande.readthedocs.io/en/latest/manual/integrals.html#fcidump-format
-        i, a, j, b = [int(i) for i in orbital.split()[1:]]  # pylint: disable=invalid-name
+        i, a, j, b = [int(i) for i in orbital.split()[1:]]
         if i == a == j == b == 0:
             output["ecore"] = x
         elif a == j == b == 0:
@@ -214,7 +213,6 @@ def _permute_1e_ints(
 def _permute_2e_ints(
     hijkl: np.ndarray, elements: Set[Tuple[int, ...]], norb: int, beta: int = 0
 ) -> None:
-    # pylint: disable=wrong-spelling-in-comment
     for elem in elements.copy():
         shifted = tuple(e - ((e >= norb) * norb) for e in elem)
         # initially look for "transposed" element if spins are equal

--- a/qiskit_nature/drivers/pyquanted/integrals.py
+++ b/qiskit_nature/drivers/pyquanted/integrals.py
@@ -160,14 +160,14 @@ def _parse_molecule(val, units, charge, multiplicity):
     val = _check_molecule_format(val)
 
     parts = [x.strip() for x in val.split(";")]
-    if parts is None or len(parts) < 1:  # pylint: disable=len-as-condition
+    if parts is None or len(parts) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
     geom = []
     for n, _ in enumerate(parts):
         part = parts[n]
         geom.append(_parse_atom(part))
 
-    if len(geom) < 1:  # pylint: disable=len-as-condition
+    if len(geom) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
 
     try:
@@ -184,7 +184,7 @@ def _parse_molecule(val, units, charge, multiplicity):
 def _check_molecule_format(val):
     """If it seems to be zmatrix rather than xyz format we convert before returning"""
     atoms = [x.strip() for x in val.split(";")]
-    if atoms is None or len(atoms) < 1:  # pylint: disable=len-as-condition
+    if atoms is None or len(atoms) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
 
     # An xyz format has 4 parts in each atom, if not then do zmatrix convert
@@ -216,7 +216,7 @@ def _check_molecule_format(val):
 
 
 def _parse_atom(val):
-    if val is None or len(val) < 1:  # pylint: disable=len-as-condition
+    if val is None or len(val) < 1:
         raise QiskitNatureError("Molecule atom format error: empty")
 
     parts = re.split(r"\s+", val)

--- a/qiskit_nature/drivers/pyquanted/integrals.py
+++ b/qiskit_nature/drivers/pyquanted/integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/pyquanted/pyquantedriver.py
+++ b/qiskit_nature/drivers/pyquanted/pyquantedriver.py
@@ -116,7 +116,7 @@ class PyQuanteDriver(FermionicDriver):
             spec = importlib.util.find_spec("pyquante2")
             if spec is not None:
                 return
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             logger.debug("PyQuante2 check error %s", str(ex))
             raise QiskitNatureError(err_msg) from ex
 

--- a/qiskit_nature/drivers/pyquanted/pyquantedriver.py
+++ b/qiskit_nature/drivers/pyquanted/pyquantedriver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/pyscfd/integrals.py
+++ b/qiskit_nature/drivers/pyscfd/integrals.py
@@ -95,7 +95,7 @@ def compute_integrals(
 def _check_molecule_format(val):
     """If it seems to be zmatrix rather than xyz format we convert before returning"""
     atoms = [x.strip() for x in val.split(";")]
-    if atoms is None or len(atoms) < 1:  # pylint: disable=len-as-condition
+    if atoms is None or len(atoms) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
 
     # An xyz format has 4 parts in each atom, if not then do zmatrix convert

--- a/qiskit_nature/drivers/pyscfd/integrals.py
+++ b/qiskit_nature/drivers/pyscfd/integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/pyscfd/pyscfdriver.py
+++ b/qiskit_nature/drivers/pyscfd/pyscfdriver.py
@@ -147,7 +147,7 @@ class PySCFDriver(FermionicDriver):
             spec = importlib.util.find_spec("pyscf")
             if spec is not None:
                 return
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             logger.debug("PySCF check error %s", str(ex))
             raise MissingOptionalLibraryError(
                 libname="PySCF",

--- a/qiskit_nature/drivers/pyscfd/pyscfdriver.py
+++ b/qiskit_nature/drivers/pyscfd/pyscfdriver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/qmolecule.py
+++ b/qiskit_nature/drivers/qmolecule.py
@@ -618,7 +618,6 @@ class QMolecule:
         return moh2_qubit
 
     symbols = [
-        # pylint: disable=bad-option-value,bad-whitespace
         "_",
         "H",
         "He",

--- a/qiskit_nature/drivers/qmolecule.py
+++ b/qiskit_nature/drivers/qmolecule.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/dumper.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/dumper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/dumper.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/dumper.py
@@ -28,7 +28,6 @@ def dump(
     orbsym: Optional[List[str]] = None,
     isym: int = 1,
 ) -> None:
-    # pylint: disable=wrong-spelling-in-docstring
     """Generates a FCIDump output.
 
     Args:
@@ -100,7 +99,6 @@ def _dump_2e_ints(
     for b in range(beta):
         idx_offsets[1 - b] += len(mos)
     hijkl_elements = set()
-    # pylint: disable=invalid-name
     for elem in itertools.product(mos, repeat=4):
         if np.isclose(hijkl[elem], 0.0, atol=1e-14):
             continue

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/fcidumpdriver.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/fcidumpdriver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/fcidumpdriver.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/fcidumpdriver.py
@@ -85,10 +85,6 @@ class FCIDumpDriver(ElectronicStructureDriver):
             nuclear_repulsion_energy=fcidump_data.get("ecore", None),
         )
 
-        # NOTE: under Python 3.6, pylint appears to be unable to properly identify this case of
-        # nested abstract classes (cf. https://github.com/Qiskit/qiskit-nature/runs/3245395353).
-        # However, since the tests pass I am adding an exception for this specific case.
-        # pylint: disable=abstract-class-instantiated
         driver_result = ElectronicStructureDriverResult()
         driver_result.add_property(electronic_energy)
         driver_result.add_property(particle_number)

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/parser.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/fcidumpd/parser.py
+++ b/qiskit_nature/drivers/second_quantization/fcidumpd/parser.py
@@ -21,7 +21,6 @@ from qiskit_nature import QiskitNatureError
 
 
 def parse(fcidump: str) -> Dict[str, Any]:
-    # pylint: disable=wrong-spelling-in-comment
     """Parses a FCIDump output.
 
     Args:
@@ -127,7 +126,7 @@ def parse(fcidump: str) -> Dict[str, Any]:
         x = float(orbital.split()[0])
         # Note: differing naming than ijkl due to E741 and this iajb is inline with this:
         # https://hande.readthedocs.io/en/latest/manual/integrals.html#fcidump-format
-        i, a, j, b = [int(i) for i in orbital.split()[1:]]  # pylint: disable=invalid-name
+        i, a, j, b = [int(i) for i in orbital.split()[1:]]
         if i == a == j == b == 0:
             output["ecore"] = x
         elif a == j == b == 0:
@@ -214,7 +213,6 @@ def _permute_1e_ints(
 def _permute_2e_ints(
     hijkl: np.ndarray, elements: Set[Tuple[int, ...]], norb: int, beta: int = 0
 ) -> None:
-    # pylint: disable=wrong-spelling-in-comment
     for elem in elements.copy():
         shifted = tuple(e - ((e >= norb) * norb) for e in elem)
         # initially look for "transposed" element if spins are equal

--- a/qiskit_nature/drivers/second_quantization/pyquanted/integrals.py
+++ b/qiskit_nature/drivers/second_quantization/pyquanted/integrals.py
@@ -163,14 +163,14 @@ def _parse_molecule(val, units, charge, multiplicity):
     val = _check_molecule_format(val)
 
     parts = [x.strip() for x in val.split(";")]
-    if parts is None or len(parts) < 1:  # pylint: disable=len-as-condition
+    if parts is None or len(parts) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
     geom = []
     for n, _ in enumerate(parts):
         part = parts[n]
         geom.append(_parse_atom(part))
 
-    if len(geom) < 1:  # pylint: disable=len-as-condition
+    if len(geom) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
 
     try:
@@ -187,7 +187,7 @@ def _parse_molecule(val, units, charge, multiplicity):
 def _check_molecule_format(val):
     """If it seems to be zmatrix rather than xyz format we convert before returning"""
     atoms = [x.strip() for x in val.split(";")]
-    if atoms is None or len(atoms) < 1:  # pylint: disable=len-as-condition
+    if atoms is None or len(atoms) < 1:
         raise QiskitNatureError("Molecule format error: " + val)
 
     # An xyz format has 4 parts in each atom, if not then do zmatrix convert
@@ -219,7 +219,7 @@ def _check_molecule_format(val):
 
 
 def _parse_atom(val):
-    if val is None or len(val) < 1:  # pylint: disable=len-as-condition
+    if val is None or len(val) < 1:
         raise QiskitNatureError("Molecule atom format error: empty")
 
     parts = re.split(r"\s+", val)

--- a/qiskit_nature/drivers/second_quantization/pyquanted/integrals.py
+++ b/qiskit_nature/drivers/second_quantization/pyquanted/integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/pyquanted/pyquantedriver.py
+++ b/qiskit_nature/drivers/second_quantization/pyquanted/pyquantedriver.py
@@ -191,7 +191,7 @@ class PyQuanteDriver(ElectronicStructureDriver):
             spec = importlib.util.find_spec("pyquante2")
             if spec is not None:
                 return
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             logger.debug("PyQuante2 check error %s", str(ex))
             raise MissingOptionalLibraryError(
                 libname="PyQuante2",

--- a/qiskit_nature/drivers/second_quantization/pyquanted/pyquantedriver.py
+++ b/qiskit_nature/drivers/second_quantization/pyquanted/pyquantedriver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/drivers/second_quantization/pyscfd/pyscfdriver.py
+++ b/qiskit_nature/drivers/second_quantization/pyscfd/pyscfdriver.py
@@ -367,7 +367,7 @@ class PySCFDriver(ElectronicStructureDriver):
             spec = importlib.util.find_spec("pyscf")
             if spec is not None:
                 return
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             logger.debug("PySCF check error %s", str(ex))
             raise MissingOptionalLibraryError(
                 libname="PySCF",
@@ -472,7 +472,7 @@ class PySCFDriver(ElectronicStructureDriver):
             The coordinates in XYZ format.
         """
         atoms = [x.strip() for x in val.split(";")]
-        if atoms is None or len(atoms) < 1:  # pylint: disable=len-as-condition
+        if atoms is None or len(atoms) < 1:
             raise QiskitNatureError("Molecule format error: " + val)
 
         # An xyz format has 4 parts in each atom, if not then do zmatrix convert
@@ -531,10 +531,6 @@ class PySCFDriver(ElectronicStructureDriver):
             )
 
     def _construct_driver_result(self) -> ElectronicStructureDriverResult:
-        # NOTE: under Python 3.6, pylint appears to be unable to properly identify this case of
-        # nested abstract classes (cf. https://github.com/Qiskit/qiskit-nature/runs/3245395353).
-        # However, since the tests pass I am adding an exception for this specific case.
-        # pylint: disable=abstract-class-instantiated
         driver_result = ElectronicStructureDriverResult()
 
         self._populate_driver_result_molecule(driver_result)

--- a/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
@@ -102,7 +102,6 @@ class BravyiKitaevMapper(FermionicMapper):  # pylint: disable=missing-class-docs
         pauli_table = []
         # FIND BINARY SUPERSET SIZE
         bin_sup = 1
-        # pylint: disable=comparison-with-callable
         while nmodes > np.power(2, bin_sup):
             bin_sup += 1
         # DEFINE INDEX SETS FOR EVERY FERMIONIC MODE

--- a/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/bravyi_kitaev_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/problems/sampling/protein_folding/bead_distances/distance_map_builder.py
+++ b/qiskit_nature/problems/sampling/protein_folding/bead_distances/distance_map_builder.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/problems/sampling/protein_folding/bead_distances/distance_map_builder.py
+++ b/qiskit_nature/problems/sampling/protein_folding/bead_distances/distance_map_builder.py
@@ -108,7 +108,6 @@ class DistanceMapBuilder:
         return _fix_qubits(distance)
 
     def _calc_distances_main_chain(self, peptide: Peptide) -> None:
-        # pylint:disable=anomalous-backslash-in-string
         r"""
         Calculates distance between beads based on the number of turns in
         the main chain. Note, here we consider distances between beads

--- a/qiskit_nature/properties/second_quantization/electronic/bases/electronic_basis.py
+++ b/qiskit_nature/properties/second_quantization/electronic/bases/electronic_basis.py
@@ -25,7 +25,6 @@ class ElectronicBasis(Enum):
     :class:`~qiskit_nature.operators.second_quantization.SecondQuantizedOp`.
     """
 
-    # pylint: disable=invalid-name
     AO = "atomic"
     MO = "molecular"
     SO = "spin"

--- a/qiskit_nature/properties/second_quantization/electronic/bases/electronic_basis.py
+++ b/qiskit_nature/properties/second_quantization/electronic/bases/electronic_basis.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/transformers/second_quantization/electronic/freeze_core_transformer.py
+++ b/qiskit_nature/transformers/second_quantization/electronic/freeze_core_transformer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/transformers/second_quantization/electronic/freeze_core_transformer.py
+++ b/qiskit_nature/transformers/second_quantization/electronic/freeze_core_transformer.py
@@ -131,7 +131,7 @@ class FreezeCoreTransformer(ActiveSpaceTransformer):
         return self.periodic_table.index(atom.lower().capitalize())
 
     periodic_table = [
-        # pylint: disable=bad-option-value,bad-whitespace,line-too-long
+        # pylint: disable=line-too-long
         # fmt: off
         "_",
          "H", "He",

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -169,7 +169,6 @@ class TestAdaptVQE(QiskitNatureTestCase):
                 # Here, we can create essentially any custom excitation pool.
                 # For testing purposes only, we simply select some hopping operator already
                 # available in the ansatz object.
-                # pylint: disable=no-member
                 custom_excitation_pool = [solver.ansatz.operators[2]]
                 solver.ansatz.operators = custom_excitation_pool
                 return solver

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -314,11 +314,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         """Regression tests against https://github.com/Qiskit/qiskit-nature/issues/53."""
         try:
             # pylint: disable=import-outside-toplevel
-            # pylint: disable=unused-import
             from qiskit import Aer
 
             backend = Aer.get_backend("aer_simulator")
-        except ImportError as ex:  # pylint: disable=broad-except
+        except ImportError as ex:
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
@@ -406,7 +405,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             from qiskit import Aer
 
             backend = Aer.get_backend("aer_simulator_statevector")
-        except ImportError as ex:  # pylint: disable=broad-except
+        except ImportError as ex:
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
@@ -432,7 +431,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             from qiskit import Aer
 
             backend = Aer.get_backend("aer_simulator")
-        except ImportError as ex:  # pylint: disable=broad-except
+        except ImportError as ex:
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
@@ -463,7 +462,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             from qiskit import Aer
 
             backend = Aer.get_backend("aer_simulator")
-        except ImportError as ex:  # pylint: disable=broad-except
+        except ImportError as ex:
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -34,11 +34,10 @@ class TestReadmeSample(QiskitNatureTestCase):
 
         try:
             # pylint: disable=import-outside-toplevel
-            # pylint: disable=unused-import
             from qiskit import Aer
 
             _ = Aer.get_backend("aer_simulator_statevector")
-        except ImportError as ex:  # pylint: disable=broad-except
+        except ImportError as ex:
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 

--- a/test/transformers/second_quantization/electronic/test_active_space_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_active_space_transformer.py
@@ -35,8 +35,6 @@ from qiskit_nature.properties.second_quantization.electronic.integrals import (
 from qiskit_nature.transformers.second_quantization.electronic import ActiveSpaceTransformer
 
 
-# With Python 3.6 this false positive is being raised for the ElectronicStructureDriverResult
-# pylint: disable=abstract-class-instantiated
 @ddt
 class TestActiveSpaceTransformer(QiskitNatureTestCase):
     """ActiveSpaceTransformer tests."""

--- a/test/transformers/second_quantization/electronic/test_active_space_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_active_space_transformer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
@@ -21,8 +21,6 @@ from qiskit_nature.drivers.second_quantization import HDF5Driver
 from qiskit_nature.transformers.second_quantization.electronic import FreezeCoreTransformer
 
 
-# With Python 3.6 this false positive is being raised for the ElectronicStructureDriverResult
-# pylint: disable=abstract-class-instantiated
 @ddt
 class TestFreezeCoreTransformer(QiskitNatureTestCase):
     """FreezeCoreTransformer tests."""

--- a/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This will log warnings when unused `# pylint: disable=...` comments are encountered enabling us to remove clutter of these comments.
This is equivalent to mypy's `warn_unused_configs` which was enabled in commit 205a3174.


### Details and comments


