### PR TITLE
Improve `TwoBodyElectronicIntegrals.to_second_q_op` performance

### DIFF
--- a/qiskit_nature/properties/second_quantization/electronic/integrals/electronic_integrals.py
+++ b/qiskit_nature/properties/second_quantization/electronic/integrals/electronic_integrals.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import importlib
-import itertools
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Generator, Optional, Union

--- a/qiskit_nature/properties/second_quantization/electronic/integrals/electronic_integrals.py
+++ b/qiskit_nature/properties/second_quantization/electronic/integrals/electronic_integrals.py
@@ -356,32 +356,20 @@ class ElectronicIntegrals(ABC):
         if not np.any(spin_matrix):
             return FermionicOp.zero(register_length)
 
-        return sum(  # type: ignore
-            self._create_base_op(indices, spin_matrix[indices], register_length)
-            for indices in itertools.product(
-                range(register_length), repeat=2 * self._num_body_terms
-            )
-            if spin_matrix[indices]
-        )
+        spin_matrix_iter = spin_matrix.flat
+        # NOTE: we need to access `.coords` before `.next()` is called for the first time!
+        coords = spin_matrix_iter.coords
+        op_data = []
+        for coeff in spin_matrix_iter:
+            if coeff:
+                op_data.append((self._calc_coeffs_with_ops(coords), coeff))
+            coords = spin_matrix_iter.coords
 
-    def _create_base_op(self, indices: tuple[int, ...], coeff: complex, length: int) -> FermionicOp:
-        """Creates a single base operator for the given coefficient.
+        return FermionicOp(op_data, register_length=register_length, display_format="sparse")
 
-        Args:
-            indices: the indices of the current integral.
-            coeff: the current integral value.
-            length: the register length of the created operator.
-
-        Returns:
-            The base operator.
-        """
-        base_op = FermionicOp(("I_0", coeff), register_length=length, display_format="sparse")
-        for i, op in self._calc_coeffs_with_ops(indices):
-            base_op @= FermionicOp(f"{op}_{i}", display_format="sparse")
-        return base_op
-
+    @staticmethod
     @abstractmethod
-    def _calc_coeffs_with_ops(self, indices: tuple[int, ...]) -> list[tuple[int, str]]:
+    def _calc_coeffs_with_ops(indices: tuple[int, ...]) -> list[tuple[str, int]]:
         """Maps indices to creation/annihilation operator symbols.
 
         Args:

--- a/qiskit_nature/properties/second_quantization/electronic/integrals/one_body_electronic_integrals.py
+++ b/qiskit_nature/properties/second_quantization/electronic/integrals/one_body_electronic_integrals.py
@@ -108,8 +108,9 @@ class OneBodyElectronicIntegrals(ElectronicIntegrals):
 
         return np.where(np.abs(so_matrix) > self._threshold, so_matrix, 0.0)
 
-    def _calc_coeffs_with_ops(self, indices: tuple[int, ...]) -> list[tuple[int, str]]:
-        return [(indices[0], "+"), (indices[1], "-")]
+    @staticmethod
+    def _calc_coeffs_with_ops(indices: tuple[int, ...]) -> list[tuple[str, int]]:
+        return [("+", indices[0]), ("-", indices[1])]
 
     def compose(self, other: ElectronicIntegrals, einsum_subscript: str = "ij,ji") -> complex:
         """Composes these ``OneBodyElectronicIntegrals`` with another instance thereof.

--- a/qiskit_nature/properties/second_quantization/electronic/integrals/two_body_electronic_integrals.py
+++ b/qiskit_nature/properties/second_quantization/electronic/integrals/two_body_electronic_integrals.py
@@ -14,12 +14,15 @@
 
 from __future__ import annotations
 
+import itertools
 from typing import Optional, Union, cast
 
 import numpy as np
 
+from qiskit.tools import parallel_map
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.settings import settings
+from qiskit_nature.operators.second_quantization import FermionicOp
 
 from .electronic_integrals import ElectronicIntegrals
 from .one_body_electronic_integrals import OneBodyElectronicIntegrals
@@ -181,8 +184,9 @@ class TwoBodyElectronicIntegrals(ElectronicIntegrals):
 
         return np.where(np.abs(so_matrix) > self._threshold, so_matrix, 0.0)
 
