### PR TITLE
Fix test_direct_mapper (fix CI breakage)

### DIFF
--- a/test/mappers/second_quantization/test_direct_mapper.py
+++ b/test/mappers/second_quantization/test_direct_mapper.py
@@ -17,10 +17,6 @@ import warnings
 
 from test import QiskitNatureTestCase
 
-import numpy as np
-
-from qiskit.opflow import PauliSumOp
-
 from qiskit_nature.drivers.second_quantization import GaussianForcesDriver
 from qiskit_nature.mappers.second_quantization import DirectMapper
 from qiskit_nature.properties.second_quantization.vibrational.bases import HarmonicBasis
@@ -31,20 +27,9 @@ from .resources.reference_direct_mapper import _num_modals_2_q_op, _num_modals_3
 class TestDirectMapper(QiskitNatureTestCase):
     """Test Direct Mapper"""
 
-    def compare_pauli_sum_op(self, first: PauliSumOp, second: PauliSumOp, msg: str = None) -> None:
-        """Compares two PauliSumOp instances."""
-        for (f_lbl, f_coeff), (s_lbl, s_coeff) in zip(
-            first.primitive.to_list(), second.primitive.to_list()
-        ):
-            if f_lbl != s_lbl:
-                raise self.failureException(msg)
-            if not np.isclose(f_coeff, s_coeff):
-                raise self.failureException(msg)
-
     def setUp(self) -> None:
         """Setup."""
         super().setUp()
-        self.addTypeEqualityFunc(PauliSumOp, self.compare_pauli_sum_op)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix and simplify `test_direct_mapper`.
Because `PauliSumOp.__eq__` does equivalency check, I removed the customized comparison.
See https://github.com/Qiskit/qiskit-terra/pull/7656 for details.

This fixes CI breakage. https://github.com/Qiskit/qiskit-nature/actions/runs/2001894175

### Details and comments


