### PR TITLE
Add apply fixes to copyright checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
-          make copyright
+          python tools/check_copyright.py -check
         if: ${{ !cancelled() }}
         shell: bash
       - name: Spell Check


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #606

The copyright tool works similar to `black` now. 
`make copyright` will fix any wrong copyright years, similar to `make black`.
Adding the optional argument `-check`, the tool will just check the years without fixing it like the option `--check` in black.
The CI will run `python tools/check_copyright.py -check`.

### Details and comments


