### PR TITLE
Apply `simplify` more often in `QubitMapper.mode_based_mapping`

### DIFF
--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -141,7 +141,9 @@ class QubitMapper(ABC):
                     raise QiskitNatureError(
                         f"FermionicOp label included '{char}'. Allowed characters: I, N, E, +, -"
                     )
-                ret_op = ret_op.simplify()
+                if ret_op.size >= 100:
+                    # `simplify` pays off only if there are many Pauli strings
+                    ret_op = ret_op.simplify()
             ret_op_list.append(ret_op)
 
         return PauliSumOp(SparsePauliOp.sum(ret_op_list).simplify())

--- a/qiskit_nature/mappers/second_quantization/qubit_mapper.py
+++ b/qiskit_nature/mappers/second_quantization/qubit_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -141,6 +141,7 @@ class QubitMapper(ABC):
                     raise QiskitNatureError(
                         f"FermionicOp label included '{char}'. Allowed characters: I, N, E, +, -"
                     )
+                ret_op = ret_op.simplify()
             ret_op_list.append(ret_op)
 
         return PauliSumOp(SparsePauliOp.sum(ret_op_list).simplify())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This workaround can resolve the issue #545.
But it may get slower for other cases because it applies `simplify` too many times.

Update:
I added a threshold of number of Pauli strings to apply `simplify`.
`simplify` pays off only if there are many Pauli strings.

Fixes #545

### Details and comments


