### PR TITLE
Keep matplotlib installed in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,13 +245,13 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
-      - name: Nature Unit Tests without matplotlib/pyscf/psi4/pyquante2 under Python ${{ matrix.python-version }}
+      - name: Nature Unit Tests without pyscf/psi4/pyquante2 under Python ${{ matrix.python-version }}
         env:
           PYTHONWARNINGS: default
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
-          pip uninstall -y matplotlib pyscf
+          pip uninstall -y pyscf
           if [[ "${{ matrix.os }}" != "windows-2019" || ("${{ matrix.os }}" == "windows-2019" && "${{ matrix.python-version }}" != "3.10") ]]; then
               echo 'Uninstall psi4'
               conda remove -y --force psi4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
VQE has a statement `logger.info(self.print_settings())` that ends up calling `__str__` in `QuantumCircuit` which calls `str(self.draw(output="text"))`. This ends up importing `circuit_drawer` from visualization that imports `Bloch` which finally imports `matplotlib` and fails it it is not installed.
Keeping it installed in the CI.


### Details and comments


