### PR TITLE
Update 05_Sampling_potential_energy_surfaces.ipynb

### DIFF
--- a/docs/tutorials/05_Sampling_potential_energy_surfaces.ipynb
+++ b/docs/tutorials/05_Sampling_potential_energy_surfaces.ipynb
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Make a perturbation to the molecule along the absolute_stretching dof"
+    "### Make a perturbation to the molecule along the absolute_stretching Degree of Freedom (DoF)"
    ]
   },
   {


### PR DESCRIPTION
- the word `dof` only appears once and without the proper explanation next to it (even though one can infer from the rest of the notebook).
- this problem was raised by Y Zheng (dran.z) on crowdin [here](https://crowdin.com/translate/qiskit-docs/9674/en-zhcn?filter=basic&value=0#272798).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


