### PR TITLE
Pin sphinx < 5.2.0 & pyscf < 2.1.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,8 +209,8 @@ html_theme_options = {
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "qiskit": ("https://qiskit.org/documentation/", None),
     "retworkx": ("https://qiskit.org/documentation/retworkx/", None),
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 reno>=3.4.0
-Sphinx>=1.8.3,!=3.1.0
+Sphinx>=1.8.3,!=3.1.0,<5.2.0
 sphinx-design>=0.2.0
 sphinx-gallery
 sphinx-autodoc-typehints<1.14.0

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        "pyscf": ["pyscf; sys_platform != 'win32' and (python_version < '3.10' or sys_platform != 'darwin')"],
+        "pyscf": ["pyscf<2.1.1; sys_platform != 'win32' and (python_version < '3.10' or sys_platform != 'darwin')"],
         "mpl": ["matplotlib>=3.3,<3.6"],
     },
     zip_safe=False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Latest version of Sphinx 5.2.0 is failing documentation
Latest version of Pyscf 2.1.1 is crashing MacOS python 3.8 unit test. I suspect it is a new requirement `libomp.dylib`. I had to install it locally to make new pyscf work and I suspect the CI `libomp.dylib` may be causing the crash. It needs more investigation. Pin for now

Also update intersphinx_mapping with latest urls.


### Details and comments


