### PR TITLE
fix: ensure compatibility of generalized and preserve_spin

### DIFF
--- a/qiskit_nature/second_q/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
+++ b/qiskit_nature/second_q/circuit/library/ansatzes/utils/fermionic_excitation_generator.py
@@ -160,7 +160,9 @@ def generate_fermionic_excitations(
         # generating the single excitations of an _interleaved_ spin orbital system.
         # For this, we can reuse the alpha single excitation generator in a system of double the
         # actual size.
-        single_excitations = get_alpha_excitations(sum(num_particles), num_spin_orbitals * 2, False)
+        single_excitations = get_alpha_excitations(
+            sum(num_particles), num_spin_orbitals * 2, generalized
+        )
 
         def interleaved2blocked(index: int, total: int) -> int:
             if index % 2 == 0:

--- a/releasenotes/notes/fix-generalized-non-spin-preserving-excitations-72745abc12e06c92.yaml
+++ b/releasenotes/notes/fix-generalized-non-spin-preserving-excitations-72745abc12e06c92.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the compatibility of the fermionic excitation generator options which
+    disables spin preserving while also enabling generalized behavior.

--- a/test/second_q/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/second_q/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -203,3 +203,33 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
             num_excitations, num_spin_orbitals, num_particles, preserve_spin=False
         )
         self.assertEqual(excitations, expect)
+
+    @unpack
+    @data(
+        (
+            1,
+            4,
+            [0, 0],
+            [((0,), (1,)), ((0,), (2,)), ((0,), (3,)), ((1,), (3,)), ((2,), (1,)), ((2,), (3,))],
+        ),
+        (
+            1,
+            4,
+            [1, 0],
+            [((0,), (1,)), ((0,), (2,)), ((0,), (3,)), ((1,), (3,)), ((2,), (1,)), ((2,), (3,))],
+        ),
+        (
+            1,
+            4,
+            [1, 1],
+            [((0,), (1,)), ((0,), (2,)), ((0,), (3,)), ((1,), (3,)), ((2,), (1,)), ((2,), (3,))],
+        ),
+    )
+    def test_generalized_preserve_spin_excitations(
+        self, num_excitations, num_spin_orbitals, num_particles, expect
+    ):
+        """Test allowing spin-flipped excitations."""
+        excitations = generate_fermionic_excitations(
+            num_excitations, num_spin_orbitals, num_particles, generalized=True, preserve_spin=False
+        )
+        self.assertEqual(excitations, expect)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I noticed an incompatibility between `generalized=True` and `preserve_spin=False` in the fermionic excitation generator method.
This PR fixes and tests this.

### Details and comments


