### PR TITLE
Fix #829

### DIFF
--- a/qiskit_nature/runtime/vqe_client.py
+++ b/qiskit_nature/runtime/vqe_client.py
@@ -266,6 +266,7 @@ class VQEClient(VariationalAlgorithm, MinimumEigensolver):
 
         # try to convert the operators to a PauliSumOp, if it isn't already one
         operator = _convert_to_paulisumop(operator)
+        wrapped_type = type(aux_operators)
         wrapped_aux_operators = {
             str(aux_op_name_or_idx): _convert_to_paulisumop(aux_op)
             for aux_op_name_or_idx, aux_op in ListOrDict(aux_operators).items()
@@ -306,11 +307,16 @@ class VQEClient(VariationalAlgorithm, MinimumEigensolver):
         vqe_result.eigenstate = result.get("eigenstate", None)
         vqe_result.eigenvalue = result.get("eigenvalue", None)
         aux_op_eigenvalues = result.get("aux_operator_eigenvalues", None)
-        if isinstance(aux_operators, dict) and aux_op_eigenvalues is not None:
-            aux_op_eigenvalues = dict(
-                zip(wrapped_aux_operators.keys(), aux_op_eigenvalues.values())
-            )
-            if not aux_op_eigenvalues:  # For consistency set to None for empty dict
+        if aux_op_eigenvalues is not None:
+            if wrapped_type == list:
+                aux_op_eigenvalues = list(
+                    aux_op_eigenvalues.get(str(key), None) for key in range(len(aux_op_eigenvalues))
+                )
+            elif wrapped_type == dict:
+                aux_op_eigenvalues = dict(
+                    zip(wrapped_aux_operators.keys(), aux_op_eigenvalues.values())
+                )
+            if not aux_op_eigenvalues:  # For consistency set to None for empty dict/list
                 aux_op_eigenvalues = None
         vqe_result.aux_operator_eigenvalues = aux_op_eigenvalues
         vqe_result.optimal_parameters = result.get("optimal_parameters", None)

--- a/releasenotes/notes/fix-vqe-client-aux-operator-types-ef721cdc127e2fff.yaml
+++ b/releasenotes/notes/fix-vqe-client-aux-operator-types-ef721cdc127e2fff.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes the :class:`qiskit_nature.runtime.VQEClient` to correctly detect the
+    type of the wrapped auxiliary operators. Previously, it would always wrap
+    them into a dictionary and then fail when unwrapping them later, since it
+    did not preserve the previously wrapped data type.


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes the VQEClient to correctly detect the type of the wrapped auxiliary operators. Previously, it would always wrap them into a dictionary and then fail when unwrapping them later, since it did not preserve the previously wrapped data type.


### Details and comments

Closes #829
