### PR TITLE
Run CI unit tests step without matplotlib,pyscf,psi4,pyquante2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,6 +239,26 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
+      - name: Nature Unit Tests without matplotlib/pyscf/psi4/pyquante2 under Python ${{ matrix.python-version }}
+        env:
+          PYTHONWARNINGS: default
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate psi4env
+          pip uninstall -y matplotlib pyscf
+          if [[ "${{ matrix.os }}" != "windows-2019" || ("${{ matrix.os }}" == "windows-2019" && "${{ matrix.python-version }}" != "3.10") ]]; then
+              echo 'Uninstall psi4'
+              conda remove -y --force psi4
+          fi
+          echo 'Uninstall pyquante2'
+          conda remove -y --force pyquante2_pure
+          pip uninstall -y pyquante2
+          if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}" == "true" ]; then
+              export QISKIT_TESTS="run_slow"
+          fi
+          stestr --test-path test run
+        if: ${{ !cancelled() }}
+        shell: bash
   Tutorials:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add additional CI step to run unit tests without optional libraries to make sure code loads and tests are skipped.


### Details and comments


