### PR TITLE
[Refactor] Temporary disable running stable tutorials in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,37 +312,6 @@ jobs:
         with:
           name: tutorials${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
-      - name: Run stable tutorials
-        env:
-          QISKIT_PARALLEL: False
-          QISKIT_DOCS_BUILD_TUTORIALS: 'always'
-        run: |
-          # clean last sphinx output
-          make clean_sphinx
-          # get current version
-          version=$(pip show qiskit-nature | awk -F. '/^Version:/ { print substr($1,10), $2-1 }' OFS=.)
-          # download stable version
-          wget https://codeload.github.com/Qiskit/qiskit-nature/zip/stable/$version -O /tmp/repo.zip
-          unzip /tmp/repo.zip -d /tmp/
-          # copy stable tutorials to main tutorials
-          rm -rf docs/tutorials/*
-          cp -R /tmp/qiskit-nature-stable-$version/docs/tutorials/* docs/tutorials
-          # run tutorials and zip results
-          echo "earliest_version: 0.1.0" >> releasenotes/config.yaml
-          # ignore unreleased/untagged notes
-          tools/ignore_untagged_notes.sh
-          make html
-          cd docs/_build/html
-          mkdir artifacts
-          tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
-        if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
-        shell: bash
-      - name: Run upload stable tutorials
-        uses: actions/upload-artifact@v2
-        with:
-          name: tutorials-stable${{ matrix.python-version }}
-          path: docs/_build/html/artifacts/tutorials.tar.gz
-        if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
     needs: [Checks, Nature, Tutorials]
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
While the refactor branch doesn't contain the old code, the stable tutorials will fail.
Disable running them until the old deprecated code gets reinstated.

This PR will need to be reverted in the final PR from "refactor" to "main"


### Details and comments


