### PR TITLE
fix: catch DriverMetadata-related warnings during transform

### DIFF
--- a/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
+++ b/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
@@ -25,6 +25,7 @@ from qiskit_nature.properties.second_quantization import (
     SecondQuantizedProperty,
     GroupedSecondQuantizedProperty,
 )
+from qiskit_nature.properties.second_quantization.driver_metadata import DriverMetadata
 from qiskit_nature.properties.second_quantization.electronic import ParticleNumber
 from qiskit_nature.properties.second_quantization.electronic.bases import (
     ElectronicBasis,
@@ -424,6 +425,11 @@ class ActiveSpaceTransformer(BaseTransformer):
 
         elif isinstance(prop, ElectronicBasisTransform):
             # transformation done manually during `transform`
+            transformed_property = prop
+
+        elif isinstance(prop, DriverMetadata):
+            # for the time being we manually catch this to avoid unnecessary warnings
+            # TODO: support storing transformer information in the DriverMetadata container
             transformed_property = prop
 
         else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The DriverMetadata property currently raises a lot of errors when being
transformed. Since this part of the normal stack this should be avoided.
For the time being, we simply catch the case and pass the DriverMetadata
object down to the transformed grouped property unchanged. However, in
the future we could envision storing additional information about the
transformer in the DriverMetadata container.


### Details and comments

EDIT: #574 outlines how this can be improved upon in the future