### PR TITLE
[Stable] Fix #788 (#789) backport

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -98,6 +98,7 @@ cz
 das
 dataset
 dcx
+de
 debye
 deepcopy
 dft

--- a/releasenotes/notes/fix-generalized-non-spin-preserving-excitations-72745abc12e06c92.yaml
+++ b/releasenotes/notes/fix-generalized-non-spin-preserving-excitations-72745abc12e06c92.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes the compatibility of the fermionic excitation generator options which
+    disables spin preserving while also enabling generalized behavior.
+    Now, combining `generalized=True` with `preserve_spin=False` results in all
+    combinations of excitations in the given spin orbital space. De-excitations
+    are not included and filtered accordingly.

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -201,5 +201,65 @@ class TestFermionicExcitationGenerator(QiskitNatureTestCase):
         """Test allowing spin-flipped excitations."""
         excitations = generate_fermionic_excitations(
             num_excitations, num_spin_orbitals, num_particles, preserve_spin=False
+        )
+        self.assertEqual(excitations, expect)
+
+    @unpack
+    @data(
+        (1, 4, [1, 1], [((0,), (1,)), ((0,), (3,)), ((2,), (1,)), ((2,), (3,))]),
+        (1, 4, [2, 1], [((0,), (1,)), ((0,), (3,)), ((2,), (1,)), ((2,), (3,))]),
+        (1, 4, [2, 2], [((0,), (1,)), ((0,), (3,)), ((2,), (1,)), ((2,), (3,))]),
+        (2, 4, [1, 1], [((0, 2), (1, 3))]),
+        (
+            1,
+            6,
+            [1, 1],
+            [
+                ((0,), (1,)),
+                ((0,), (2,)),
+                ((0,), (4,)),
+                ((0,), (5,)),
+                ((1,), (2,)),
+                ((1,), (5,)),
+                ((3,), (1,)),
+                ((3,), (2,)),
+                ((3,), (4,)),
+                ((3,), (5,)),
+                ((4,), (2,)),
+                ((4,), (5,)),
+            ],
+        ),
+        (
+            2,
+            6,
+            [1, 1],
+            [
+                ((0, 3), (1, 2)),
+                ((0, 3), (1, 4)),
+                ((0, 3), (1, 5)),
+                ((0, 4), (1, 2)),
+                ((0, 4), (1, 5)),
+                ((0, 1), (2, 5)),
+                ((0, 3), (2, 4)),
+                ((0, 3), (2, 5)),
+                ((0, 4), (2, 5)),
+                ((0, 3), (4, 5)),
+                ((1, 3), (2, 4)),
+                ((1, 3), (2, 5)),
+                ((1, 4), (2, 5)),
+                ((1, 3), (5, 4)),
+                ((3, 4), (2, 5)),
+            ],
+        ),
+    )
+    def test_generalized_preserve_spin_excitations(
+        self, num_excitations, num_spin_orbitals, num_particles, expect
+    ):
+        """Test combining generalized and preserve_spin settings.
+
+        This is a regression-test against https://github.com/Qiskit/qiskit-nature/issues/788
+        """
+        excitations = generate_fermionic_excitations(
+            num_excitations, num_spin_orbitals, num_particles, preserve_spin=False, generalized=True
         )
         self.assertEqual(excitations, expect)


### PR DESCRIPTION
This commit properly ensures the compatibility of the generalized and
preserve_spin keyword arguments available in the fermionic excitation
generator methods.
A previous attempt to fix this was done in #747, but some edge cases
were overlooked.

This commit also includes the same patch as a bugfix in the legacy code
location.

Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


