### PR TITLE
UCC operator creation on demand

### DIFF
--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -19,7 +19,7 @@ from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import EvolvedOperatorAnsatz
-from qiskit.opflow import OperatorBase, PauliTrotterEvolution
+from qiskit.opflow import PauliTrotterEvolution
 
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.converters.second_quantization import QubitConverter
@@ -86,6 +86,7 @@ class UCC(EvolvedOperatorAnsatz):
 
     Keep in mind, that in all of the examples above we have not set any of the following keyword
     arguments, which must be specified before the Ansatz becomes usable:
+
     - `qubit_converter`
     - `num_particles`
     - `num_spin_orbitals`
@@ -196,6 +197,7 @@ class UCC(EvolvedOperatorAnsatz):
     @qubit_converter.setter
     def qubit_converter(self, conv: QubitConverter) -> None:
         """Sets the qubit operator converter."""
+        self._operators = None
         self._invalidate()
         self._qubit_converter = conv
 
@@ -207,6 +209,7 @@ class UCC(EvolvedOperatorAnsatz):
     @num_spin_orbitals.setter
     def num_spin_orbitals(self, n: int) -> None:
         """Sets the number of spin orbitals."""
+        self._operators = None
         self._invalidate()
         self._num_spin_orbitals = n
 
@@ -218,6 +221,7 @@ class UCC(EvolvedOperatorAnsatz):
     @num_particles.setter
     def num_particles(self, n: Tuple[int, int]) -> None:
         """Sets the number of particles."""
+        self._operators = None
         self._invalidate()
         self._num_particles = n
 
@@ -229,22 +233,94 @@ class UCC(EvolvedOperatorAnsatz):
     @excitations.setter
     def excitations(self, exc: Union[str, int, List[int], Callable]) -> None:
         """Sets the excitations."""
+        self._operators = None
         self._invalidate()
         self._excitations = exc
+
+    @EvolvedOperatorAnsatz.operators.getter
+    def operators(self):  # pylint: disable=invalid-overridden-method
+        """The operators that are evolved in this circuit.
+
+        Returns:
+            list: The operators to be evolved contained in this ansatz or
+                  None if the configuration is not complete
+        """
+        # Overriding the getter to build the operators on demand when they are
+        # requested, if they are still set to None.
+        operators = super(UCC, self.__class__).operators.__get__(self)
+
+        if operators is None or operators == [None]:
+            # If the operators are None build them out if the ucc config checks out ok, otherwise
+            # they will be left as None to be built at some later time.
+            if self._check_ucc_configuration(raise_on_failure=False):
+                # The qubit operators are cached by `EvolvedOperatorAnsatz` class. We only generate
+                # them from the `SecondQuantizedOp`s produced by the generators, if they're not already
+                # present. This behavior also enables the adaptive usage of the `UCC` class by
+                # algorithms such as `AdaptVQE`.
+                excitation_ops = self.excitation_ops()
+
+                logger.debug("Converting SecondQuantizedOps into PauliSumOps...")
+                # Convert operators according to saved state in converter from the conversion of the
+                # main operator since these need to be compatible. If Z2 Symmetry tapering was done
+                # it may be that one or more excitation operators do not commute with the
+                # symmetry. Normally the converted operators are maintained at the same index by
+                # the converter inserting None as the result if an operator did not commute. Here
+                # we are not interested in that just getting the valid set of operators so that
+                # behavior is suppressed.
+                self.operators = self.qubit_converter.convert_match(
+                    excitation_ops, suppress_none=True
+                )
+
+        return super(UCC, self.__class__).operators.__get__(self)
 
     def _invalidate(self):
         self._excitation_ops = None
         super()._invalidate()
 
     def _check_configuration(self, raise_on_failure: bool = True) -> bool:
-        if self.num_spin_orbitals < 0:
+        # Check our local config is valid first. The super class will check the
+        # operators by getting them, and if we detect they are still None they
+        # will be built so that its valid check will end up passing in that regard.
+        if not self._check_ucc_configuration(raise_on_failure):
+            return False
+
+        return super()._check_configuration(raise_on_failure)
+
+    # pylint: disable=too-many-return-statements
+    def _check_ucc_configuration(self, raise_on_failure: bool = True) -> bool:
+        # Check the local config, separated out that it can be checked via build
+        # or ahead of building operators to make sure everything needed is present.
+        if self.num_spin_orbitals is None:
             if raise_on_failure:
