### PR TITLE
Cache .stestr in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,6 +219,17 @@ jobs:
           pip install -U -r requirements-dev.txt
           make lint
         shell: bash
+      - name: Stestr Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .stestr
+            .stestr1
+          key: stestr-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          restore-keys: |
+            stestr-${{ matrix.os }}-${{ matrix.python-version }}-
+            stestr-${{ matrix.os }}-
+        if: ${{ !cancelled() }}
       - name: Nature Unit Tests under Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-tests
         with:
@@ -262,7 +273,8 @@ jobs:
           if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}" == "true" ]; then
               export QISKIT_TESTS="run_slow"
           fi
-          stestr --test-path test run
+          mkdir -p ./.stestr1
+          stestr --test-path test --repo-url .stestr1 run
         if: ${{ !cancelled() }}
         shell: bash
   Tutorials:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Caching the `.stestr` database created by `stestr` so that it can be read in later runs in order to improve the grouping of unit test methods per process.
This is already done in qiskit-terra


### Details and comments


