### PR TITLE
Load Aer dynamically in unit tests

### DIFF
--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -22,7 +22,6 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 
-import qiskit
 from qiskit import BasicAer
 from qiskit.algorithms import VQE
 from qiskit.algorithms.optimizers import SLSQP, SPSA
@@ -329,7 +328,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_eval_op_qasm_aer(self):
         """Regression tests against https://github.com/Qiskit/qiskit-nature/issues/53."""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         solver = VQEUCCFactory(
             optimizer=SLSQP(maxiter=100),
@@ -414,7 +416,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_statevector(self):
         """uccsd hf test with Aer statevector"""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator_statevector")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 
@@ -435,7 +440,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_qasm(self):
         """uccsd hf test with Aer qasm simulator."""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 
@@ -461,7 +469,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_qasm_snapshot(self):
         """uccsd hf test with Aer qasm simulator snapshot."""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 

--- a/test/algorithms/pes_samplers/test_bopes_sampler.py
+++ b/test/algorithms/pes_samplers/test_bopes_sampler.py
@@ -21,7 +21,6 @@ import numpy as np
 from qiskit.opflow import PauliOp
 from qiskit.quantum_info import Pauli
 
-import qiskit
 from qiskit.algorithms import NumPyMinimumEigensolver, VQE
 from qiskit.utils import algorithm_globals, QuantumInstance, optionals
 import qiskit_nature.optionals as _optionals
@@ -134,8 +133,11 @@ class TestBOPES(QiskitNatureTestCase):
     def test_vqe_bootstrap(self):
         """Test with VQE and bootstrapping."""
         qubit_converter = QubitConverter(JordanWignerMapper())
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         quantum_instance = QuantumInstance(
-            backend=qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            backend=aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=self.seed,
             seed_transpiler=self.seed,
         )
@@ -170,8 +172,11 @@ class TestBOPES(QiskitNatureTestCase):
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_h2_bopes_sampler_with_factory(self):
         """Test BOPES Sampler with Factory"""
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         quantum_instance = QuantumInstance(
-            backend=qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            backend=aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=self.seed,
             seed_transpiler=self.seed,
         )
@@ -266,8 +271,11 @@ class TestBOPES(QiskitNatureTestCase):
         problem = ElectronicStructureProblem(driver)
 
         qubit_converter = QubitConverter(JordanWignerMapper(), z2symmetry_reduction=None)
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         quantum_instance = QuantumInstance(
-            backend=qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            backend=aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=self.seed,
             seed_transpiler=self.seed,
         )
@@ -312,8 +320,11 @@ class TestBOPES(QiskitNatureTestCase):
         problem = ElectronicStructureProblem(driver)
 
         qubit_converter = QubitConverter(JordanWignerMapper(), z2symmetry_reduction=None)
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         quantum_instance = QuantumInstance(
-            backend=qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            backend=aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=self.seed,
             seed_transpiler=self.seed,
         )

--- a/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -21,7 +21,6 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 
-import qiskit
 from qiskit import BasicAer
 from qiskit.algorithms import VQE
 from qiskit.algorithms.optimizers import SLSQP, SPSA
@@ -286,8 +285,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_eval_op_qasm_aer(self):
         """Regression tests against https://github.com/Qiskit/qiskit-nature/issues/53."""
+        import importlib
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         solver = VQEUCCFactory(
             optimizer=SLSQP(maxiter=100),
@@ -370,7 +371,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_statevector(self):
         """uccsd hf test with Aer statevector"""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator_statevector")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 
@@ -391,7 +395,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_qasm(self):
         """uccsd hf test with Aer qasm simulator."""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 
@@ -417,7 +424,10 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_uccsd_hf_aer_qasm_snapshot(self):
         """uccsd hf test with Aer qasm simulator snapshot."""
 
-        backend = qiskit.providers.aer.Aer.get_backend("aer_simulator")
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+        backend = aer.Aer.get_backend("aer_simulator")
 
         ansatz = self._prepare_uccsd_hf(self.qubit_converter)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Aer is in the process of migrating out of namespaces.
In the meantime, `from qiskit import Aer` emits a deprecation asking to use `qiskit_aer` which is not ready yet.
Using `qiskit.providers.aer` works fine but it is giving pylint errors for some people locally.

Until qiskit-aer has its own root package `qiskit_aer`, I am importing  Aer dynamically under unit tests to avoid possible local pylint errors.


### Details and comments


