### PR TITLE
fix: make PolynomialTensor method names consistent

### DIFF
--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -164,7 +164,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         print(PolynomialTensor({"+-": sparse_matrix}))
 
     One can convert between dense and sparse representation of the same tensor via the
-    :meth:`todense` and :meth:`tosparse` methods, respectively.
+    :meth:`to_dense` and :meth:`to_sparse` methods, respectively.
     """
 
     def __init__(
@@ -253,11 +253,11 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         return len(self) == 0
 
     @_optionals.HAS_SPARSE.require_in_call
-    def issparse(self) -> bool:
+    def is_sparse(self) -> bool:
         """Returns whether all matrices in this tensor are sparse."""
         return all(isinstance(self[key], SparseArray) for key in self if key != "")
 
-    def isdense(self) -> bool:
+    def is_dense(self) -> bool:
         """Returns whether all matrices in this tensor are dense."""
         return all(isinstance(self[key], np.ndarray) for key in self if key != "")
 
@@ -280,13 +280,13 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         """Returns an iterator of the ``PolynomialTensor``."""
         return self._data.__iter__()
 
-    def todense(self) -> PolynomialTensor:
+    def to_dense(self) -> PolynomialTensor:
         """Returns a new instance where all matrices are now dense numpy arrays.
 
         If the instance on which this method was called already fulfilled this requirement, it is
         returned unchanged.
         """
-        if self.isdense():
+        if self.is_dense():
             return self
 
         _optionals.HAS_SPARSE.require_now("SparseArray")
@@ -300,7 +300,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
 
     # TODO: change the following type-hint if/when SparseArray dictates the existence of from_numpy
     @_optionals.HAS_SPARSE.require_in_call
-    def tosparse(
+    def to_sparse(
         self, *, sparse_type: Type[COO] | Type[DOK] | Type[GCXS] = COO
     ) -> PolynomialTensor:
         """Returns a new instance where all matrices are now sparse arrays.
@@ -317,7 +317,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             A new ``PolynomialTensor`` with all its matrices converted to the requested sparse array
             type.
         """
-        if self.issparse():
+        if self.is_sparse():
             return self
 
         sparse_dict: dict[str, ARRAY_TYPE] = {}
@@ -725,8 +725,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
 
            :class:`sparse.SparseArray` does not support ``numpy.einsum``. Thus, the resultant
            ``PolynomialTensor`` will contain all dense numpy arrays. If a user would like to work
-           with a sparse array instead, they should convert it explicitly using the :meth:`tosparse`
-           method.
+           with a sparse array instead, they should convert it explicitly using the
+           :meth:`to_sparse` method.
 
         Args:
             einsum_map: a dictionary, mapping from :meth:`numpy.einsum` subscripts to a tuple of
@@ -740,7 +740,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         Returns:
             A new ``PolynomialTensor``.
         """
-        dense_operands = [op.todense() for op in operands]
+        dense_operands = [op.to_dense() for op in operands]
         new_data: dict[str, ARRAY_TYPE] = {}
         for einsum, terms in einsum_map.items():
             *inputs, output = terms

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -138,40 +138,40 @@ class TestPolynomialTensor(QiskitNatureTestCase):
         with self.subTest("non-empty"):
             self.assertFalse(PolynomialTensor({"": 1.0}).is_empty())
 
-    def test_issparse(self):
-        """Test PolynomialTensor.issparse"""
+    def test_is_sparse(self):
+        """Test PolynomialTensor.is_sparse"""
         import sparse as sp  # pylint: disable=import-error
 
         with self.subTest("sparse"):
-            self.assertTrue(PolynomialTensor({"+": sp.as_coo({(0,): 1})}).issparse())
+            self.assertTrue(PolynomialTensor({"+": sp.as_coo({(0,): 1})}).is_sparse())
 
         with self.subTest("sparse with empty key"):
