### PR TITLE
Revert #176

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -26,7 +26,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
 sys.path.append(os.path.abspath("."))
 
 """


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This reverts the manual insertion of the Qiskit Nature source path into
`sys.path` during documentation generation. This change no longer
appears to be necessary and therefore poses an unnecessary risk by
manipulating `sys.path` at runtime.

### Details and comments

The motivation for rechecking whether #176 is really needed came from the fact that https://github.com/Qiskit/qiskit-terra/pull/6379 was just closed due to the above concerns. I am not entirely sure what has changed in the meantime (could be anything from my virtual environment setup over tox to sphinx) but the important part is that this specific aspect is no longer needed.

Since #176 Qiskit Nature has added `custom_directives` rendering the other lines necessary. See #191 for more details.
