### PR TITLE
fix: do not hard-code minor Terra version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.21.0
+qiskit-terra>=0.21.*
 scipy>=1.4
 numpy>=1.17
 psutil>=5


### PR DESCRIPTION
Using 0.21 actually does not match any release candidates as explained
here: https://peps.python.org/pep-0440/#version-matching