### PR TITLE
Update protein_plotter.py

### DIFF
--- a/qiskit_nature/results/utils/protein_plotter.py
+++ b/qiskit_nature/results/utils/protein_plotter.py
@@ -118,7 +118,7 @@ class ProteinPlotter:
             side_scatter: Scattering object that we will use for the legend.
         """
 
-        self._ax_graph.set_box_aspect([1, 1, 1])
+        #self._ax_graph.set_box_aspect([1,1,1])
 
         self._ax_graph.grid(grid)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I have been simulating several proteins and trying to generate their 3D structure. But unfortunately, I am facing an error that says 'Axes3DSubplot' object has no attribute 'set_box_aspect' I have also explored matplotlib's Axes and the only parameter set_box_aspect take is aspect and that should be either a float or none.  

### Details and comments
Here is the link https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_box_aspect.html#matplotlib.axes.Axes.set_box_aspect
I might not be correct by commenting the "ax_graph.set_box_aspect" line out, but I have also tried changing the given list [1,1,1] to a float value which didn't work either. I strongly feel the error is with Axes3Dplot. Please look into this. Thanks!!

