### PR TITLE
Loosen python version requirement from pyscf extra dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        "pyscf": ["pyscf; python_version < '3.10' and sys_platform != 'win32'"],
+        "pyscf": ["pyscf; sys_platform != 'win32'"],
         "mpl": ["matplotlib>=3.3"],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        "pyscf": ["pyscf; sys_platform != 'win32'"],
+        "pyscf": ["pyscf; sys_platform != 'win32' and (python_version < '3.10' or sys_platform != 'darwin')"],
         "mpl": ["matplotlib>=3.3"],
     },
     zip_safe=False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR loosens the Python version limitation from the `pyscf` extra. This makes `pip install qiskit-nature[pyscf]` work as expected also under Python 3.10 (at least under systems not running macOS) .

### Details and comments

Starting from `pyscf==2.1.0` (released Sep 3, 2022) the project also provides wheels for Python 3.10 (see https://pypi.org/project/pyscf/2.1.0/#files). As a consequence, the limitation on the `pyscf` extra introduced in https://github.com/Qiskit/qiskit-nature/pull/513 can be loosened. 

Unfortunately, it can't be dropped completely because the installs for macOS systems using Python 3.10 fails.
This is mainly due to 
- `pyscf==2.1.0` pinning `scipy<=1.1.0` (due to https://github.com/scipy/scipy/issues/15362 and https://github.com/scipy/scipy/issues/16151) and `qiskit-nature` requiring `scipy>=1.4.0`. 
- Hence, the install falls back to `pyscf==2.0.1` which works for all systems with Python<3.10.
- However, the source install under Python 3.10 fails due to https://github.com/pyscf/pyscf/issues/1112, which only got fixed in v2.1.0.

The corresponding issue in `pyscf` is being tracked at https://github.com/pyscf/pyscf/issues/1405.
