### PR TITLE
Allow driver result to be passed to solver

### DIFF
--- a/qiskit_nature/algorithms/excited_states_solvers/excited_states_eigensolver.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/excited_states_eigensolver.py
@@ -22,6 +22,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.converters.second_quantization.utils import ListOrDict
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import EigenstateResult
 
 from .excited_states_solver import ExcitedStatesSolver
@@ -61,11 +62,12 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
         """Gets the operator and auxiliary operators, and transforms the provided auxiliary operators"""
         # Note that ``aux_ops`` contains not only the transformed ``aux_operators`` passed by the
         # user but also additional ones from the transformation
-        second_q_ops = problem.second_q_ops()
+        second_q_ops = problem.second_q_ops(driver_result)
         aux_second_q_ops: ListOrDictType[SecondQuantizedOp]
         if isinstance(second_q_ops, list):
             main_second_q_op = second_q_ops[0]
@@ -120,12 +122,14 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> EigenstateResult:
         """Compute Ground and Excited States properties.
 
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Raises:
             ValueError: if the grouped property object returned by the driver does not contain a

--- a/qiskit_nature/algorithms/excited_states_solvers/excited_states_solver.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/excited_states_solver.py
@@ -20,6 +20,7 @@ from qiskit.opflow import PauliSumOp
 from qiskit_nature import ListOrDictType
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import EigenstateResult
 
 
@@ -31,12 +32,14 @@ class ExcitedStatesSolver(ABC):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> EigenstateResult:
         r"""Compute the excited states energies of the molecule that was supplied via the driver.
 
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Returns:
             An interpreted :class:`~.EigenstateResult`. For more information see also
@@ -54,6 +57,7 @@ class ExcitedStatesSolver(ABC):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
         """Construct qubit operators by getting the second quantized operators from the problem
         (potentially running a driver in doing so [can be computationally expensive])
@@ -61,6 +65,7 @@ class ExcitedStatesSolver(ABC):
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Returns:
             Qubit operator.

--- a/qiskit_nature/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/algorithms/excited_states_solvers/qeom.py
@@ -33,6 +33,7 @@ from qiskit.opflow import (
 from qiskit_nature import ListOrDictType
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import EigenstateResult
 from .excited_states_solver import ExcitedStatesSolver
 from ..ground_state_solvers import GroundStateSolver
@@ -85,13 +86,15 @@ class QEOM(ExcitedStatesSolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
-        return self._gsc.get_qubit_operators(problem, aux_operators)
+        return self._gsc.get_qubit_operators(problem, aux_operators, driver_result)
 
     def solve(
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[SecondQuantizedOp]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> EigenstateResult:
         """Run the excited-states calculation.
 
@@ -101,6 +104,7 @@ class QEOM(ExcitedStatesSolver):
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Returns:
             An interpreted :class:`~.EigenstateResult`. For more information see also
@@ -117,7 +121,7 @@ class QEOM(ExcitedStatesSolver):
         groundstate_result = self._gsc.solve(problem, aux_operators)
 
         # 2. Prepare the excitation operators
-        second_q_ops = problem.second_q_ops()
+        second_q_ops = problem.second_q_ops(driver_result)
         if isinstance(second_q_ops, list):
             main_second_q_op = second_q_ops[0]
         elif isinstance(second_q_ops, dict):

--- a/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/adapt_vqe.py
@@ -32,6 +32,7 @@ from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.converters.second_quantization.utils import ListOrDict
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import ElectronicStructureResult
 from qiskit_nature.deprecation import deprecate_arguments
 
