### PR TITLE
Revert "Temporarily skip broken tests (#527)"

### DIFF
--- a/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -87,10 +87,6 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
     def test_vqe_mes_jw_auto(self):
         """Test VQEUCCSDFactory with QEOM + Jordan Wigner mapping + auto symmetry"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         converter = QubitConverter(JordanWignerMapper(), z2symmetry_reduction="auto")
         self._solve_with_vqe_mes(converter)
 
@@ -101,28 +97,16 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
     def test_vqe_mes_parity_2q(self):
         """Test VQEUCCSDFactory with QEOM + Parity mapping + reduction"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)
         self._solve_with_vqe_mes(converter)
 
     def test_vqe_mes_parity_auto(self):
         """Test VQEUCCSDFactory with QEOM + Parity mapping + auto symmetry"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         converter = QubitConverter(ParityMapper(), z2symmetry_reduction="auto")
         self._solve_with_vqe_mes(converter)
 
     def test_vqe_mes_parity_2q_auto(self):
         """Test VQEUCCSDFactory with QEOM + Parity mapping + reduction + auto symmetry"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         converter = QubitConverter(
             ParityMapper(), two_qubit_reduction=True, z2symmetry_reduction="auto"
         )
@@ -135,10 +119,6 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
     def test_vqe_mes_bk_auto(self):
         """Test VQEUCCSDFactory with QEOM + Bravyi-Kitaev mapping + auto symmetry"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         converter = QubitConverter(BravyiKitaevMapper(), z2symmetry_reduction="auto")
         self._solve_with_vqe_mes(converter)
 

--- a/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2022.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -87,10 +87,6 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
     @slow_test
     def test_uccsd_hf_qpUCCD(self):
         """paired uccd test"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         optimizer = SLSQP(maxiter=100)
 
         initial_state = HartreeFock(
@@ -119,10 +115,6 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
     @slow_test
     def test_uccsd_hf_qUCCD0(self):
         """singlet uccd test"""
-        self.skipTest(
-            "Temporarily skip test until the changes done by "
-            "https://github.com/Qiskit/qiskit-terra/pull/7551 are handled properly."
-        )
         optimizer = SLSQP(maxiter=100)
 
         initial_state = HartreeFock(

--- a/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Now that Qiskit/qiskit-terra#7598 is merged, we can again enable the tests relying on Z2 symmetries which were temporarily skipped in #527.

### Details and comments


