### PR TITLE
fix: replace retworkx with rustworkx in tutorials

### DIFF
--- a/docs/tutorials/10_lattice_models.ipynb
+++ b/docs/tutorials/10_lattice_models.ipynb
@@ -28,7 +28,7 @@
     "from math import pi\n",
     "\n",
     "import numpy as np\n",
-    "import retworkx as rx\n",
+    "import rustworkx as rx\n",
     "from qiskit_nature.second_q.hamiltonians.lattices import (\n",
     "    BoundaryCondition,\n",
     "    HyperCubicLattice,\n",


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I found one more occurrence of `retworkx` that was missed by #868

### Details and comments