@@ -188,12 +189,14 @@ class AdaptVQE(GroundStateEigensolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> "AdaptVQEResult":
         """Computes the ground state.
 
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Raises:
             QiskitNatureError: if a solver other than VQE or a ansatz other than UCCSD is provided
@@ -211,7 +214,7 @@ class AdaptVQE(GroundStateEigensolver):
             information about the AdaptVQE algorithm like the number of iterations, finishing
             criterion, and the final maximum gradient.
         """
-        second_q_ops = problem.second_q_ops()
+        second_q_ops = problem.second_q_ops(driver_result)
 
         aux_second_q_ops: ListOrDictType[SecondQuantizedOp]
         if isinstance(second_q_ops, list):

--- a/qiskit_nature/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -27,6 +27,7 @@ from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.converters.second_quantization.utils import ListOrDict
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import EigenstateResult
 from .ground_state_solver import GroundStateSolver
 from .minimum_eigensolver_factories import MinimumEigensolverFactory
@@ -68,12 +69,14 @@ class GroundStateEigensolver(GroundStateSolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> EigenstateResult:
         """Compute Ground State properties.
 
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Raises:
             ValueError: if the grouped property object returned by the driver does not contain a
@@ -87,7 +90,7 @@ class GroundStateEigensolver(GroundStateSolver):
             An interpreted :class:`~.EigenstateResult`. For more information see also
             :meth:`~.BaseProblem.interpret`.
         """
-        main_operator, aux_ops = self.get_qubit_operators(problem, aux_operators)
+        main_operator, aux_ops = self.get_qubit_operators(problem, aux_operators, driver_result)
         raw_mes_result = self._solver.compute_minimum_eigenvalue(main_operator, aux_ops)  # type: ignore
 
         result = problem.interpret(raw_mes_result)
@@ -97,11 +100,12 @@ class GroundStateEigensolver(GroundStateSolver):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
         """Gets the operator and auxiliary operators, and transforms the provided auxiliary operators"""
         # Note that ``aux_ops`` contains not only the transformed ``aux_operators`` passed by the
         # user but also additional ones from the transformation
-        second_q_ops = problem.second_q_ops()
+        second_q_ops = problem.second_q_ops(driver_result)
         aux_second_q_ops: ListOrDictType[SecondQuantizedOp]
         if isinstance(second_q_ops, list):
             main_second_q_op = second_q_ops[0]

--- a/qiskit_nature/algorithms/ground_state_solvers/ground_state_solver.py
+++ b/qiskit_nature/algorithms/ground_state_solvers/ground_state_solver.py
@@ -26,6 +26,7 @@ from qiskit_nature import ListOrDictType
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.problems.second_quantization import BaseProblem
+from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 from qiskit_nature.results import EigenstateResult
 
 
@@ -45,12 +46,14 @@ class GroundStateSolver(ABC):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> EigenstateResult:
         """Compute the ground state energy of the molecule that was supplied via the driver.
 
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously calculated driver result.
 
         Returns:
             An interpreted :class:`~.EigenstateResult`. For more information see also
@@ -63,6 +66,7 @@ class GroundStateSolver(ABC):
         self,
         problem: BaseProblem,
         aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        driver_result: Optional[ElectronicStructureDriverResult] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
         """Construct qubit operators by getting the second quantized operators from the problem
         (potentially running a driver in doing so [can be computationally expensive])
@@ -70,6 +74,7 @@ class GroundStateSolver(ABC):
         Args:
             problem: a class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
+            driver_result: Previously generated driver result.
 
         Returns:
             Qubit operator.

--- a/qiskit_nature/problems/second_quantization/base_problem.py
+++ b/qiskit_nature/problems/second_quantization/base_problem.py
@@ -104,10 +104,16 @@ class BaseProblem(ABC):
         return None
 
     @abstractmethod
-    def second_q_ops(self) -> ListOrDictType[SecondQuantizedOp]:
+    def second_q_ops(
+        self,
+        driver_result: Optional[GroupedSecondQuantizedProperty],
+    ) -> ListOrDictType[SecondQuantizedOp]:
         """Returns the second quantized operators associated with this Property.
 
         The actual return-type is determined by `qiskit_nature.settings.dict_aux_operators`.
+
+        Args:
+            driver_result: Previously calculated driver result.
 
         Returns:
             A `list` or `dict` of `SecondQuantizedOp` objects.

--- a/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/electronic/electronic_structure_problem.py
@@ -25,6 +25,7 @@ from qiskit_nature.circuit.library.initial_states.hartree_fock import hartree_fo
 from qiskit_nature.drivers.second_quantization import ElectronicStructureDriver
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.converters.second_quantization import QubitConverter
+from qiskit_nature.properties.second_quantization import GroupedSecondQuantizedProperty
 from qiskit_nature.properties.second_quantization.electronic import ParticleNumber
 from qiskit_nature.results import EigenstateResult, ElectronicStructureResult
 from qiskit_nature.transformers.second_quantization import BaseTransformer
@@ -73,7 +74,10 @@ class ElectronicStructureProblem(BaseProblem):
             )
         return self._grouped_property_transformed.get_property("ParticleNumber").num_spin_orbitals
 
-    def second_q_ops(self) -> ListOrDictType[SecondQuantizedOp]:
+    def second_q_ops(
+        self,
+        driver_result: Optional[GroupedSecondQuantizedProperty] = None,
+    ) -> ListOrDictType[SecondQuantizedOp]:
         """Returns the second quantized operators associated with this Property.
 
         If the arguments are returned as a `list`, the operators are in the following order: the
@@ -81,11 +85,14 @@ class ElectronicStructureProblem(BaseProblem):
         magnetization operator, and (if available) x, y, z dipole operators.
 
         The actual return-type is determined by `qiskit_nature.settings.dict_aux_operators`.
-
+        Args:
+            driver_result: An optional GroupedSecondQuantizedProperty that can be provided if
+                           the driver results are already known.
         Returns:
             A `list` or `dict` of `SecondQuantizedOp` objects.
         """
-        driver_result = self.driver.run()
+        if driver_result is None:
+            driver_result = self.driver.run()
 
         self._grouped_property = driver_result
         self._grouped_property_transformed = self._transform(self._grouped_property)

--- a/qiskit_nature/problems/second_quantization/lattice/lattice_model_problem.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattice_model_problem.py
@@ -20,6 +20,7 @@ from qiskit.opflow import PauliSumOp
 from qiskit_nature import ListOrDictType, settings
 from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
+from qiskit_nature.properties.second_quantization import GroupedSecondQuantizedProperty
 from qiskit_nature.results import EigenstateResult, LatticeModelResult
 
 from ..base_problem import BaseProblem
@@ -37,14 +38,24 @@ class LatticeModelProblem(BaseProblem):
         super().__init__(main_property_name="LatticeEnergy")
         self._lattice_model = lattice_model
 
-    def second_q_ops(self) -> ListOrDictType[SecondQuantizedOp]:
+    def second_q_ops(
+        self,
+        driver_result: Optional[GroupedSecondQuantizedProperty] = None,
+    ) -> ListOrDictType[SecondQuantizedOp]:
         """Returns the second quantized operators created based on the lattice models.
+
+        Args:
+            driver_result: Previously calculated driver result.
 
         Returns:
             A ``list`` or ``dict`` of
             :class:`~qiskit_nature.operators.second_quantization.SecondQuantizedOp`
         """
-        second_q_ops: ListOrDictType[SecondQuantizedOp] = self._lattice_model.second_q_ops()
+        if driver_result is None:
+            second_q_ops: ListOrDictType[SecondQuantizedOp] = self._lattice_model.second_q_ops()
+        else:
+            second_q_ops = driver_result.second_q_ops()
+
         if settings.dict_aux_operators:
             second_q_ops = {self._main_property_name: second_q_ops}
         else:

--- a/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
+++ b/qiskit_nature/problems/second_quantization/vibrational/vibrational_structure_problem.py
@@ -23,9 +23,8 @@ from qiskit_nature import ListOrDictType
 from qiskit_nature.drivers.second_quantization import VibrationalStructureDriver
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.converters.second_quantization import QubitConverter
-from qiskit_nature.properties.second_quantization.vibrational import (
-    VibrationalStructureDriverResult,
-)
+from qiskit_nature.properties.second_quantization import GroupedSecondQuantizedProperty
+from qiskit_nature.properties.second_quantization.vibrational import VibrationalStructureDriverResult
 from qiskit_nature.properties.second_quantization.vibrational.bases import HarmonicBasis
 from qiskit_nature.results import EigenstateResult, VibrationalStructureResult
 from qiskit_nature.transformers.second_quantization import BaseTransformer
@@ -55,7 +54,10 @@ class VibrationalStructureProblem(BaseProblem):
         self.num_modals = num_modals
         self.truncation_order = truncation_order
 
-    def second_q_ops(self) -> ListOrDictType[SecondQuantizedOp]:
+    def second_q_ops(
+        self,
+        driver_result: Optional[GroupedSecondQuantizedProperty] = None,
+    ) -> ListOrDictType[SecondQuantizedOp]:
         """Returns the second quantized operators created based on the driver and transformations.
 
         If the arguments are returned as a `list`, the operators are in the following order: the
@@ -63,10 +65,14 @@ class VibrationalStructureProblem(BaseProblem):
 
         The actual return-type is determined by `qiskit_nature.settings.dict_aux_operators`.
 
+        Args:
+            driver_result: Previously calculated driver result
+
         Returns:
             A `list` or `dict` of `SecondQuantizedOp` objects.
         """
-        driver_result = self.driver.run()
+        if driver_result is None:
+            driver_result = self.driver.run()
 
         self._grouped_property = driver_result
         self._grouped_property_transformed = self._transform(self._grouped_property)

--- a/releasenotes/notes/short-description-string-7ad8606b0405ffc6.yaml
+++ b/releasenotes/notes/short-description-string-7ad8606b0405ffc6.yaml
@@ -1,0 +1,15 @@
+---
+feature:
+  - |
+    Introduced new functionality that allows a previously calculated driver
+    result to be passed as an optional argument when using an eigensolver.
+    This allows the solver to avoid doing redundant calculations.
+    
+    Example Usage::
+        driver_result = driver.run()
+        problem = ElectronicStructureProblem(driver, tranformers=[])
+        qubit_converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)
+        gs_solver = GroundStateEigenSolver(qubit_converter, NumPyMinimumEigensolver())
+        gs_result = gs_solver.solve(problem, driver_result=driver_result)
+---
+


### PR DESCRIPTION
The changes in this commit allow for a previously calculated driver
result to be passed to the eigensolver for it to get information on the
molecule. In its current state, the driver is run regardless of whether
or not the result is already known.

As the size of the models increase, it is important that expensive operations
like driver.run() are used only when necessary and avoided when
possible. This change introduces the framework for that.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


