### PR TITLE
Fix transpiling UCC and UVCC

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -472,6 +472,7 @@ traceback
 tran
 translational
 transpilation
+transpile
 trotterization
 tryptophan
 tuple

--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -192,6 +192,13 @@ class UCC(EvolvedOperatorAnsatz):
         # same reason!
         self._excitation_ops: list[SecondQuantizedOp] = None
 
+        # Our parent, EvolvedOperatorAnsatz, sets qregs when it knows the
+        # number of qubits, which it gets from the operators. Getting the
+        # operators here will build them if configuration already allows.
+        # This will allow the circuit to be fully built/valid when it's
+        # possible at this stage.
+        _ = self.operators
+
     @property
     def qubit_converter(self) -> QubitConverter:
         """The qubit operator converter."""

--- a/qiskit_nature/circuit/library/ansatzes/uvcc.py
+++ b/qiskit_nature/circuit/library/ansatzes/uvcc.py
@@ -101,6 +101,13 @@ class UVCC(EvolvedOperatorAnsatz):
         # same reason!
         self._excitation_ops: list[SecondQuantizedOp] | None = None
 
+        # Our parent, EvolvedOperatorAnsatz, sets qregs when it knows the
+        # number of qubits, which it gets from the operators. Getting the
+        # operators here will build them if configuration already allows.
+        # This will allow the circuit to be fully built/valid when it's
+        # possible at this stage.
+        _ = self.operators
+
     @property
     def qubit_converter(self) -> QubitConverter | None:
         """The qubit operator converter."""

--- a/releasenotes/notes/fix-transpile-uccsd-db7f2557e6155017.yaml
+++ b/releasenotes/notes/fix-transpile-uccsd-db7f2557e6155017.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :class:`~qiskit_nature.circuit.library.ansatzes.UCC` and 
+    :class:`~qiskit_nature.circuit.library.ansatzes.UVCC` when
+    fully configured via the constructor failed to transpile and were not valid circuits.
+    This fixes that to ensure that if `UCC` / `UVCC` are fully configured then as circuits
+    they are are immediately valid from the get go.

--- a/test/circuit/library/ansatzes/test_chc.py
+++ b/test/circuit/library/ansatzes/test_chc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,6 +15,7 @@
 import unittest
 
 from test import QiskitNatureTestCase
+from test.circuit.library.ansatzes.utils.vibrational_op_label_creator import _create_labels
 
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance, algorithm_globals
@@ -27,8 +28,6 @@ from qiskit_nature.circuit.library.ansatzes.utils.vibration_excitation_generator
 from qiskit_nature.mappers.second_quantization import DirectMapper
 from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.operators.second_quantization import VibrationalOp
-
-from .utils.vibrational_op_label_creator import _create_labels
 
 
 class TestCHCVSCF(QiskitNatureTestCase):

--- a/test/circuit/library/ansatzes/test_ucc.py
+++ b/test/circuit/library/ansatzes/test_ucc.py
@@ -16,6 +16,7 @@ from test import QiskitNatureTestCase
 
 from ddt import data, ddt, unpack
 
+from qiskit import transpile
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.circuit.library import UCC
 from qiskit_nature.converters.second_quantization import QubitConverter
@@ -124,15 +125,31 @@ class TestUCC(QiskitNatureTestCase):
         def custom_excitations(num_spin_orbitals, num_particles):
             return excitations
 
+        with self.assertRaises(QiskitNatureError):
+            ansatz = UCC(
+                qubit_converter=converter,
+                num_particles=num_particles,
+                num_spin_orbitals=num_spin_orbitals,
+                excitations=custom_excitations,
+            )
+            ansatz.excitation_ops()
+
+    def test_transpile_no_parameters(self):
+        """Test transpilation without parameters"""
+
+        num_spin_orbitals = 8
+        num_particles = (2, 2)
+        qubit_converter = QubitConverter(mapper=JordanWignerMapper())
+
         ansatz = UCC(
-            qubit_converter=converter,
-            num_particles=num_particles,
             num_spin_orbitals=num_spin_orbitals,
-            excitations=custom_excitations,
+            num_particles=num_particles,
+            qubit_converter=qubit_converter,
+            excitations="s",
         )
 
-        with self.assertRaises(QiskitNatureError):
-            ansatz.excitation_ops()
+        ansatz = transpile(ansatz, optimization_level=3)
+        self.assertEqual(ansatz.num_qubits, 8)
 
     def test_build_ucc(self):
         """Test building UCC"""

--- a/test/circuit/library/ansatzes/test_uvcc.py
+++ b/test/circuit/library/ansatzes/test_uvcc.py
@@ -13,12 +13,13 @@
 """Test the UVCC Ansatz."""
 
 from test import QiskitNatureTestCase
+from test.circuit.library.ansatzes.utils.vibrational_op_label_creator import _create_labels
 
 import unittest
 
 from ddt import ddt, data, unpack
 
-from qiskit import BasicAer
+from qiskit import BasicAer, transpile
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.algorithms import VQE
 from qiskit.algorithms.optimizers import COBYLA
@@ -26,8 +27,6 @@ from qiskit_nature.circuit.library import UVCC, VSCF
 from qiskit_nature.mappers.second_quantization import DirectMapper
 from qiskit_nature.operators.second_quantization import VibrationalOp
 from qiskit_nature.converters.second_quantization import QubitConverter
-
-from .utils.vibrational_op_label_creator import _create_labels
 
 
 def assert_ucc_like_ansatz(test_case, ansatz, num_modals, expected_ops):
@@ -65,6 +64,15 @@ class TestUVCC(QiskitNatureTestCase):
         ansatz = UVCC(qubit_converter=converter, num_modals=num_modals, excitations=excitations)
 
         assert_ucc_like_ansatz(self, ansatz, num_modals, expect)
+
+    def test_transpile_no_parameters(self):
+        """Test transpilation without parameters"""
+
+        qubit_converter = QubitConverter(mapper=DirectMapper())
+
+        ansatz = UVCC(qubit_converter=qubit_converter, num_modals=[2], excitations="s")
+        ansatz = transpile(ansatz, optimization_level=3)
+        self.assertEqual(ansatz.num_qubits, 2)
 
 
 class TestUVCCVSCF(QiskitNatureTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #671


### Details and comments
UCC and UVCC when fully configured via the constructor failed to transpile and were not valid circuits. This fixes that to ensure that if UCC  / UVCC are fully configured then as circuits they are are immediately valid from the get go.

