### PR TITLE
refactor: use TemporaryDirectory where possible

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -122,7 +122,8 @@ class TestLogging(QiskitNatureTestCase):
             finally:
                 with open(tmp_file, encoding="utf8") as file:
                     lines = file.read()
-                file_handler.close()
+                for name in self._logging_dict:
+                    nature_logging.remove_handler(name, file_handler)
 
         for name in self._logging_dict:
             self.assertTrue(f"{name}." in lines, msg=f"name {name} not found in log file.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Instead of using a NamedTemporaryFile and juggle its existence state,
this commit refactors all scenarios to use a TemporaryDirectory within
which the file names can be controlled more easily.
The reason for this refactoring was to guard against possible runtime
conflicts when multiple processes might be attempting to access the same
temporary file name, after the object has been unlinked (which might
free up the temporary name for reuse).

### Details and comments

Thanks @woodsp-ibm for this suggestion :+1: 