-            self.assertTrue(PolynomialTensor({"": 1.0, "+": sp.as_coo({(0,): 1})}).issparse())
+            self.assertTrue(PolynomialTensor({"": 1.0, "+": sp.as_coo({(0,): 1})}).is_sparse())
 
         with self.subTest("dense"):
-            self.assertFalse(PolynomialTensor({"+": np.array([1])}).issparse())
+            self.assertFalse(PolynomialTensor({"+": np.array([1])}).is_sparse())
 
         with self.subTest("mixed"):
             self.assertFalse(
-                PolynomialTensor({"+": sp.as_coo({(1,): 1}), "+-": np.eye(2)}).issparse()
+                PolynomialTensor({"+": sp.as_coo({(1,): 1}), "+-": np.eye(2)}).is_sparse()
             )
 
-    def test_isdense(self):
-        """Test PolynomialTensor.isdense"""
+    def test_is_dense(self):
+        """Test PolynomialTensor.is_dense"""
         import sparse as sp  # pylint: disable=import-error
 
         with self.subTest("dense"):
-            self.assertTrue(PolynomialTensor({"+": np.array([1])}).isdense())
+            self.assertTrue(PolynomialTensor({"+": np.array([1])}).is_dense())
 
         with self.subTest("dense with empty key"):
-            self.assertTrue(PolynomialTensor({"": 1.0, "+": np.array([1])}).isdense())
+            self.assertTrue(PolynomialTensor({"": 1.0, "+": np.array([1])}).is_dense())
 
         with self.subTest("sparse"):
-            self.assertFalse(PolynomialTensor({"+": sp.as_coo({(0,): 1})}).isdense())
+            self.assertFalse(PolynomialTensor({"+": sp.as_coo({(0,): 1})}).is_dense())
 
         with self.subTest("mixed"):
             self.assertFalse(
-                PolynomialTensor({"+": sp.as_coo({(1,): 1}), "+-": np.eye(2)}).isdense()
+                PolynomialTensor({"+": sp.as_coo({(1,): 1}), "+-": np.eye(2)}).is_dense()
             )
 
     def test_get_item(self):
@@ -202,9 +202,9 @@ class TestPolynomialTensor(QiskitNatureTestCase):
         exp_iter = [key for key, _ in self.og_poly.items()]
         self.assertEqual(exp_iter, list(iter(og_poly_tensor)))
 
-    def test_todense(self):
-        """Test PolynomialTensor.todense"""
-        dense_tensor = PolynomialTensor(self.sparse_1).todense()
+    def test_to_dense(self):
+        """Test PolynomialTensor.to_dense"""
+        dense_tensor = PolynomialTensor(self.sparse_1).to_dense()
         two_body = np.zeros((4, 4, 4, 4))
         two_body[0, 0, 0, 1] = 1
         two_body[1, 0, 2, 1] = 2
@@ -216,11 +216,11 @@ class TestPolynomialTensor(QiskitNatureTestCase):
         }
         self.assertEqual(dense_tensor, PolynomialTensor(expected))
 
-    def tosparse(self):
-        """Test PolynomialTensor.tosparse"""
+    def test_to_sparse(self):
+        """Test PolynomialTensor.to_sparse"""
         import sparse as sp  # pylint: disable=import-error
 
-        sparse_tensor = PolynomialTensor(self.og_poly).tosparse()
+        sparse_tensor = PolynomialTensor(self.og_poly).to_sparse()
         expected = {
             "": 1.0,
             "+": sp.as_coo(np.arange(1, 5)),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In 46f4dd853233df8b832966aaa03695e13ee4c88f we made the method naming of the `FermionicOp` more consistent.
This PR does the same consistency check on the `PolynomialTensor`.


### Details and comments

The following renaming is done:

- `isdense` -> `is_dense`
- `issparse` -> `is_sparse`
- `todense` -> `to_dense`
- `tosparse` -> `to_sparse`
