### PR TITLE
Change from retworkx to rustworkx, pylint whitelist rustworkx

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -464,6 +464,7 @@ rossmannek
 rtol
 rtype
 runtime
+rustworkx
 rv
 rx
 rxx

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=retworkx
+extension-pkg-whitelist=rustworkx
 
 
 [MESSAGES CONTROL]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,7 +212,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "qiskit": ("https://qiskit.org/documentation/", None),
-    "retworkx": ("https://qiskit.org/documentation/retworkx/", None),
+    "rustworkx": ("https://qiskit.org/documentation/rustworkx/", None),
 }
 # -- Extension configuration -------------------------------------------------
 

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/hyper_cubic_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from retworkx import PyGraph
+from rustworkx import PyGraph  # pylint: disable=no-name-in-module
 
 from .boundary_condition import BoundaryCondition
 from .lattice import Lattice, LatticeDrawStyle
@@ -312,9 +312,9 @@ class HyperCubicLattice(Lattice):
 
         Args:
             self_loop: Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
         graph = self.graph

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/hyper_cubic_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from rustworkx import PyGraph  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph
 
 from .boundary_condition import BoundaryCondition
 from .lattice import Lattice, LatticeDrawStyle

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
@@ -19,8 +19,9 @@ import numbers
 
 import numpy as np
 
-from retworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
-from retworkx.visualization import mpl_draw
+from rustworkx import NodeIndices, PyGraph, WeightedEdgeList  # pylint: disable=no-name-in-module
+from rustworkx import adjacency_matrix, networkx_converter
+from rustworkx.visualization import mpl_draw
 
 from qiskit.utils import optionals as _optionals
 
@@ -38,7 +39,7 @@ if _optionals.HAS_MATPLOTLIB:
 class LatticeDrawStyle:
     """A stylesheet for lattice figure.
     Please see
-    https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+    https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
     for each element.
     """
 
@@ -116,8 +117,8 @@ class Lattice:
     def __init__(self, graph: Union[PyGraph, "nx.Graph"]) -> None:
         """
         Args:
-            graph: Input graph for Lattice. Can be provided as ``retworkx.PyGraph``, which is
-                used internally, or, for convenience, as ``networkx.Graph``. The graph
+            graph: Input graph for Lattice. Can be provided as ``rustworkx.PyGraph``, which is
+                used internally, or, for convenience, as ``rustworkx.Graph``. The graph
                 cannot be a multigraph.
 
         Raises:
@@ -247,9 +248,9 @@ class Lattice:
 
         Args:
             self_loop : Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
 

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/lattice.py
@@ -19,8 +19,7 @@ import numbers
 
 import numpy as np
 
-from rustworkx import NodeIndices, PyGraph, WeightedEdgeList  # pylint: disable=no-name-in-module
-from rustworkx import adjacency_matrix, networkx_converter
+from rustworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
 from rustworkx.visualization import mpl_draw
 
 from qiskit.utils import optionals as _optionals

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/triangular_lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/triangular_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from retworkx import PyGraph
+from rustworkx import PyGraph  # pylint: disable=no-name-in-module
 
 from .lattice import LatticeDrawStyle, Lattice
 from .boundary_condition import BoundaryCondition
@@ -239,9 +239,9 @@ class TriangularLattice(Lattice):
 
         Args:
             self_loop: Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
         graph = self.graph

--- a/qiskit_nature/problems/second_quantization/lattice/lattices/triangular_lattice.py
+++ b/qiskit_nature/problems/second_quantization/lattice/lattices/triangular_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from rustworkx import PyGraph  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph
 
 from .lattice import LatticeDrawStyle, Lattice
 from .boundary_condition import BoundaryCondition

--- a/qiskit_nature/problems/second_quantization/lattice/models/lattice_model.py
+++ b/qiskit_nature/problems/second_quantization/lattice/models/lattice_model.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import numpy as np
-from rustworkx import PyGraph  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph
 
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization.lattice.lattices import Lattice

--- a/qiskit_nature/problems/second_quantization/lattice/models/lattice_model.py
+++ b/qiskit_nature/problems/second_quantization/lattice/models/lattice_model.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import numpy as np
-from retworkx import PyGraph
+from rustworkx import PyGraph  # pylint: disable=no-name-in-module
 
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization.lattice.lattices import Lattice
@@ -67,7 +67,7 @@ class LatticeModel(ABC):
     @staticmethod
     def _generate_lattice_from_parameters(interaction_matrix: np.ndarray):
         # make a graph from the interaction matrix.
-        # This should be replaced by from_adjacency_matrix of retworkx.
+        # This should be replaced by from_adjacency_matrix of rustworkx.
         shape = interaction_matrix.shape
         if len(shape) != 2 or shape[0] != shape[1]:
             raise ValueError(

--- a/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from retworkx import PyGraph
+from rustworkx import PyGraph  # pylint: disable=no-name-in-module
 
 from .boundary_condition import BoundaryCondition
 from .lattice import Lattice, LatticeDrawStyle
@@ -312,9 +312,9 @@ class HyperCubicLattice(Lattice):
 
         Args:
             self_loop: Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
         graph = self.graph

--- a/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from rustworkx import PyGraph  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph
 
 from .boundary_condition import BoundaryCondition
 from .lattice import Lattice, LatticeDrawStyle

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -21,7 +21,7 @@ import numbers
 
 import numpy as np
 
-from rustworkx import NodeIndices, PyGraph, WeightedEdgeList  # pylint: disable=no-name-in-module
+from rustworkx import NodeIndices, PyGraph, WeightedEdgeList
 from rustworkx import adjacency_matrix, networkx_converter
 from rustworkx.visualization import mpl_draw
 

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -21,8 +21,9 @@ import numbers
 
 import numpy as np
 
-from retworkx import NodeIndices, PyGraph, WeightedEdgeList, adjacency_matrix, networkx_converter
-from retworkx.visualization import mpl_draw
+from rustworkx import NodeIndices, PyGraph, WeightedEdgeList  # pylint: disable=no-name-in-module
+from rustworkx import adjacency_matrix, networkx_converter
+from rustworkx.visualization import mpl_draw
 
 from qiskit.utils import optionals as _optionals
 
@@ -40,7 +41,7 @@ if _optionals.HAS_MATPLOTLIB:
 class LatticeDrawStyle:
     """A stylesheet for lattice figure.
     Please see
