### PR TITLE
Change unit tests to use the new dict. based aux. operators

### DIFF
--- a/qiskit_nature/drivers/second_quantization/gaussiand/gaussian_log_result.py
+++ b/qiskit_nature/drivers/second_quantization/gaussiand/gaussian_log_result.py
@@ -268,7 +268,7 @@ class GaussianLogResult:
         "0.4.0",
         DeprecatedType.METHOD,
         "get_vibrational_energy",
-        "Construct a VibrationalEnergy instead of the deprecated WatsonHamiltonian directly.",
+        "Construct a VibrationalEnergy instead of the deprecated WatsonHamiltonian directly",
     )
     def get_watson_hamiltonian(self, normalize: bool = True) -> WatsonHamiltonian:
         """

--- a/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -136,7 +136,7 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
         # pylint: disable=unused-argument
         def filter_criterion(eigenstate, eigenvalue, aux_values):
-            return np.isclose(aux_values[0][0], 2.0)
+            return np.isclose(aux_values["ParticleNumber"][0], 2.0)
 
         solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
         esc = ExcitedStatesEigensolver(self.qubit_converter, solver)

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -111,12 +111,16 @@ class TestAdaptVQE(QiskitNatureTestCase):
         modes = 4
         h_1 = np.eye(modes, dtype=complex)
         h_2 = np.zeros((modes, modes, modes, modes))
-        aux_ops = ElectronicEnergy(
-            [
-                OneBodyElectronicIntegrals(ElectronicBasis.MO, (h_1, None)),
-                TwoBodyElectronicIntegrals(ElectronicBasis.MO, (h_2, None, None, None)),
-            ]
-        ).second_q_ops()
+        aux_ops = list(
+            ElectronicEnergy(
+                [
+                    OneBodyElectronicIntegrals(ElectronicBasis.MO, (h_1, None)),
+                    TwoBodyElectronicIntegrals(ElectronicBasis.MO, (h_2, None, None, None)),
+                ]
+            )
+            .second_q_ops()
+            .values()
+        )
         aux_ops_copy = copy.deepcopy(aux_ops)
 
         _ = calc.solve(self.problem)

--- a/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -31,7 +31,6 @@ from qiskit_nature.problems.second_quantization import ElectronicStructureProble
 from qiskit_nature.transformers.second_quantization.electronic import FreezeCoreTransformer
 import qiskit_nature.optionals as _optionals
 
-
 # pylint: disable=invalid-name
 
 
@@ -55,7 +54,10 @@ class TestUCCSDHartreeFock(QiskitNatureTestCase):
         # because we create the initial state and ansatzes early, we need to ensure the qubit
         # converter already ran such that convert_match works as expected
         _ = self.qubit_converter.convert(
-            self.electronic_structure_problem.second_q_ops()[0], self.num_particles
+            self.electronic_structure_problem.second_q_ops()[
+                self.electronic_structure_problem.main_property_name
+            ],
+            self.num_particles,
         )
 
         self.reference_energy_pUCCD = -1.1434447924298028

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -190,9 +190,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         # now we decide that we want to evaluate another operator
         # for testing simplicity, we just use some pre-constructed auxiliary operators
         second_q_ops = self.electronic_structure_problem.second_q_ops()
-        aux_ops_dict = {}
-        for key, value in second_q_ops.items():
-            aux_ops_dict[key] = self.qubit_converter.convert_match(value)
+        # Remove main op to leave just aux ops
+        second_q_ops.pop(self.electronic_structure_problem.main_property_name)
+        aux_ops_dict = self.qubit_converter.convert_match(second_q_ops)
         return calc, res, aux_ops_dict
 
     def test_eval_op_single(self):

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -30,7 +30,6 @@ from qiskit.opflow import AerPauliExpectation, PauliExpectation
 from qiskit.test import slow_test
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
 
-from qiskit_nature import settings
 from qiskit_nature.algorithms import (
     GroundStateEigensolver,
     VQEUCCFactory,
@@ -48,6 +47,7 @@ from qiskit_nature.properties.second_quantization.electronic.integrals import (
     TwoBodyElectronicIntegrals,
 )
 from qiskit_nature.transformers.second_quantization.electronic import FreezeCoreTransformer
+from qiskit_nature import settings
 
 
 class TestGroundStateEigensolver(QiskitNatureTestCase):
@@ -129,12 +129,16 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         modes = 4
         h_1 = np.eye(modes, dtype=complex)
         h_2 = np.zeros((modes, modes, modes, modes))
-        aux_ops = ElectronicEnergy(
-            [
-                OneBodyElectronicIntegrals(ElectronicBasis.MO, (h_1, None)),
-                TwoBodyElectronicIntegrals(ElectronicBasis.MO, (h_2, None, None, None)),
-            ],
-        ).second_q_ops()
+        aux_ops = list(
+            ElectronicEnergy(
+                [
+                    OneBodyElectronicIntegrals(ElectronicBasis.MO, (h_1, None)),
+                    TwoBodyElectronicIntegrals(ElectronicBasis.MO, (h_2, None, None, None)),
+                ],
+            )
+            .second_q_ops()
+            .values()
+        )
         aux_ops_copy = copy.deepcopy(aux_ops)
 
         _ = calc.solve(self.electronic_structure_problem)
@@ -142,55 +146,40 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             frozenset(a.to_list()) == frozenset(b.to_list()) for a, b in zip(aux_ops, aux_ops_copy)
         )
 
-    def test_dict_based_aux_ops(self):
-        """Test the `test_dict_based_aux_ops` variant"""
-        try:
-            settings.dict_aux_operators = True
-            solver = NumPyMinimumEigensolverFactory()
-            calc = GroundStateEigensolver(self.qubit_converter, solver)
-            res = calc.solve(self.electronic_structure_problem)
-            self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
-            self.assertTrue(
-                np.all(isinstance(aux_op, dict) for aux_op in res.aux_operator_eigenvalues)
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["ParticleNumber"][0], 2.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["ParticleNumber"][1], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["AngularMomentum"][0], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["AngularMomentum"][1], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["Magnetization"][0], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["Magnetization"][1], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentX"][0], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentX"][1], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentY"][0], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentY"][1], 0.0, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentZ"][0], -1.3889487, places=6
-            )
-            self.assertAlmostEqual(
-                res.aux_operator_eigenvalues[0]["DipoleMomentZ"][1], 0.0, places=6
-            )
-        finally:
+    def test_list_based_aux_ops(self):
+        """Test the list based aux ops variant"""
+        msg_ref = (
+            "List-based `aux_operators` are deprecated as of version 0.3.0 and support "
+            "for them will be removed no sooner than 3 months after the release. Instead, "
+            "use dict-based `aux_operators`. You can switch to the dict-based interface "
+            "immediately, by setting `qiskit_nature.settings.dict_aux_operators` to `True`."
+        )
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
             settings.dict_aux_operators = False
+            try:
+                solver = NumPyMinimumEigensolverFactory()
+                calc = GroundStateEigensolver(self.qubit_converter, solver)
+                res = calc.solve(self.electronic_structure_problem)
+                self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
+                self.assertTrue(
+                    np.all(isinstance(aux_op, dict) for aux_op in res.aux_operator_eigenvalues)
+                )
+                aux_op_eigenvalue = res.aux_operator_eigenvalues[0]
+                self.assertAlmostEqual(aux_op_eigenvalue[0][0], 2.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[1][1], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[2][0], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[2][1], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[3][0], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[3][1], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[4][0], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[4][1], 0.0, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[5][0], -1.3889487, places=6)
+                self.assertAlmostEqual(aux_op_eigenvalue[5][1], 0.0, places=6)
+            finally:
+                settings.dict_aux_operators = True
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, msg_ref)
 
     def _setup_evaluation_operators(self):
         # first we run a ground state calculation
@@ -200,16 +189,17 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
         # now we decide that we want to evaluate another operator
         # for testing simplicity, we just use some pre-constructed auxiliary operators
-        _, *aux_ops = self.qubit_converter.convert_match(
-            self.electronic_structure_problem.second_q_ops()
-        )
-        return calc, res, aux_ops
+        second_q_ops = self.electronic_structure_problem.second_q_ops()
+        aux_ops_dict = {}
+        for key, value in second_q_ops.items():
+            aux_ops_dict[key] = self.qubit_converter.convert_match(value)
+        return calc, res, aux_ops_dict
 
     def test_eval_op_single(self):
         """Test evaluating a single additional operator"""
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because in this test we test a single operator evaluation
-        add_aux_op = aux_ops[0][0]
+        add_aux_op = aux_ops["ParticleNumber"][0]
 
         # now we have the ground state calculation evaluate it
         add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
@@ -231,7 +221,11 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {"number of particles": 2, "s^2": 0, "magnetization": 0}
-        add_aux_op = aux_ops[0:3]
+        add_aux_op = [
+            aux_ops["ParticleNumber"],
+            aux_ops["AngularMomentum"],
+            aux_ops["Magnetization"],
+        ]
 
         # now we have the ground state calculation evaluate them
         add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
@@ -245,7 +239,11 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {"number of particles": 2, "s^2": 0, "magnetization": 0}
-        add_aux_op = aux_ops[0:3] + [None]
+        add_aux_op = [
+            aux_ops["ParticleNumber"],
+            aux_ops["AngularMomentum"],
+            aux_ops["Magnetization"],
+        ] + [None]
 
         # now we have the ground state calculation evaluate them
         add_aux_op_res = calc.evaluate_operators(res.raw_result.eigenstate, add_aux_op)
@@ -260,7 +258,11 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {"number of particles": 2, "s^2": 0, "magnetization": 0}
-        add_aux_op = aux_ops[0:3]
+        add_aux_op = [
+            aux_ops["ParticleNumber"],
+            aux_ops["AngularMomentum"],
+            aux_ops["Magnetization"],
+        ]
         # now we convert it into a dictionary
         add_aux_op = dict(zip(expected_results.keys(), add_aux_op))
 
@@ -275,7 +277,11 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc, res, aux_ops = self._setup_evaluation_operators()
         # we filter the list because of simplicity
         expected_results = {"number of particles": 2, "s^2": 0, "magnetization": 0}
-        add_aux_op = aux_ops[0:3]
+        add_aux_op = [
+            aux_ops["ParticleNumber"],
+            aux_ops["AngularMomentum"],
+            aux_ops["Magnetization"],
+        ]
         # now we convert it into a dictionary
         add_aux_op = dict(zip(expected_results.keys(), add_aux_op))
         add_aux_op["None"] = None
@@ -302,7 +308,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res_qasm = calc.solve(self.electronic_structure_problem)
 
-        hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
+        hamiltonian = self.electronic_structure_problem.second_q_ops()[
+            self.electronic_structure_problem.main_property_name
+        ]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
         ansatz = solver.get_solver(self.electronic_structure_problem, self.qubit_converter).ansatz
@@ -330,7 +338,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res_qasm = calc.solve(self.electronic_structure_problem)
 
-        hamiltonian = self.electronic_structure_problem.second_q_ops()[0]
+        hamiltonian = self.electronic_structure_problem.second_q_ops()[
+            self.electronic_structure_problem.main_property_name
+        ]
         qubit_op = self.qubit_converter.map(hamiltonian)
 
         ansatz = solver.get_solver(self.electronic_structure_problem, self.qubit_converter).ansatz

--- a/test/converters/second_quantization/test_qubit_converter.py
+++ b/test/converters/second_quantization/test_qubit_converter.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -92,7 +92,7 @@ class TestQubitConverter(QiskitNatureTestCase):
         self.driver_result = driver.run()
         particle_number = cast(ParticleNumber, self.driver_result.get_property(ParticleNumber))
         self.num_particles = (particle_number.num_alpha, particle_number.num_beta)
-        self.h2_op = self.driver_result.second_q_ops()[0]
+        self.h2_op = self.driver_result.second_q_ops()["ElectronicEnergy"]
 
     def test_mapping_basic(self):
         """Test mapping to qubit operator"""
@@ -277,7 +277,7 @@ class TestQubitConverter(QiskitNatureTestCase):
         mapper = JordanWignerMapper()
         qubit_conv = QubitConverter(mapper, two_qubit_reduction=True, z2symmetry_reduction="auto")
         qubit_op = qubit_conv.convert(
-            problem.second_q_ops()[0],
+            problem.second_q_ops()[problem.main_property_name],
             self.num_particles,
             sector_locator=problem.symmetry_sector_locator,
         )

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian_log.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian_log.py
@@ -15,7 +15,7 @@
 import unittest
 
 from test import QiskitNatureTestCase
-
+import warnings
 import numpy as np
 
 from qiskit_nature.hdf5 import load_from_hdf5
@@ -181,39 +181,48 @@ class TestDriverGaussianLog(QiskitNatureTestCase):
 
     def test_watson_hamiltonian(self):
         """Test the watson hamiltonian"""
-        result = GaussianLogResult(self.logfile)
-        watson = result.get_watson_hamiltonian()
-        expected = [
-            [352.3005875, 2, 2],
-            [-352.3005875, -2, -2],
-            [631.6153975, 1, 1],
-            [-631.6153975, -1, -1],
-            [115.653915, 4, 4],
-            [-115.653915, -4, -4],
-            [115.653915, 3, 3],
-            [-115.653915, -3, -3],
-            [-15.341901966295344, 2, 2, 2],
-            [-88.2017421687633, 1, 1, 2],
-            [42.40478531359112, 4, 4, 2],
-            [26.25167512727164, 4, 3, 2],
-            [2.2874639206341865, 3, 3, 2],
-            [0.4207357291666667, 2, 2, 2, 2],
-            [4.9425425, 1, 1, 2, 2],
-            [1.6122932291666665, 1, 1, 1, 1],
-            [-4.194299375, 4, 4, 2, 2],
-            [-4.194299375, 3, 3, 2, 2],
-            [-10.20589125, 4, 4, 1, 1],
-            [-10.20589125, 3, 3, 1, 1],
-            [2.2973803125, 4, 4, 4, 4],
-            [2.7821204166666664, 4, 4, 4, 3],
-            [7.329224375, 4, 4, 3, 3],
-            [-2.7821200000000004, 4, 3, 3, 3],
-            [2.2973803125, 3, 3, 3, 3],
-        ]
-        for i, entry in enumerate(watson.data):
-            msg = f"mode[{i}]={entry} does not match expected {expected[i]}"
-            self.assertAlmostEqual(entry[0], expected[i][0], msg=msg)
-            self.assertListEqual(entry[1:], expected[i][1:], msg=msg)
+        msg_ref = (
+            "The get_watson_hamiltonian method is deprecated as of version 0.4.0 and "
+            "will be removed no sooner than 3 months after the release. Instead use the "
+            "get_vibrational_energy method Construct a VibrationalEnergy instead of the "
+            "deprecated WatsonHamiltonian directly."
+        )
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            result = GaussianLogResult(self.logfile)
+            watson = result.get_watson_hamiltonian()
+            expected = [
+                [352.3005875, 2, 2],
+                [-352.3005875, -2, -2],
+                [631.6153975, 1, 1],
+                [-631.6153975, -1, -1],
+                [115.653915, 4, 4],
+                [-115.653915, -4, -4],
+                [115.653915, 3, 3],
+                [-115.653915, -3, -3],
+                [-15.341901966295344, 2, 2, 2],
+                [-88.2017421687633, 1, 1, 2],
+                [42.40478531359112, 4, 4, 2],
+                [26.25167512727164, 4, 3, 2],
+                [2.2874639206341865, 3, 3, 2],
+                [0.4207357291666667, 2, 2, 2, 2],
+                [4.9425425, 1, 1, 2, 2],
+                [1.6122932291666665, 1, 1, 1, 1],
+                [-4.194299375, 4, 4, 2, 2],
+                [-4.194299375, 3, 3, 2, 2],
+                [-10.20589125, 4, 4, 1, 1],
+                [-10.20589125, 3, 3, 1, 1],
+                [2.2973803125, 4, 4, 4, 4],
+                [2.7821204166666664, 4, 4, 4, 3],
+                [7.329224375, 4, 4, 3, 3],
+                [-2.7821200000000004, 4, 3, 3, 3],
+                [2.2973803125, 3, 3, 3, 3],
+            ]
+            for i, entry in enumerate(watson.data):
+                msg = f"mode[{i}]={entry} does not match expected {expected[i]}"
+                self.assertAlmostEqual(entry[0], expected[i][0], msg=msg)
+                self.assertListEqual(entry[1:], expected[i][1:], msg=msg)
+            self.assertEqual(str(c_m[0].message), msg_ref)
 
 
 if __name__ == "__main__":

--- a/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
+++ b/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -51,7 +51,7 @@ class TestBravyiKitaevMapper(QiskitNatureTestCase):
             )
         )
         driver_result = driver.run()
-        fermionic_op = driver_result.second_q_ops()[0]
+        fermionic_op = driver_result.second_q_ops()["ElectronicEnergy"]
         mapper = BravyiKitaevMapper()
         qubit_op = mapper.map(fermionic_op)
 

--- a/test/mappers/second_quantization/test_direct_mapper.py
+++ b/test/mappers/second_quantization/test_direct_mapper.py
@@ -64,7 +64,7 @@ class TestDirectMapper(QiskitNatureTestCase):
         vibration_energy = self.driver_result.get_property("VibrationalEnergy")
         vibration_energy.basis = HarmonicBasis(num_modals)
 
-        vibration_op = vibration_energy.second_q_ops()[0]
+        vibration_op = vibration_energy.second_q_ops()["VibrationalEnergy"]
 
         mapper = DirectMapper()
         qubit_op = mapper.map(vibration_op)
@@ -79,7 +79,7 @@ class TestDirectMapper(QiskitNatureTestCase):
         vibration_energy = self.driver_result.get_property("VibrationalEnergy")
         vibration_energy.basis = HarmonicBasis(num_modals)
 
-        vibration_op = vibration_energy.second_q_ops()[0]
+        vibration_op = vibration_energy.second_q_ops()["VibrationalEnergy"]
 
         mapper = DirectMapper()
         qubit_op = mapper.map(vibration_op)

--- a/test/mappers/second_quantization/test_jordan_wigner_mapper.py
+++ b/test/mappers/second_quantization/test_jordan_wigner_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -51,7 +51,7 @@ class TestJordanWignerMapper(QiskitNatureTestCase):
             )
         )
         driver_result = driver.run()
-        fermionic_op = driver_result.second_q_ops()[0]
+        fermionic_op = driver_result.second_q_ops()["ElectronicEnergy"]
         mapper = JordanWignerMapper()
         qubit_op = mapper.map(fermionic_op)
 

--- a/test/mappers/second_quantization/test_parity_mapper.py
+++ b/test/mappers/second_quantization/test_parity_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -51,7 +51,7 @@ class TestParityMapper(QiskitNatureTestCase):
             )
         )
         driver_result = driver.run()
-        fermionic_op = driver_result.second_q_ops()[0]
+        fermionic_op = driver_result.second_q_ops()["ElectronicEnergy"]
         mapper = ParityMapper()
         qubit_op = mapper.map(fermionic_op)
 
@@ -70,27 +70,27 @@ class TestParityMapper(QiskitNatureTestCase):
     def test_mapping_for_single_op(self):
         """Test for single register operator."""
         with self.subTest("test +"):
-            op = FermionicOp("+")
+            op = FermionicOp("+", display_format="dense")
             expected = PauliSumOp.from_list([("X", 0.5), ("Y", -0.5j)])
             self.assertEqual(ParityMapper().map(op), expected)
 
         with self.subTest("test -"):
-            op = FermionicOp("-")
+            op = FermionicOp("-", display_format="dense")
             expected = PauliSumOp.from_list([("X", 0.5), ("Y", 0.5j)])
             self.assertEqual(ParityMapper().map(op), expected)
 
         with self.subTest("test N"):
-            op = FermionicOp("N")
+            op = FermionicOp("N", display_format="dense")
             expected = PauliSumOp.from_list([("I", 0.5), ("Z", -0.5)])
             self.assertEqual(ParityMapper().map(op), expected)
 
         with self.subTest("test E"):
-            op = FermionicOp("E")
+            op = FermionicOp("E", display_format="dense")
             expected = PauliSumOp.from_list([("I", 0.5), ("Z", 0.5)])
             self.assertEqual(ParityMapper().map(op), expected)
 
         with self.subTest("test I"):
-            op = FermionicOp("I")
+            op = FermionicOp("I", display_format="dense")
             expected = PauliSumOp.from_list([("I", 1)])
             self.assertEqual(ParityMapper().map(op), expected)
 

--- a/test/nature_test_case.py
+++ b/test/nature_test_case.py
@@ -20,6 +20,7 @@ import logging
 import os
 import unittest
 import time
+from qiskit_nature import settings
 
 # disable deprecation warnings that can cause log output overflow
 # pylint: disable=unused-argument
@@ -40,6 +41,7 @@ class QiskitNatureTestCase(unittest.TestCase, ABC):
     log = None
 
     def setUp(self) -> None:
+        settings.dict_aux_operators = True
         warnings.filterwarnings("default", category=DeprecationWarning)
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="pyscf")
         warnings.filterwarnings(action="ignore", category=DeprecationWarning, module=".*drivers*")

--- a/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
+++ b/test/problems/second_quantization/electronic/builders/test_fermionic_op_builder.py
@@ -45,7 +45,9 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
             )
         )
         driver_result = driver.run()
-        fermionic_op = driver_result.get_property("ElectronicEnergy").second_q_ops()[0]
+        fermionic_op = driver_result.get_property("ElectronicEnergy").second_q_ops()[
+            "ElectronicEnergy"
+        ]
 
         with self.subTest("Check type of fermionic operator"):
             assert isinstance(fermionic_op, FermionicOp)
@@ -76,7 +78,7 @@ class TestFermionicOpBuilder(QiskitNatureTestCase):
         reduced = ElectronicEnergy(
             [electronic_energy.get_electronic_integral(ElectronicBasis.MO, 1)]
         )
-        fermionic_op = reduced.second_q_ops()[0]
+        fermionic_op = reduced.second_q_ops()["ElectronicEnergy"]
 
         with self.subTest("Check type of fermionic operator"):
             assert isinstance(fermionic_op, FermionicOp)

--- a/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
+++ b/test/problems/second_quantization/electronic/test_electronic_structure_problem.py
@@ -59,7 +59,8 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
         electronic_structure_problem = ElectronicStructureProblem(driver)
 
         second_quantized_ops = electronic_structure_problem.second_q_ops()
-        electr_sec_quant_op = second_quantized_ops[0]
+        electr_sec_quant_op = second_quantized_ops[electronic_structure_problem.main_property_name]
+        second_quantized_ops = list(second_quantized_ops.values())
 
         with self.subTest("Check that the correct properties are/aren't None"):
             with warnings.catch_warnings():
@@ -100,7 +101,8 @@ class TestElectronicStructureProblem(QiskitNatureTestCase):
 
         electronic_structure_problem = ElectronicStructureProblem(driver, [trafo])
         second_quantized_ops = electronic_structure_problem.second_q_ops()
-        electr_sec_quant_op = second_quantized_ops[0]
+        electr_sec_quant_op = second_quantized_ops[electronic_structure_problem.main_property_name]
+        second_quantized_ops = list(second_quantized_ops.values())
 
         with self.subTest("Check that the correct properties are/aren't None"):
             with warnings.catch_warnings():
@@ -139,7 +141,7 @@ class TestElectronicStructureProblemLegacyDrivers(QiskitNatureTestCase):
             mapper=ParityMapper(), two_qubit_reduction=True, z2symmetry_reduction="auto"
         )
         qubit_conv.convert(
-            es_problem.second_q_ops()[0],
+            es_problem.second_q_ops()[es_problem.main_property_name],
             num_particles=es_problem.num_particles,
             sector_locator=es_problem.symmetry_sector_locator,
         )
@@ -160,7 +162,7 @@ class TestElectronicStructureProblemLegacyDrivers(QiskitNatureTestCase):
             mapper=ParityMapper(), two_qubit_reduction=True, z2symmetry_reduction="auto"
         )
         qubit_conv.convert(
-            es_problem.second_q_ops()[0],
+            es_problem.second_q_ops()[es_problem.main_property_name],
             num_particles=es_problem.num_particles,
             sector_locator=es_problem.symmetry_sector_locator,
         )

--- a/test/problems/second_quantization/vibrational/test_vibrational_structure_problem.py
+++ b/test/problems/second_quantization/vibrational/test_vibrational_structure_problem.py
@@ -63,7 +63,7 @@ class TestVibrationalStructureProblem(QiskitNatureTestCase):
         num_modals = [num_modals] * num_modes
         vibrational_problem = VibrationalStructureProblem(self.driver, num_modals, truncation_order)
         second_quantized_ops = vibrational_problem.second_q_ops()
-        vibrational_op = second_quantized_ops[0]
+        vibrational_op = second_quantized_ops[vibrational_problem.main_property_name]
 
         with self.subTest("Check expected length of the list of second quantized operators."):
             assert len(second_quantized_ops) == expected_num_of_sec_quant_ops
@@ -83,7 +83,7 @@ class TestVibrationalStructureProblem(QiskitNatureTestCase):
         num_modals = [num_modals] * num_modes
         vibrational_problem = VibrationalStructureProblem(self.driver, num_modals, truncation_order)
         second_quantized_ops = vibrational_problem.second_q_ops()
-        vibrational_op = second_quantized_ops[0]
+        vibrational_op = second_quantized_ops[vibrational_problem.main_property_name]
 
         with self.subTest("Check expected length of the list of second quantized operators."):
             assert len(second_quantized_ops) == expected_num_of_sec_quant_ops

--- a/test/properties/second_quantization/electronic/integrals/test_integral_property.py
+++ b/test/properties/second_quantization/electronic/integrals/test_integral_property.py
@@ -89,7 +89,7 @@ class TestIntegralProperty(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        second_q_ops = self.prop.second_q_ops()
+        second_q_ops = [self.prop.second_q_ops()["test"]]
         with open(
             self.get_resource_path(
                 "integral_property_op.json",

--- a/test/properties/second_quantization/electronic/test_angular_momentum.py
+++ b/test/properties/second_quantization/electronic/test_angular_momentum.py
@@ -38,7 +38,7 @@ class TestAngularMomentum(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [self.prop.second_q_ops()["AngularMomentum"]]
         self.assertEqual(len(ops), 1)
         with open(
             self.get_resource_path(

--- a/test/properties/second_quantization/electronic/test_dipole_moment.py
+++ b/test/properties/second_quantization/electronic/test_dipole_moment.py
@@ -43,7 +43,11 @@ class TestElectronicDipoleMoment(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [
+            self.prop.second_q_ops()["DipoleMomentX"],
+            self.prop.second_q_ops()["DipoleMomentY"],
+            self.prop.second_q_ops()["DipoleMomentZ"],
+        ]
         self.assertEqual(len(ops), 3)
         with open(
             self.get_resource_path(

--- a/test/properties/second_quantization/electronic/test_electronic_energy.py
+++ b/test/properties/second_quantization/electronic/test_electronic_energy.py
@@ -47,7 +47,7 @@ class TestElectronicEnergy(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [self.prop.second_q_ops()["ElectronicEnergy"]]
         self.assertEqual(len(ops), 1)
         with open(
             self.get_resource_path(

--- a/test/properties/second_quantization/electronic/test_magnetization.py
+++ b/test/properties/second_quantization/electronic/test_magnetization.py
@@ -36,7 +36,7 @@ class TestMagnetization(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [self.prop.second_q_ops()["Magnetization"]]
         self.assertEqual(len(ops), 1)
         expected = [
             ("+_0 -_0", 0.5),

--- a/test/properties/second_quantization/electronic/test_particle_number.py
+++ b/test/properties/second_quantization/electronic/test_particle_number.py
@@ -39,7 +39,7 @@ class TestParticleNumber(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [self.prop.second_q_ops()["ParticleNumber"]]
         self.assertEqual(len(ops), 1)
         expected = [
             "+_0 -_0",

--- a/test/properties/second_quantization/vibrational/test_occupied_modals.py
+++ b/test/properties/second_quantization/vibrational/test_occupied_modals.py
@@ -38,7 +38,7 @@ class TestOccupiedModals(PropertyTest):
 
     def test_second_q_ops(self):
         """Test second_q_ops."""
-        ops = self.prop.second_q_ops()
+        ops = [self.prop.second_q_ops()["0"]]
         expected = [
             [("NIIIIIIII", (1 + 0j)), ("INIIIIIII", (1 + 0j))],
             [("IINIIIIII", (1 + 0j)), ("IIINIIIII", (1 + 0j)), ("IIIINIIII", (1 + 0j))],

--- a/test/properties/second_quantization/vibrational/test_vibrational_energy.py
+++ b/test/properties/second_quantization/vibrational/test_vibrational_energy.py
@@ -79,7 +79,7 @@ class TestVibrationalEnergy(PropertyTest):
             encoding="utf8",
         ) as file:
             expected = json.load(file)
-        for op, expected_op in zip(ops[0].to_list(), expected):
+        for op, expected_op in zip(ops["VibrationalEnergy"].to_list(), expected):
             self.assertEqual(op[0], expected_op[0])
             self.assertTrue(np.isclose(op[1], expected_op[1]))
 

--- a/test/test_end2end_with_vqe.py
+++ b/test/test_end2end_with_vqe.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -40,7 +40,7 @@ class TestEnd2End(QiskitNatureTestCase):
             )
         )
         problem = ElectronicStructureProblem(driver)
-        second_q_ops = problem.second_q_ops()
+        second_q_ops = [problem.second_q_ops()[problem.main_property_name]]
         converter = QubitConverter(mapper=ParityMapper(), two_qubit_reduction=True)
         num_particles = (
             problem.grouped_property_transformed.get_property("ParticleNumber").num_alpha,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Moved all unit tests to new dict.based aux.opertators.

Left `test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py test_list_based_aux_ops` to test the deprecated list based.


### Details and comments


