### PR TITLE
Fix release notes

### DIFF
--- a/releasenotes/notes/BOPERSampler-supports-MinimumEigensolverFactories-d920a7870d7e265d.yaml
+++ b/releasenotes/notes/BOPERSampler-supports-MinimumEigensolverFactories-d920a7870d7e265d.yaml
@@ -1,8 +1,9 @@
 ---
-issues:
+fixes:
   - |
-    Fixes: :class:`~qiskit_nature.algorithms.per_samplers.boper_sampler.BOPESSampler` does not support MinimumEigensolverFactories.
-    Now, the factory can be used as following:
+    The :class:`~qiskit_nature.algorithms.per_samplers.boper_sampler.BOPESSampler` did not support 
+    GroundStateSolvers when built out with MinimumEigensolverFactories.
+    This is fixed, so code like the following now functions correctly:
 
     .. code-block:: python
 

--- a/releasenotes/notes/simplify-01d1b75c00a7eac9.yaml
+++ b/releasenotes/notes/simplify-01d1b75c00a7eac9.yaml
@@ -7,9 +7,14 @@ features:
     :class:`qiskit_nature.operators.second_quantization.FermionicOp`.
     These methods replace `reduce` and `to_normal_order`, which are deprecated.
     The differences between the new and old methods are the following:
+    
     * `simplify` does not perform normal-ordering, while `reduce` does
     * `normal_ordered` simplifies the result, while `to_normal_order` does not
 deprecations:
   - |
-    * `qiskit_nature.operators.second_quantization.SecondQuantizedOp.reduce`. Instead, use `simplify`.
-    * :meth:`qiskit_nature.operators.second_quantization.FermionicOp.to_normal_order`. Instead, use `normal_ordered`.
+    The following second quantization operator methods are deprecated: 
+    
+    * :meth:`qiskit_nature.operators.second_quantization.SecondQuantizedOp.reduce`. 
+      Instead, use :meth:`qiskit_nature.operators.second_quantization.SecondQuantizedOp.simplify`.
+    * :meth:`qiskit_nature.operators.second_quantization.FermionicOp.to_normal_order`. 
+      Instead, use :meth:`qiskit_nature.operators.second_quantization.FermionicOp.normal_ordered`.


### PR DESCRIPTION
In looking through the release notes, for another PR I noticed the BopesSampler factory fix was incorrectly labelled as a known issue (i.e an issue that is known to be in the release) so I changed that.

Also the formatting of the reduce/simplify had nested bullet lists without a leading blank line and were wrapping into the rest of the text and the deprecations being just a bullet list the first item ended up as a double bullet.  I fixed these and made all the methods as links. Although reduce has only been deprecated the abstract method in the base class was removed and hence that does not resolve as a link - the methods exist and are deprecated in the sub-classes, just it no longer exists in the base class.