-                raise ValueError("The number of spin orbitals cannot be smaller than 0.")
+                raise ValueError("The number of spin orbitals cannot be 'None'.")
+            return False
+
+        if self.num_spin_orbitals <= 0:
+            if raise_on_failure:
+                raise ValueError(
+                    f"The number of spin orbitals must be > 0 was {self.num_spin_orbitals}."
+                )
+            return False
+
+        if self.num_particles is None:
+            if raise_on_failure:
+                raise ValueError("The number of particles cannot be 'None'.")
             return False
 
         if any(n < 0 for n in self.num_particles):
             if raise_on_failure:
-                raise ValueError("The number of particles cannot be smaller than 0.")
+                raise ValueError(
+                    f"The number of particles cannot be smaller than 0 was {self.num_particles}."
+                )
+            return False
+
+        if sum(self.num_particles) >= self.num_spin_orbitals:
+            if raise_on_failure:
+                raise ValueError(
+                    f"The number of spin orbitals {self.num_spin_orbitals}"
+                    f"must be greater than total number of particles "
+                    f"{sum(self.num_particles)}."
+                )
             return False
 
         if self.excitations is None:
@@ -258,32 +334,6 @@ class UCC(EvolvedOperatorAnsatz):
             return False
 
         return True
-
-    def _build(self) -> None:
-        if self._is_built:
-            return
-
-        self.operators: Optional[Union[OperatorBase, QuantumCircuit, list]]
-
-        if self.operators is None or self.operators == [None]:
-            # The qubit operators are cached by the `EvolvedOperatorAnsatz` class. We only generate
-            # them from the `SecondQuantizedOp`s produced by the generators, if they are not already
-            # present. This behavior also enables the adaptive usage of the `UCC` class by
-            # algorithms such as `AdaptVQE`.
-            excitation_ops = self.excitation_ops()
-
-            logger.debug("Converting SecondQuantizedOps into PauliSumOps...")
-            # Convert operators according to saved state in converter from the conversion of the
-            # main operator since these need to be compatible. If Z2 Symmetry tapering was done
-            # it may be that one or more excitation operators do not commute with the
-            # symmetry. Normally the converted operators are maintained at the same index by
-            # the converter inserting None as the result if an operator did not commute. Here
-            # we are not interested in that just getting the valid set of operators so that
-            # behavior is suppressed.
-            self.operators = self.qubit_converter.convert_match(excitation_ops, suppress_none=True)
-
-        logger.debug("Building QuantumCircuit...")
-        super()._build()
 
     def excitation_ops(self) -> List[SecondQuantizedOp]:
         """Parses the excitations and generates the list of operators.

--- a/releasenotes/notes/fix_uccsd_op_build-6b0bc1de57f3e423.yaml
+++ b/releasenotes/notes/fix_uccsd_op_build-6b0bc1de57f3e423.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Alter :class:`~qiskit_nature.circuit.library.UCC` to build the ``operators`` on demand
+    when requested via the property, rather than, as before, when the circuit is built.
+    Now if the circuit is built, then the operators, if not built, will be created as before,
+    but since they are cached when built, if done earlier, then these are used. This avoids
+    problems when used in conjunction with VQE that presently fail - most cases today
+    use a fully configured UCC being passed into VQE but whose constructor presently has an
+    unintended side-effect of building the circuit via a logging statement. For other
+    scenarios VQE would fail when it checked on number of qubits and the operators were None,
+    even though UCC was fully configured, when the circuit had not yet been built.

--- a/test/circuit/library/ansatzes/test_ucc.py
+++ b/test/circuit/library/ansatzes/test_ucc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/circuit/library/ansatzes/test_ucc.py
+++ b/test/circuit/library/ansatzes/test_ucc.py
@@ -19,7 +19,7 @@ from ddt import data, ddt, unpack
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.circuit.library import UCC
 from qiskit_nature.converters.second_quantization import QubitConverter
-from qiskit_nature.mappers.second_quantization import JordanWignerMapper
+from qiskit_nature.mappers.second_quantization import JordanWignerMapper, ParityMapper
 from qiskit_nature.operators.second_quantization import FermionicOp
 
 
@@ -133,3 +133,87 @@ class TestUCC(QiskitNatureTestCase):
 
         with self.assertRaises(QiskitNatureError):
             ansatz.excitation_ops()
+
+    def test_build_ucc(self):
+        """Test building UCC"""
+        ucc = UCC()
+
+        with self.subTest("Check defaulted construction"):
+            self.assertIsNone(ucc.num_particles)
+            self.assertIsNone(ucc.num_spin_orbitals)
+            self.assertIsNone(ucc.excitations)
+            self.assertIsNone(ucc.qubit_converter)
+            self.assertIsNone(ucc.operators)
+            self.assertEqual(ucc.num_qubits, 0)
+            with self.assertRaises(ValueError):
+                _ = ucc.data
+
+        with self.subTest("Set num particles"):
+            ucc.num_particles = (1, 1)
+            self.assertEqual(ucc.num_particles, (1, 1))
+            self.assertIsNone(ucc.operators)
+            with self.assertRaises(ValueError):
+                _ = ucc.data
+
+        with self.subTest("Set num spin orbitals"):
+            ucc.num_spin_orbitals = 4
+            self.assertEqual(ucc.num_spin_orbitals, 4)
+            self.assertIsNone(ucc.operators)
+            with self.assertRaises(ValueError):
+                _ = ucc.data
+
+        with self.subTest("Set excitations"):
+            ucc.excitations = "sd"
+            self.assertEqual(ucc.excitations, "sd")
+            self.assertIsNone(ucc.operators)
+            with self.assertRaises(ValueError):
+                _ = ucc.data
+
+        with self.subTest("Set qubit converter to complete build"):
+            converter = QubitConverter(JordanWignerMapper())
+            ucc.qubit_converter = converter
+            self.assertEqual(ucc.qubit_converter, converter)
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 3)
+            self.assertEqual(ucc.num_qubits, 4)
+            self.assertIsNotNone(ucc.data)
+
+        with self.subTest("Set custom operators"):
+            self.assertEqual(len(ucc.operators), 3)
+            ucc.operators = ucc.operators[:2]
+            self.assertEqual(len(ucc.operators), 2)
+            self.assertEqual(ucc.num_qubits, 4)
+
+        with self.subTest("Reset operators back to as per UCC"):
+            ucc.operators = None
+            self.assertEqual(ucc.num_qubits, 4)
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 3)
+
+        with self.subTest("Set num particles to include 0"):
+            ucc.num_particles = (1, 0)
+            self.assertEqual(ucc.num_particles, (1, 0))
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 1)
+
+        with self.subTest("Change num particles"):
+            ucc.num_particles = (1, 1)
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 3)
+
+        with self.subTest("Change num spin orbitals"):
+            ucc.num_spin_orbitals = 6
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 8)
+
+        with self.subTest("Change excitations"):
+            ucc.excitations = "s"
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(len(ucc.operators), 4)
+
+        with self.subTest("Change qubit converter"):
+            ucc.qubit_converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)
+            # Has not been used to convert so we need to force it to do two qubit reduction
+            ucc.qubit_converter.force_match(ucc.num_particles)
+            self.assertIsNotNone(ucc.operators)
+            self.assertEqual(ucc.num_qubits, 4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Change UCC such that `operators` are built on demand rather than being built only when the circuit is built. This means now, that as soon as UCC has a valid configuration, a call to get `operators` or `num_qubits` will return actual values rather than None and 0 respectively. The later behavior is problematic with VQE when used more dynamically (i.e. beyond just passing in a fully configured UCC to VQE constructor). See discussion in #570.

Operators will still be built, if they were not already, when the circuit is built, but if they were built earlier it will use these. Any built operators are invalidated if UCC config is changed as before. The config checking was improved to include None checks since UCC starts out with None for num particles and spin orbitals and config check would fail previously if it gets to the point of building and either was still None.

Why it works via the VQE constructor today happens to be a side effect of a logging statement that draws the circuit and hence builds it, see https://github.com/Qiskit/qiskit-terra/blob/c9fc6d29b4c81b06d1c154690e3d2e64749e9870/qiskit/algorithms/minimum_eigen_solvers/vqe.py#L164

The updated UCC now works whether that side-effect exists or not.

Also fixes a minor bullet list formatting in the docstring that needed a new line preceding the first item in order not to be wrapped up into the paragraph text where it did not end up as a list.


### Details and comments

I should have noted, that UVCC ought to have a similar alteration. That is not included in this PR at this point.