-    https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+    https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
     for each element.
     """
 
@@ -118,8 +119,8 @@ class Lattice:
     def __init__(self, graph: Union[PyGraph, "nx.Graph"]) -> None:
         """
         Args:
-            graph: Input graph for Lattice. Can be provided as ``retworkx.PyGraph``, which is
-                used internally, or, for convenience, as ``networkx.Graph``. The graph
+            graph: Input graph for Lattice. Can be provided as ``rustworkx.PyGraph``, which is
+                used internally, or, for convenience, as ``rustworkx.Graph``. The graph
                 cannot be a multigraph.
 
         Raises:
@@ -234,7 +235,7 @@ class Lattice:
             A new lattice based on the provided adjacency matrix.
         """
         # make a graph from the interaction matrix.
-        # This should be replaced by from_adjacency_matrix of retworkx.
+        # This should be replaced by from_adjacency_matrix of rustworkx.
         shape = interaction_matrix.shape
         if len(shape) != 2 or shape[0] != shape[1]:
             raise ValueError(
@@ -310,9 +311,9 @@ class Lattice:
 
         Args:
             self_loop : Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
 

--- a/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from retworkx import PyGraph
+from rustworkx import PyGraph  # pylint: disable=no-name-in-module
 
 from .lattice import LatticeDrawStyle, Lattice
 from .boundary_condition import BoundaryCondition
@@ -239,9 +239,9 @@ class TriangularLattice(Lattice):
 
         Args:
             self_loop: Draw self-loops in the lattice. Defaults to False.
-            style : Styles for retworkx.visualization.mpl_draw.
+            style : Styles for rustworkx.visualization.mpl_draw.
                 Please see
-                https://qiskit.org/documentation/retworkx/stubs/retworkx.visualization.mpl_draw.html#retworkx.visualization.mpl_draw
+                https://qiskit.org/documentation/rustworkx/stubs/rustworkx.visualization.mpl_draw.html#rustworkx.visualization.mpl_draw
                 for details.
         """
         graph = self.graph

--- a/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
@@ -17,7 +17,7 @@ from math import pi
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from rustworkx import PyGraph  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph
 
 from .lattice import LatticeDrawStyle, Lattice
 from .boundary_condition import BoundaryCondition