-    def _calc_coeffs_with_ops(self, indices: tuple[int, ...]) -> list[tuple[int, str]]:
-        return [(indices[0], "+"), (indices[2], "+"), (indices[3], "-"), (indices[1], "-")]
+    @staticmethod
+    def _calc_coeffs_with_ops(indices: tuple[int, ...]) -> list[tuple[str, int]]:
+        return [("+", indices[0]), ("+", indices[2]), ("-", indices[3]), ("-", indices[1])]
 
     def compose(
         self, other: ElectronicIntegrals, einsum_subscript: Optional[str] = None

--- a/qiskit_nature/properties/second_quantization/electronic/integrals/two_body_electronic_integrals.py
+++ b/qiskit_nature/properties/second_quantization/electronic/integrals/two_body_electronic_integrals.py
@@ -14,15 +14,12 @@
 
 from __future__ import annotations
 
-import itertools
 from typing import Optional, Union, cast
 
 import numpy as np
 
-from qiskit.tools import parallel_map
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.settings import settings
-from qiskit_nature.operators.second_quantization import FermionicOp
 
 from .electronic_integrals import ElectronicIntegrals
 from .one_body_electronic_integrals import OneBodyElectronicIntegrals

--- a/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
+++ b/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Improves the performance of the
-    :meth:`qiskit_nature.properties.second_quantization.electronic.integrals.TwoBodyElectronicIntegrals.to_second_q_op`
+    :meth:`qiskit_nature.properties.second_quantization.electronic.integrals.ElectronicIntegrals.to_second_q_op`
     method significantly. Previously, generating the second quantized operators
     for a system size greater than 20 spin orbitals took on the order of minutes
     to hours (depending on the actual size). Now, even system sizes of 50 spin

--- a/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
+++ b/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Improves the performance of the
-    :class:`qiskit_nature.properties.second_quantization.electronic.integrals.TwoBodyElectronicIntegrals.to_second_q_op`
+    :meth:`qiskit_nature.properties.second_quantization.electronic.integrals.TwoBodyElectronicIntegrals.to_second_q_op`
     method significantly. Previously, generating the second quantized operators
     for a system size greater than 20 spin orbitals took on the order of minutes
     to hours (depending on the actual size). Now, even system sizes of 50 spin

--- a/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
+++ b/releasenotes/notes/performance-two-body-second-q-op-08f906951005ebc1.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Improves the performance of the
+    :class:`qiskit_nature.properties.second_quantization.electronic.integrals.TwoBodyElectronicIntegrals.to_second_q_op`
+    method significantly. Previously, generating the second quantized operators
+    for a system size greater than 20 spin orbitals took on the order of minutes
+    to hours (depending on the actual size). Now, even system sizes of 50 spin
+    orbitals can be handled in a matter of seconds.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This improves the performance of the `TwoBodyElectronicIntegrals.to_second_q_op` method.
The unusable performance was observed when attempting to run the following:
```python
import time

from qiskit_nature.drivers.second_quantization import PySCFDriver

driver = PySCFDriver(atom="O 0 0 0.115; H 0 0.754 -0.459; H 0 -0.754 -0.459", basis="cc-pVDZ")
props = driver.run()
print(props.get_property("ParticleNumber"))

start = time.time()
props.second_q_ops()
stop = time.time()
print(stop - start)
```
which is a system of size:
```
ParticleNumber:
        48 SOs
        5 alpha electrons
                orbital occupation: [1. 1. 1. 1. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
        5 beta electrons
                orbital occupation: [1. 1. 1. 1. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
```
On latest `main`, this snippet takes longer to execute than I am willing to wait (>10 minutes). After this PR, it will take 4.484 seconds.


### Details and comments

I also ran the following benchmark:
```python
import time

import numpy as np

from qiskit_nature.properties.second_quantization.electronic.bases import ElectronicBasis
from qiskit_nature.properties.second_quantization.electronic.integrals import (
    TwoBodyElectronicIntegrals,
)

sizes = range(1, 50)
times = []

for size in sizes:
    print(f"{size} MOs: ", end="")
    ints = TwoBodyElectronicIntegrals(
        ElectronicBasis.MO,
        (
            np.random.random((size, size, size, size)),
            None,
            None,
            None,
        ),
    )
    local = []
    for i in range(10):
        start = time.time()
        op = ints.to_second_q_op()
        stop = time.time()
        local.append(stop - start)
    times.append(np.average(local))
    print(f"{times[-1]}s")
```
Note, that this is a worst case scenario because we have a dense, non-zero matrix. Chemistry applications are highly sparse and all zero-terms will be skipped. However, iteration still needs to happen over `#SO**4` matrix elements..

Here are the benchmark results on 72d5445d59a0829ec5a65f1ba0e36be26d63e63f
```
1 MOs: 0.0003814220428466797s
2 MOs: 0.003143501281738281s
3 MOs: 0.01747605800628662s
4 MOs: 0.10729048252105713s
5 MOs: 0.4813446283340454s
6 MOs: 2.6585819482803346s
7 MOs: 10.059082674980164s
8 MOs: 33.26701810359955s
```
And here are the results with this PR:
```
1 MOs: 0.0001928091049194336s
2 MOs: 0.00028238296508789065s
3 MOs: 0.0008608579635620117s
4 MOs: 0.005258703231811523s
5 MOs: 0.010203838348388672s
6 MOs: 0.02182309627532959s
7 MOs: 0.049395179748535155s
8 MOs: 0.07928628921508789s
9 MOs: 0.12792351245880126s
10 MOs: 0.20389955043792723s
11 MOs: 0.32534089088439944s
12 MOs: 0.5057589530944824s
13 MOs: 0.6290717124938965s
14 MOs: 0.8679617881774903s
15 MOs: 1.2400678396224976s
16 MOs: 1.8723540782928467s
17 MOs: 2.1375882148742678s
18 MOs: 2.7122227430343626s
19 MOs: 3.2011844635009767s
20 MOs: 3.8472093820571898s
21 MOs: 4.834750986099243s
22 MOs: 5.815815830230713s
23 MOs: 7.087169241905213s
24 MOs: 8.564099335670472s
25 MOs: 9.87972595691681s
```
(Note: `#SOs = 2 * #MOs`)

Note: in the future we can take this optimization further by parallelizing the implementation. However, this generation is I/O bound rather than compute bound which means that a straight-forward application of `qiskit.tools.parallel_map` which actually result in worse performance (see also https://github.com/Qiskit/qiskit-terra/issues/7741). One solution could be the use of shared memory, as attempted here: https://github.com/Qiskit/qiskit-terra/pull/7789.
For the time being, performance is greatly improved by this PR and in the near future it is unlikely that we need to generate the second quantized operators for 100+ spin orbitals. At that point storage will also become concern so we will need to support the usage of sparse matrices anyways, which will also improve the performance of this method.