### PR TITLE
Make the sparse display format default of `FermionicOp` and apply the dense conversion in `FermionicOp.simplify`

### DIFF
--- a/qiskit_nature/operators/second_quantization/fermionic_op.py
+++ b/qiskit_nature/operators/second_quantization/fermionic_op.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import re
-import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from itertools import product
@@ -241,7 +240,7 @@ class FermionicOp(SecondQuantizedOp):
                   tuple (label, coeff), or list [(label, coeff)].
             register_length: positive integer that represents the length of registers.
             display_format: If sparse, the label is represented sparsely during output.
-                            if dense, the label is represented densely during output. (default: dense)
+                            if dense, the label is represented densely during output. (default: sparse)
 
         Raises:
             ValueError: given data is invalid value.
@@ -599,7 +598,7 @@ class FermionicOp(SecondQuantizedOp):
         if atol is None:
             atol = self.atol
 
-        data = defaultdict(float)  # type: dict[tuple[tuple[str, int], ...], complex]
+        data = defaultdict(complex)  # type: dict[str, complex]
         for label, coeff in self._to_dense_label_data():
             data[label] += coeff
         terms = [

--- a/qiskit_nature/operators/second_quantization/fermionic_op.py
+++ b/qiskit_nature/operators/second_quantization/fermionic_op.py
@@ -247,18 +247,7 @@ class FermionicOp(SecondQuantizedOp):
             ValueError: given data is invalid value.
             TypeError: given data has invalid type.
         """
-        if display_format is None:
-            display_format = "dense"
-            if FermionicOp._display_format_warn:
-                FermionicOp._display_format_warn = False
-                warnings.warn(
-                    "The default value for `display_format` will be changed from 'dense' "
-                    "to 'sparse' in version 0.3.0. Once that happens, you must specify "
-                    "display_format='dense' directly.",
-                    stacklevel=2,
-                )
-
-        self.display_format = display_format
+        self.display_format = display_format or "sparse"
 
         self._data: list[tuple[tuple[tuple[str, int], ...], complex]]
 
@@ -611,7 +600,7 @@ class FermionicOp(SecondQuantizedOp):
             atol = self.atol
 
         data = defaultdict(float)  # type: dict[tuple[tuple[str, int], ...], complex]
-        for label, coeff in self._data:
+        for label, coeff in self._to_dense_label_data():
             data[label] += coeff
         terms = [
             (label, coeff) for label, coeff in data.items() if not np.isclose(coeff, 0.0, atol=atol)

--- a/releasenotes/notes/fermionicop-sparse-format-3aa7c9d52b9396e4.yaml
+++ b/releasenotes/notes/fermionicop-sparse-format-3aa7c9d52b9396e4.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Changes the default ``display_format`` of the constructor of
+    :class:`~qiskit_nature.operators.second_quantization.FermionicOp` from "dense" to "sparse".

--- a/test/operators/second_quantization/test_fermionic_op.py
+++ b/test/operators/second_quantization/test_fermionic_op.py
@@ -52,7 +52,9 @@ class TestFermionicOp(QiskitNatureTestCase):
         """Fail if two FermionicOps are different.
         Note that this equality check is approximated since the true equality check is costly.
         """
-        self.assertSetEqual(frozenset(first.to_list()), frozenset(second.to_list()))
+        self.assertSetEqual(
+            frozenset(first.to_list()), frozenset(second.to_list(first.display_format))
+        )
 
     @data(
         *product(
@@ -346,7 +348,7 @@ class TestFermionicOp(QiskitNatureTestCase):
         with self.subTest("simplify doesn't reorder"):
             fer_op = FermionicOp("+_1 -_0")
             simplified_op = fer_op.simplify()
-            expected = [((("+", 1), ("-", 0)), 1)]
+            expected = [((("-", 0), ("+", 1)), -1)]
             self.assertEqual(simplified_op._data, expected)
 
     def test_hermiticity(self):
@@ -460,7 +462,7 @@ class TestFermionicOp(QiskitNatureTestCase):
                 fer_op = orig.to_normal_order()
             targ = FermionicOp("+_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for annihilation operator"):
             with warnings.catch_warnings():
@@ -469,7 +471,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.to_normal_order()
             targ = FermionicOp("-_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for number operator"):
             with warnings.catch_warnings():
@@ -478,7 +480,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.to_normal_order()
             targ = FermionicOp("+_0 -_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for empty operator"):
             with warnings.catch_warnings():
@@ -487,7 +489,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.to_normal_order()
             targ = FermionicOp([("", 1), ("+_0 -_0", -1)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for multiple operators 1"):
             with warnings.catch_warnings():
@@ -496,7 +498,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.to_normal_order()
             targ = FermionicOp([("+_1 -_0", -1)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for multiple operators 2"):
             with warnings.catch_warnings():
@@ -505,7 +507,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.to_normal_order()
             targ = FermionicOp([("+_1 -_2", 3), ("+_0 +_1 -_0 -_2", 3)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
     def test_normal_ordered(self):
         """test normal_ordered method"""
@@ -516,7 +518,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.normal_ordered()
             targ = FermionicOp("+_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for annihilation operator"):
             with warnings.catch_warnings():
@@ -525,7 +527,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.normal_ordered()
             targ = FermionicOp("-_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for number operator"):
             with warnings.catch_warnings():
@@ -534,7 +536,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.normal_ordered()
             targ = FermionicOp("+_0 -_0", display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for empty operator"):
             with warnings.catch_warnings():
@@ -543,32 +545,32 @@ class TestFermionicOp(QiskitNatureTestCase):
             fer_op = orig.normal_ordered()
             targ = FermionicOp([("", 1), ("+_0 -_0", -1)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for multiple operators 1"):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
                 orig = FermionicOp("-+")
             fer_op = orig.normal_ordered()
-            targ = FermionicOp([("+_1 -_0", -1)], display_format="sparse")
+            targ = FermionicOp([("-_0 +_1", 1)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test for multiple operators 2"):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
                 orig = 3 * FermionicOp("E+-")
             fer_op = orig.normal_ordered()
-            targ = FermionicOp([("+_1 -_2", 3), ("+_0 +_1 -_0 -_2", 3)], display_format="sparse")
+            targ = FermionicOp([("+_1 -_2", 3), ("+_0 -_0 +_1 -_2", -3)], display_format="sparse")
             self.assertFermionEqual(fer_op, targ)
-            self.assertEqual(orig.display_format, "dense")
+            self.assertEqual(orig.display_format, "sparse")
 
         with self.subTest("Test normal ordering simplifies"):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
                 orig = FermionicOp([("-_1 +_2", 3), ("+_2 -_1", -3)], display_format="sparse")
             fer_op = orig.normal_ordered()
-            expected = [((("+", 2), ("-", 1)), -6)]
+            expected = [((("-", 1), ("+", 2)), 6)]
             self.assertEqual(fer_op._data, expected)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Make the sparse display format default of `FermionicOp.__init__`
- Apply the dense conversion in `FermionicOp.simplify`

This PR is based on the proposal https://github.com/Qiskit/qiskit-nature/issues/585#issuecomment-1140769596

Closes #585 

### Details and comments

Even if this PR changes the default display format "sparse", the outcome of 0th power will be dense format due to the following line.

https://github.com/Qiskit/qiskit-nature/blob/b75742f46f6eaa255023f85c58729e09d4641add/qiskit_nature/operators/second_quantization/second_quantized_op.py#L39-L40

I think there is no common way to specify the sparse format for all `SecondQuantizedOp`. So, I updated the unit test as follows to allow comparison of the dense format and the sparse format.
I welcome your suggestion.

test_fermionic_op.py:L56-58
```python
        self.assertSetEqual(
            frozenset(first.to_list()), frozenset(second.to_list(first.display_format))
        )
```


