### PR TITLE
Fixes integer-based isinstance checks to also handle numpy integers.

### DIFF
--- a/qiskit_nature/properties/second_quantization/electronic/angular_momentum.py
+++ b/qiskit_nature/properties/second_quantization/electronic/angular_momentum.py
@@ -145,7 +145,7 @@ class AngularMomentum(ElectronicProperty):
             A new instance of this class.
         """
         return AngularMomentum(
-            h5py_group.attrs["num_spin_orbitals"],
+            int(h5py_group.attrs["num_spin_orbitals"]),
             h5py_group.attrs.get("spin", None),
             h5py_group.attrs["absolute_tolerance"],
             h5py_group.attrs["relative_tolerance"],

--- a/qiskit_nature/properties/second_quantization/electronic/magnetization.py
+++ b/qiskit_nature/properties/second_quantization/electronic/magnetization.py
@@ -79,7 +79,7 @@ class Magnetization(ElectronicProperty):
         Returns:
             A new instance of this class.
         """
-        return Magnetization(h5py_group.attrs["num_spin_orbitals"])
+        return Magnetization(int(h5py_group.attrs["num_spin_orbitals"]))
 
     @classmethod
     @deprecate_method("0.4.0")

--- a/qiskit_nature/properties/second_quantization/electronic/particle_number.py
+++ b/qiskit_nature/properties/second_quantization/electronic/particle_number.py
@@ -218,8 +218,8 @@ class ParticleNumber(ElectronicProperty):
             A new instance of this class.
         """
         return ParticleNumber(
-            h5py_group.attrs["num_spin_orbitals"],
-            (h5py_group.attrs["num_alpha"], h5py_group.attrs["num_beta"]),
+            int(h5py_group.attrs["num_spin_orbitals"]),
+            (int(h5py_group.attrs["num_alpha"]), int(h5py_group.attrs["num_beta"])),
             h5py_group["occupation_alpha"][Ellipsis],
             h5py_group["occupation_beta"][Ellipsis],
             h5py_group.attrs["absolute_tolerance"],

--- a/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
+++ b/qiskit_nature/transformers/second_quantization/electronic/active_space_transformer.py
@@ -136,7 +136,7 @@ class ActiveSpaceTransformer(BaseTransformer):
         self._density_inactive: OneBodyElectronicIntegrals = None
 
     def _check_configuration(self):
-        if isinstance(self._num_electrons, int):
+        if isinstance(self._num_electrons, (int, np.integer)):
             if self._num_electrons % 2 != 0:
                 raise QiskitNatureError(
                     "The number of active electrons must be even! Otherwise you must specify them "
@@ -149,7 +149,10 @@ class ActiveSpaceTransformer(BaseTransformer):
                     str(self._num_electrons),
                 )
         elif isinstance(self._num_electrons, tuple):
-            if not all(isinstance(n_elec, int) and n_elec >= 0 for n_elec in self._num_electrons):
+            if not all(
+                isinstance(n_elec, (int, np.integer)) and n_elec >= 0
+                for n_elec in self._num_electrons
+            ):
                 raise QiskitNatureError(
                     "Neither the number of alpha, nor the number of beta electrons can be "
                     "negative, not:",
@@ -161,7 +164,7 @@ class ActiveSpaceTransformer(BaseTransformer):
                 str(self._num_electrons),
             )
 
-        if isinstance(self._num_molecular_orbitals, int):
+        if isinstance(self._num_molecular_orbitals, (int, np.integer)):
             if self._num_molecular_orbitals < 0:
                 raise QiskitNatureError(
                     "The number of active orbitals cannot be negative, not:",
@@ -273,7 +276,7 @@ class ActiveSpaceTransformer(BaseTransformer):
         particle_number = grouped_property.get_property(ParticleNumber)
         if isinstance(self._num_electrons, tuple):
             num_alpha, num_beta = self._num_electrons
-        elif isinstance(self._num_electrons, int):
+        elif isinstance(self._num_electrons, (int, np.integer)):
             num_alpha = num_beta = self._num_electrons // 2
 
         # compute number of inactive electrons
@@ -343,7 +346,7 @@ class ActiveSpaceTransformer(BaseTransformer):
                 raise QiskitNatureError("More orbitals requested than available.")
             expected_num_electrons = (
                 self._num_electrons
-                if isinstance(self._num_electrons, int)
+                if isinstance(self._num_electrons, (int, np.integer))
                 else sum(self._num_electrons)
             )
             if sum(self._mo_occ_total[self._active_orbitals]) != expected_num_electrons:

--- a/releasenotes/notes/fix-isinstance-integer-checks-50f7614393e68e87.yaml
+++ b/releasenotes/notes/fix-isinstance-integer-checks-50f7614393e68e87.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug where numpy integer objects were causing integer-based isinstance
+    checks to fail. This also avoids such problems by explicitly converting integer
+    values to Python integers when loading properties from HDF5 files.

--- a/test/transformers/second_quantization/electronic/test_active_space_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_active_space_transformer.py
@@ -432,6 +432,31 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
             )
         )
 
+    def test_numpy_integer(self):
+        """Tests that numpy integer objects do not cause issues in `isinstance` checks.
+
+        This is a regression test against the fix applied by
+        https://github.com/Qiskit/qiskit-nature/pull/712
+        """
+        driver = HDF5Driver(
+            hdf5_input=self.get_resource_path(
+                "H2_631g.hdf5", "transformers/second_quantization/electronic"
+            )
+        )
+        driver_result = driver.run()
+
+        particle_number = driver_result.get_property("ParticleNumber")
+        particle_number.num_alpha = np.int64(particle_number.num_alpha)
+        particle_number.num_beta = np.int64(particle_number.num_beta)
+        particle_number.num_spin_orbitals = np.int64(particle_number.num_spin_orbitals)
+
+        driver_result.add_property(particle_number)
+
+        trafo = ActiveSpaceTransformer(
+            num_electrons=particle_number.num_particles, num_molecular_orbitals=2
+        )
+        _ = trafo.transform(driver_result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug where numpy integer objects were causing integer-based isinstance checks to fail.


### Details and comments

This also avoids such problems by explicitly converting integer values to Python integers when loading properties from HDF5 files.


