### PR TITLE
Fix existing initial points with reps

### DIFF
--- a/qiskit_nature/algorithms/initial_points/hf_initial_point.py
+++ b/qiskit_nature/algorithms/initial_points/hf_initial_point.py
@@ -147,7 +147,8 @@ class HFInitialPoint(InitialPoint):
         self._compute()
 
     def _compute(self) -> None:
-        self._parameters = np.zeros(len(self._excitation_list))
+        reps = self._ansatz.reps if self._ansatz is not None else 1
+        self._parameters = np.zeros(reps * len(self._excitation_list))
 
     def get_energy(self) -> float:
         """The reference energy.

--- a/qiskit_nature/algorithms/initial_points/mp2_initial_point.py
+++ b/qiskit_nature/algorithms/initial_points/mp2_initial_point.py
@@ -312,7 +312,9 @@ class MP2InitialPoint(InitialPoint):
         """The initial point as an array."""
         if self._corrections is None:
             self.compute()
-        return np.asarray([correction.coefficient for correction in self._corrections])
+        coefficients = np.asarray([correction.coefficient for correction in self._corrections])
+        reps = self._ansatz.reps if self._ansatz is not None else 1
+        return np.tile(coefficients, reps)
 
     def get_energy_corrections(self) -> np.ndarray:
         """The energy corrections for each excitation."""

--- a/qiskit_nature/algorithms/initial_points/vscf_initial_point.py
+++ b/qiskit_nature/algorithms/initial_points/vscf_initial_point.py
@@ -129,5 +129,5 @@ class VSCFInitialPoint(InitialPoint):
                 "Set the ansatz or call compute with it as an argument. "
                 "The ansatz is not required if the excitation list has been set directly."
             )
-
-        self._parameters = np.zeros(len(self._excitation_list))
+        reps = self._ansatz.reps if self._ansatz is not None else 1
+        self._parameters = reps * np.zeros(len(self._excitation_list))

--- a/qiskit_nature/algorithms/initial_points/vscf_initial_point.py
+++ b/qiskit_nature/algorithms/initial_points/vscf_initial_point.py
@@ -130,4 +130,4 @@ class VSCFInitialPoint(InitialPoint):
                 "The ansatz is not required if the excitation list has been set directly."
             )
         reps = self._ansatz.reps if self._ansatz is not None else 1
-        self._parameters = reps * np.zeros(len(self._excitation_list))
+        self._parameters = np.zeros(reps * len(self._excitation_list))

--- a/releasenotes/notes/fix-existing-initial-point-with-reps-5ca0fd2defe00539.yaml
+++ b/releasenotes/notes/fix-existing-initial-point-with-reps-5ca0fd2defe00539.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the initial point classes to account for the number of times the evolved operators are
+    repeated in the ansatz.

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -63,6 +63,7 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         algorithm_globals.random_seed = self.seed
 
         self.reference_energy = -1.1373060356951838
+        self.mp2_initial_point = [0.0, 0.0, -0.07197145]
 
         self.qubit_converter = QubitConverter(JordanWignerMapper())
         self.electronic_structure_problem = ElectronicStructureProblem(self.driver)
@@ -594,7 +595,55 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         res = calc.solve(self.electronic_structure_problem)
 
         np.testing.assert_array_almost_equal(
-            solver.initial_point.to_numpy_array(), [0.0, 0.0, -0.07197145]
+            solver.initial_point.to_numpy_array(), self.mp2_initial_point
+        )
+        self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
+
+    def test_vqe_ucc_factory_with_reps(self):
+        """Test when using the default initial point with repeated evolved operators."""
+        ansatz = UCCSD(
+            qubit_converter=self.qubit_converter,
+            num_particles=self.num_particles,
+            num_spin_orbitals=self.num_spin_orbitals,
+            reps=2,
+        )
+
+        solver = VQEUCCFactory(
+            ansatz=ansatz,
+            quantum_instance=QuantumInstance(BasicAer.get_backend("statevector_simulator")),
+        )
+        calc = GroundStateEigensolver(self.qubit_converter, solver)
+        res = calc.solve(self.electronic_structure_problem)
+
+        np.testing.assert_array_almost_equal(
+            solver.initial_point.to_numpy_array(), np.zeros(6, dtype=float)
+        )
+        self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
+
+    def test_vqe_ucc_factory_with_mp2_with_reps(self):
+        """Test when using MP2InitialPoint to generate the initial point with repeated evolved
+        operators.
+        """
+
+        initial_point = MP2InitialPoint()
+
+        ansatz = UCCSD(
+            qubit_converter=self.qubit_converter,
+            num_particles=self.num_particles,
+            num_spin_orbitals=self.num_spin_orbitals,
+            reps=2,
+        )
+
+        solver = VQEUCCFactory(
+            ansatz=ansatz,
+            quantum_instance=QuantumInstance(BasicAer.get_backend("statevector_simulator")),
+            initial_point=initial_point,
+        )
+        calc = GroundStateEigensolver(self.qubit_converter, solver)
+        res = calc.solve(self.electronic_structure_problem)
+
+        np.testing.assert_array_almost_equal(
+            solver.initial_point.to_numpy_array(), np.tile(self.mp2_initial_point, 2)
         )
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 

--- a/test/algorithms/initial_points/test_hf_initial_point.py
+++ b/test/algorithms/initial_points/test_hf_initial_point.py
@@ -46,6 +46,7 @@ class TestHFInitialPoint(QiskitNatureTestCase):
     def test_set_get_ansatz(self):
         """Test set get ansatz."""
         ansatz = Mock(spec=UCC)
+        ansatz.reps = 1
         ansatz.excitation_list = self.excitation_list
         self.hf_initial_point.ansatz = ansatz
         self.assertEqual(ansatz, self.hf_initial_point.ansatz)
@@ -89,6 +90,7 @@ class TestHFInitialPoint(QiskitNatureTestCase):
         """Test length of HF initial point array."""
         grouped_property = Mock(spec=GroupedSecondQuantizedProperty)
         ansatz = Mock(spec=UCC)
+        ansatz.reps = 1
         ansatz.excitation_list = self.excitation_list
         self.hf_initial_point.compute(ansatz=ansatz, grouped_property=grouped_property)
         initial_point = self.hf_initial_point.to_numpy_array()

--- a/test/algorithms/initial_points/test_mp2_initial_point.py
+++ b/test/algorithms/initial_points/test_mp2_initial_point.py
@@ -55,6 +55,7 @@ class TestMP2InitialPoint(QiskitNatureTestCase):
 
         self.excitation_list = [[[0], [1]]]
         self.mock_ansatz = Mock(spec=UCC)
+        self.mock_ansatz.reps = 1
         self.mock_ansatz.excitation_list = self.excitation_list
 
         electronic_energy = Mock(spec=ElectronicEnergy)
@@ -133,6 +134,7 @@ class TestMP2InitialPoint(QiskitNatureTestCase):
         self.mock_grouped_property.get_property = Mock(return_value=electronic_energy)
 
         ansatz = Mock(spec=UCC)
+        ansatz.reps = 1
         ansatz.excitation_list = self.excitation_list
 
         mp2_initial_point = MP2InitialPoint()
@@ -239,6 +241,7 @@ class TestMP2InitialPoint(QiskitNatureTestCase):
         driver_result = problem.grouped_property_transformed
 
         ansatz = Mock(spec=UCC)
+        ansatz.reps = 1
         ansatz.excitation_list = excitations
 
         mp2_initial_point = MP2InitialPoint()

--- a/test/algorithms/initial_points/test_vscf_initial_point.py
+++ b/test/algorithms/initial_points/test_vscf_initial_point.py
@@ -43,6 +43,7 @@ class TestVSCFInitialPoint(QiskitNatureTestCase):
     def test_set_get_ansatz(self):
         """Test set get ansatz."""
         ansatz = Mock(spec=UVCC)
+        ansatz.reps = 1
         ansatz.excitation_list = self.excitation_list
         self.vscf_initial_point.ansatz = ansatz
         self.assertEqual(ansatz, self.vscf_initial_point.ansatz)
@@ -64,6 +65,7 @@ class TestVSCFInitialPoint(QiskitNatureTestCase):
     def test_vscf_compute(self):
         """Test VSCF initial point is all zero when called via compute."""
         ansatz = Mock(spec=UVCC)
+        ansatz.reps = 1
         ansatz.excitation_list = self.excitation_list
         self.vscf_initial_point.compute(ansatz)
         initial_point = self.vscf_initial_point.to_numpy_array()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes the existing initial point classes to account for the number of times the evolved operators are repeated in the ansatz.

The new initial point classes are fixed with some additional refactoring in PR #805. This PR minimally fixes the issue for the existing classes.

Closes: #802.