--- a/releasenotes/notes/retworkx-rustworkx-7836a84db7669814.yaml
+++ b/releasenotes/notes/retworkx-rustworkx-7836a84db7669814.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Changes usage of library ``retworkx`` to the new substitute ``rustworkx``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn>=0.20.0
 setuptools>=40.1.0
 typing_extensions
 h5py
-retworkx>=0.10.1
+rustworkx

--- a/test/problems/second_quantization/lattice/lattices/test_hyper_cubic_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_hyper_cubic_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_hyper_cubic_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_hyper_cubic_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_lattice.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/problems/second_quantization/lattice/lattices/test_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_lattice.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/problems/second_quantization/lattice/lattices/test_line_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_line_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     LineLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_line_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_line_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     LineLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_square_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_square_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     SquareLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_square_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_square_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     SquareLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_triangular_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_triangular_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/problems/second_quantization/lattice/lattices/test_triangular_lattice.py
+++ b/test/problems/second_quantization/lattice/lattices/test_triangular_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.problems.second_quantization.lattice import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/problems/second_quantization/lattice/models/test_fermi_hubbard_model.py
+++ b/test/problems/second_quantization/lattice/models/test_fermi_hubbard_model.py
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.problems.second_quantization.lattice import FermiHubbardModel, Lattice
 

--- a/test/problems/second_quantization/lattice/models/test_fermi_hubbard_model.py
+++ b/test/problems/second_quantization/lattice/models/test_fermi_hubbard_model.py
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit_nature.problems.second_quantization.lattice import FermiHubbardModel, Lattice
 

--- a/test/problems/second_quantization/lattice/models/test_ising_model.py
+++ b/test/problems/second_quantization/lattice/models/test_ising_model.py
@@ -17,7 +17,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit_nature.problems.second_quantization.lattice import IsingModel, Lattice
 

--- a/test/problems/second_quantization/lattice/models/test_ising_model.py
+++ b/test/problems/second_quantization/lattice/models/test_ising_model.py
@@ -17,7 +17,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.problems.second_quantization.lattice import IsingModel, Lattice
 

--- a/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/second_q/hamiltonians/lattices/test_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_lattice.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/second_q/hamiltonians/lattices/test_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_lattice.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/second_q/hamiltonians/lattices/test_line_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_line_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     LineLattice,

--- a/test/second_q/hamiltonians/lattices/test_line_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_line_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     LineLattice,

--- a/test/second_q/hamiltonians/lattices/test_square_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_square_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     SquareLattice,

--- a/test/second_q/hamiltonians/lattices/test_square_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_square_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     SquareLattice,

--- a/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/second_q/hamiltonians/test_fermi_hubbard_model.py
+++ b/test/second_q/hamiltonians/test_fermi_hubbard_model.py
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.second_q.hamiltonians import FermiHubbardModel
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice

--- a/test/second_q/hamiltonians/test_fermi_hubbard_model.py
+++ b/test/second_q/hamiltonians/test_fermi_hubbard_model.py
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit_nature.second_q.hamiltonians import FermiHubbardModel
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice

--- a/test/second_q/hamiltonians/test_heisenberg_model.py
+++ b/test/second_q/hamiltonians/test_heisenberg_model.py
@@ -13,7 +13,7 @@
 """Test HeisenbergModel."""
 
 from test import QiskitNatureTestCase
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice, LineLattice
 from qiskit_nature.second_q.hamiltonians import HeisenbergModel, IsingModel
 

--- a/test/second_q/hamiltonians/test_heisenberg_model.py
+++ b/test/second_q/hamiltonians/test_heisenberg_model.py
@@ -13,7 +13,7 @@
 """Test HeisenbergModel."""
 
 from test import QiskitNatureTestCase
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice, LineLattice
 from qiskit_nature.second_q.hamiltonians import HeisenbergModel, IsingModel
 

--- a/test/second_q/hamiltonians/test_ising_model.py
+++ b/test/second_q/hamiltonians/test_ising_model.py
@@ -16,7 +16,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice
 from qiskit_nature.second_q.hamiltonians import IsingModel

--- a/test/second_q/hamiltonians/test_ising_model.py
+++ b/test/second_q/hamiltonians/test_ising_model.py
@@ -16,7 +16,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from retworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # pylint: disable=no-name-in-module
 
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice
 from qiskit_nature.second_q.hamiltonians import IsingModel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Use rustworkx instead of retworkx
rustworkx is a compiled library, so pylint whitelist it.

### Details and comments


