### PR TITLE
Pin matplotlib due to bug in retworkx visualization

### DIFF
--- a/.github/actions/install-nature/action.yml
+++ b/.github/actions/install-nature/action.yml
@@ -24,6 +24,6 @@ runs:
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
         fi
-        pip install -e .[pyscf]
+        pip install -e .[pyscf,mpl]
         pip install -U -c constraints.txt -r requirements-dev.txt
       shell: bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 coverage>=4.4.0
-matplotlib>=3.3
 black[jupyter]~=22.0
 pylint>=2.9.0,<2.14.0
 pylatexenc>=1.4

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setuptools.setup(
     python_requires=">=3.7",
     extras_require={
         "pyscf": ["pyscf; sys_platform != 'win32' and (python_version < '3.10' or sys_platform != 'darwin')"],
-        "mpl": ["matplotlib>=3.3"],
+        "mpl": ["matplotlib>=3.3,<3.6"],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
With the recent matplotlib release retworkx visualization fails. Pin matplotlib until it gets fixed:
Qiskit/rustworkx#680


### Details and comments


