### PR TITLE
Fix `groundenergy` in `EigenstateResult`

### DIFF
--- a/qiskit_nature/results/eigenstate_result.py
+++ b/qiskit_nature/results/eigenstate_result.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -106,7 +106,7 @@ class EigenstateResult(AlgorithmResult):
     def groundenergy(self) -> Optional[float]:
         """returns ground energy"""
         energies = self.eigenenergies
-        if isinstance(energies, np.ndarray) and not energies.size:
+        if isinstance(energies, np.ndarray) and energies.size:
             return energies[0].real
         return None
 

--- a/releasenotes/notes/fix_groundenergy-f973527ae6296c59.yaml
+++ b/releasenotes/notes/fix_groundenergy-f973527ae6296c59.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the `groundenergy` to return a correct value in :class:`~qiskit_nature.results.EigenstateResult`.
+

--- a/releasenotes/notes/fix_groundenergy-f973527ae6296c59.yaml
+++ b/releasenotes/notes/fix_groundenergy-f973527ae6296c59.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Fix the `groundenergy` to return a correct value in :class:`~qiskit_nature.results.EigenstateResult`.
+    Fix the `groundenergy` in :class:`~qiskit_nature.results.EigenstateResult`
+    to return a correct value.
 

--- a/test/results/test_eigenstate_result.py
+++ b/test/results/test_eigenstate_result.py
@@ -1,0 +1,29 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the EigenstateResult."""
+
+from test import QiskitNatureTestCase
+
+import numpy as np
+
+from qiskit_nature.results import EigenstateResult
+
+
+class TestEigenstateResult(QiskitNatureTestCase):
+    """Tests EigenstateResult"""
+
+    def test_groundenergy(self):
+        """Tests ground energy"""
+        eigenstate_result = EigenstateResult()
+        eigenstate_result.eigenenergies = np.array([1, 2, 3])
+        self.assertEqual(eigenstate_result.groundenergy, 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix `groundenergy` in `EigenstateResult` to return a correct value. 

### Details and comments
Previously, it returns None, even if we have some energies. I changed `not energies.size`  to `energies.size`  in the 'if' sentence.

```
@property
def groundenergy(self) -> Optional[float]:
    """returns ground energy"""
    energies = self.eigenenergies
    if isinstance(energies, np.ndarray) and not energies.size:
        return energies[0].real
    return None
```

