### PR TITLE
Set main_property_name through the constructor of BaseProblem

### DIFF
--- a/qiskit_nature/problems/second_quantization/base_problem.py
+++ b/qiskit_nature/problems/second_quantization/base_problem.py
@@ -38,13 +38,14 @@ class BaseProblem(ABC):
         self,
         driver: BaseDriver,
         transformers: Optional[List[BaseTransformer]] = None,
+        main_property_name: Optional[str] = None,
     ):
         """
 
         Args:
             driver: A driver encoding the molecule information.
             transformers: A list of transformations to be applied to the driver result.
-
+            main_property_name: A main property name for the problem
         """
 
         self.driver = driver
@@ -56,7 +57,7 @@ class BaseProblem(ABC):
         self._grouped_property: Optional[GroupedSecondQuantizedProperty] = None
         self._grouped_property_transformed: Optional[GroupedSecondQuantizedProperty] = None
 
-        self._main_property_name: str = ""
+        self._main_property_name: str = main_property_name
 
     @property  # type: ignore[misc]
     @deprecate_property(

--- a/qiskit_nature/problems/second_quantization/base_problem.py
+++ b/qiskit_nature/problems/second_quantization/base_problem.py
@@ -38,7 +38,7 @@ class BaseProblem(ABC):
         self,
         driver: BaseDriver,
         transformers: Optional[List[BaseTransformer]] = None,
-        main_property_name: Optional[str] = None,
+        main_property_name: str = "",
     ):
         """
 

--- a/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
@@ -52,8 +52,7 @@ class ElectronicStructureProblem(BaseProblem):
             driver: A fermionic driver encoding the molecule information.
             transformers: A list of transformations to be applied to the driver result.
         """
-        super().__init__(driver, transformers)
-        self._main_property_name = "ElectronicEnergy"
+        super().__init__(driver, transformers, "ElectronicEnergy")
 
     @property
     def num_particles(self) -> Tuple[int, int]:

--- a/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
@@ -51,10 +51,9 @@ class VibrationalStructureProblem(BaseProblem):
             truncation_order: order at which an n-body expansion is truncated
             transformers: a list of transformations to be applied to the driver result.
         """
-        super().__init__(bosonic_driver, transformers)
+        super().__init__(bosonic_driver, transformers, "VibrationalEnergy")
         self.num_modals = num_modals
         self.truncation_order = truncation_order
-        self._main_property_name = "VibrationalEnergy"
 
     def second_q_ops(self) -> ListOrDictType[SecondQuantizedOp]:
         """Returns the second quantized operators created based on the driver and transformations.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Set `main_property_name` thought  the constructor of `BaseProblem` instead of setting in each sub class. 

Based on this discussion https://github.com/Qiskit/qiskit-nature/pull/620#discussion_r881292144 .

- [x] `ElectronicStructureProblem`
- [x] `VibrationalStructureProblem`

### Details and comments


