### PR TITLE
Fix behavior of `FermionicOp.simplify` on zero-operators

### DIFF
--- a/qiskit_nature/operators/second_quantization/fermionic_op.py
+++ b/qiskit_nature/operators/second_quantization/fermionic_op.py
@@ -248,7 +248,10 @@ class FermionicOp(SecondQuantizedOp):
 
         self._data: list[tuple[tuple[tuple[str, int], ...], complex]]
 
-        if (
+        if not isinstance(data, str) and not data:
+            # empty list or tuple means zero operator
+            self._data = [((), 0j)]
+        elif (
             isinstance(data, list)
             and isinstance(data[0], tuple)
             and isinstance(data[0][0], tuple)

--- a/releasenotes/notes/fix-simplify-zero-fermionicop-f2f68e6f19613468.yaml
+++ b/releasenotes/notes/fix-simplify-zero-fermionicop-f2f68e6f19613468.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the behavior of `FermionicOp.simplify` when called on a zero-operator.

--- a/test/operators/second_quantization/test_fermionic_op.py
+++ b/test/operators/second_quantization/test_fermionic_op.py
@@ -351,6 +351,12 @@ class TestFermionicOp(QiskitNatureTestCase):
             expected = [((("-", 0), ("+", 1)), -1)]
             self.assertEqual(simplified_op._data, expected)
 
+        with self.subTest("simplify zero"):
+            fer_op = FermionicOp("+") - FermionicOp("+")
+            simplified_op = fer_op.simplify()
+            targ = FermionicOp.zero(1)
+            self.assertFermionEqual(simplified_op, targ)
+
     def test_hermiticity(self):
         """test is_hermitian"""
         with self.subTest("operator hermitian"):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #781

### Details and comments

This is a partial back-port of #697
