### PR TITLE
Fix doc.deploy script due to matplotlib, retworkx limitation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,15 +29,15 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Nature
-        run: |
-          pip install -e .[pyscf]
-          pip install -U -c constraints.txt -r requirements-dev.txt
-        shell: bash
       - name: Install Dependencies
         run: |
           pip install jupyter sphinx_rtd_theme qiskit-terra[visualization]
           sudo apt-get install -y pandoc graphviz
+        shell: bash
+      - name: Install Nature
+        run: |
+          pip install -e .[pyscf,mpl]
+          pip install -U -c constraints.txt -r requirements-dev.txt
         shell: bash
       - name: Build and publish
         env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage>=4.4.0
+matplotlib>=3.3,<3.6
 black[jupyter]~=22.0
 pylint>=2.9.0,<2.14.0
 pylatexenc>=1.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The documentation deploy script was adjusted to account for the matplotlib/retworkx version problem.
Also the matplotlib was reinserted into requirements-dev.txt since this file is used by the doc.translate scripts.

It is not necessary to backport this PR since those changes have already been made in stable/0.4


### Details and comments


