### PR TITLE
fix num_spin_orbitals for FermionicOp with zero spin orbitals

### DIFF
--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -201,7 +201,7 @@ class FermionicOp(SparseLabelOp):
 
         num_so = self.num_spin_orbitals
 
-        max_index = 0
+        max_index = -1
 
         for key in keys:
             # 0. explicitly allow the empty key

--- a/test/second_q/operators/test_fermionic_op.py
+++ b/test/second_q/operators/test_fermionic_op.py
@@ -416,15 +416,19 @@ class TestFermionicOp(QiskitNatureTestCase):
 
     def test_no_num_spin_orbitals(self):
         """Test operators with automatic register length"""
+        op0 = FermionicOp({"": 1})
         op1 = FermionicOp({"+_0 -_0": 1})
         op2 = FermionicOp({"-_0 +_1": 2})
 
         with self.subTest("Inferred register length"):
+            self.assertEqual(op0.num_spin_orbitals, 0)
             self.assertEqual(op1.num_spin_orbitals, 1)
             self.assertEqual(op2.num_spin_orbitals, 2)
 
         with self.subTest("Mathematical operations"):
+            self.assertEqual((op0 + op2).num_spin_orbitals, 2)
             self.assertEqual((op1 + op2).num_spin_orbitals, 2)
+            self.assertEqual((op0 @ op2).num_spin_orbitals, 2)
             self.assertEqual((op1 @ op2).num_spin_orbitals, 2)
             self.assertEqual((op1 ^ op2).num_spin_orbitals, 3)
 
@@ -438,6 +442,9 @@ class TestFermionicOp(QiskitNatureTestCase):
             np.testing.assert_array_almost_equal(op1.to_matrix(False), ref)
             op1.num_spin_orbitals = 2
             np.testing.assert_array_almost_equal(op1.to_matrix(False), np.kron(ref, np.eye(2)))
+
+            ref = np.array([[1]])
+            np.testing.assert_array_almost_equal(op0.to_matrix(False), ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug where `op = FermionicOp({"": 1.0})` was being assigned `num_spin_orbitals` equal to 1 instead of 0.


### Details and comments


