### PR TITLE
refactor: update API to kwargs-only where sensible

### DIFF
--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/excited_states_eigensolver.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/excited_states_eigensolver.py
@@ -80,7 +80,9 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
         if aux_operators is not None:
             for name_aux, aux_op in aux_operators.items():
                 if isinstance(aux_op, SecondQuantizedOp):
-                    converted_aux_op = self._qubit_converter.convert_match(aux_op, True)
+                    converted_aux_op = self._qubit_converter.convert_match(
+                        aux_op, suppress_none=True
+                    )
                 else:
                     converted_aux_op = aux_op
                 if name_aux in aux_ops.keys():

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -106,7 +106,9 @@ class GroundStateEigensolver(GroundStateSolver):
         if aux_operators is not None:
             for name_aux, aux_op in aux_operators.items():
                 if isinstance(aux_op, SecondQuantizedOp):
-                    converted_aux_op = self._qubit_converter.convert_match(aux_op, True)
+                    converted_aux_op = self._qubit_converter.convert_match(
+                        aux_op, suppress_none=True
+                    )
                 else:
                     converted_aux_op = aux_op
                 if name_aux in aux_ops.keys():

--- a/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
+++ b/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
@@ -98,7 +98,7 @@ class MP2InitialPoint(InitialPoint):
     :attr:`threshold` or that correspond to single, triple, or higher excitations will be zero.
     """
 
-    def __init__(self, threshold: float = 1e-12) -> None:
+    def __init__(self, *, threshold: float = 1e-12) -> None:
         super().__init__()
         self.threshold: float = threshold
         self._ansatz: UCC | None = None

--- a/qiskit_nature/second_q/circuit/library/bogoliubov_transform.py
+++ b/qiskit_nature/second_q/circuit/library/bogoliubov_transform.py
@@ -134,6 +134,7 @@ class BogoliubovTransform(QuantumCircuit):
         self,
         transformation_matrix: np.ndarray,
         qubit_converter: Optional[QubitConverter] = None,
+        *,
         validate: bool = True,
         rtol: float = 1e-5,
         atol: float = 1e-8,

--- a/qiskit_nature/second_q/drivers/gaussiand/gaussian_forces_driver.py
+++ b/qiskit_nature/second_q/drivers/gaussiand/gaussian_forces_driver.py
@@ -47,6 +47,7 @@ class GaussianForcesDriver(VibrationalStructureDriver):
         self,
         jcf: Union[str, list[str]] = B3YLP_JCF_DEFAULT,
         logfile: Optional[str] = None,
+        *,
         normalize: bool = True,
     ) -> None:
         r"""
@@ -142,7 +143,7 @@ class GaussianForcesDriver(VibrationalStructureDriver):
             glr = GaussianLogDriver(jcf=self._jcf).run()
 
         driver_result = VibrationalStructureProblem(
-            glr.get_vibrational_energy(self._normalize),
+            glr.get_vibrational_energy(normalize=self._normalize),
             num_modes=len(glr.a_to_h_numbering),
         )
         driver_result.properties.occupied_modals = OccupiedModals()

--- a/qiskit_nature/second_q/drivers/gaussiand/gaussian_log_result.py
+++ b/qiskit_nature/second_q/drivers/gaussiand/gaussian_log_result.py
@@ -221,7 +221,7 @@ class GaussianLogResult:
         num_indices = len(entry) - 3
         return [a2h_vals + 1 - a2h[cast(str, x)] for x in entry[0:num_indices]]
 
-    def get_vibrational_energy(self, normalize: bool = True) -> VibrationalEnergy:
+    def get_vibrational_energy(self, *, normalize: bool = True) -> VibrationalEnergy:
         """
         Get the force constants as a VibrationalEnergy property.
 

--- a/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
@@ -305,6 +305,7 @@ class HyperCubicLattice(Lattice):
 
     def draw_without_boundary(
         self,
+        *,
         self_loop: bool = False,
         style: Optional[LatticeDrawStyle] = None,
     ):

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -304,6 +304,7 @@ class Lattice:
 
     def draw(
         self,
+        *,
         self_loop: bool = False,
         style: Optional[LatticeDrawStyle] = None,
     ):

--- a/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
@@ -232,6 +232,7 @@ class TriangularLattice(Lattice):
 
     def draw_without_boundary(
         self,
+        *,
         self_loop: bool = False,
         style: Optional[LatticeDrawStyle] = None,
     ):

--- a/qiskit_nature/second_q/hamiltonians/quadratic_hamiltonian.py
+++ b/qiskit_nature/second_q/hamiltonians/quadratic_hamiltonian.py
@@ -58,6 +58,7 @@ class QuadraticHamiltonian(Hamiltonian, TolerancesMixin):
         hermitian_part: Optional[np.ndarray] = None,
         antisymmetric_part: Optional[np.ndarray] = None,
         constant: float = 0.0,
+        *,
         num_modes: Optional[int] = None,
         validate: bool = True,
         rtol: float = 1e-5,

--- a/qiskit_nature/second_q/hamiltonians/vibrational_energy.py
+++ b/qiskit_nature/second_q/hamiltonians/vibrational_energy.py
@@ -35,6 +35,7 @@ class VibrationalEnergy(Hamiltonian):
     def __init__(
         self,
         vibrational_integrals: list[VibrationalIntegrals],
+        *,
         truncation_order: Optional[int] = None,
         basis: Optional[VibrationalBasis] = None,
     ) -> None:

--- a/qiskit_nature/second_q/mappers/logarithmic_mapper.py
+++ b/qiskit_nature/second_q/mappers/logarithmic_mapper.py
@@ -40,7 +40,7 @@ class LogarithmicMapper(SpinMapper):
             https://doi.org/10.1103/PhysRevD.102.094501
     """
 
-    def __init__(self, padding: float = 1, embed_upper: bool = True) -> None:
+    def __init__(self, *, padding: float = 1, embed_upper: bool = True) -> None:
         r"""
         Args:
             padding:

--- a/qiskit_nature/second_q/mappers/qubit_converter.py
+++ b/qiskit_nature/second_q/mappers/qubit_converter.py
@@ -279,6 +279,7 @@ class QubitConverter:
 
     def force_match(
         self,
+        *,
         num_particles: Optional[Tuple[int, int]] = None,
         z2symmetries: Optional[Z2Symmetries] = None,
     ) -> None:
@@ -316,6 +317,7 @@ class QubitConverter:
     def convert_match(
         self,
         second_q_ops: OPERATOR | ListOrDictType[OPERATOR],
+        *,
         suppress_none: bool = False,
         check_commutes: bool = True,
     ) -> Union[PauliSumOp, ListOrDictType[PauliSumOp]]:

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -541,7 +541,7 @@ class FermionicOp(SparseLabelOp):
         new_label = " ".join(f"{term[0]}_{term[1]}" for term in terms)
         return new_label, coeff
 
-    def is_hermitian(self, *, atol: float | None = None) -> bool:
+    def is_hermitian(self, atol: float | None = None) -> bool:
         """Checks whether the operator is hermitian.
 
         Args:
@@ -554,7 +554,7 @@ class FermionicOp(SparseLabelOp):
         diff = (self - self.adjoint()).normal_order().simplify(atol=atol)
         return all(np.isclose(coeff, 0.0, atol=atol) for coeff in diff.values())
 
-    def simplify(self, *, atol: float | None = None) -> FermionicOp:
+    def simplify(self, atol: float | None = None) -> FermionicOp:
         atol = self.atol if atol is None else atol
 
         data = defaultdict(complex)  # type: dict[str, complex]

--- a/qiskit_nature/second_q/operators/sparse_label_op.py
+++ b/qiskit_nature/second_q/operators/sparse_label_op.py
@@ -393,24 +393,24 @@ class SparseLabelOp(LinearMixin, AdjointMixin, GroupMixin, TolerancesMixin, ABC,
         indices = self.argsort(weight=weight)
         return self._new_instance({ind: self[ind] for ind in indices})
 
-    def chop(self, tol: float | None = None) -> SparseLabelOp:
+    def chop(self, atol: float | None = None) -> SparseLabelOp:
         """Chops the real and imaginary phases of the operator coefficients.
 
         This function separately chops the real and imaginary phase of all coefficients to the
         provided tolerance.
 
         Args:
-            tol: the tolerance to which to chop. If ``None``, :attr:`atol` will be used.
+            atol: the tolerance to which to chop. If ``None``, :attr:`atol` will be used.
 
         Returns:
             The chopped operator.
         """
-        tol = tol if tol is not None else self.atol
+        atol = atol if atol is not None else self.atol
 
         new_data = {}
         for key, value in self.items():
-            zero_real = cmath.isclose(value.real, 0.0, abs_tol=tol)
-            zero_imag = cmath.isclose(value.imag, 0.0, abs_tol=tol)
+            zero_real = cmath.isclose(value.real, 0.0, abs_tol=atol)
+            zero_imag = cmath.isclose(value.imag, 0.0, abs_tol=atol)
             if zero_real and zero_imag:
                 continue
             if zero_imag:
@@ -423,7 +423,7 @@ class SparseLabelOp(LinearMixin, AdjointMixin, GroupMixin, TolerancesMixin, ABC,
         return self._new_instance(new_data)
 
     @abstractmethod
-    def simplify(self, *, atol: float | None = None) -> SparseLabelOp:
+    def simplify(self, atol: float | None = None) -> SparseLabelOp:
         """Simplify the operator.
 
         Merges terms with same labels and eliminates terms with coefficients close to 0.

--- a/qiskit_nature/second_q/problems/vibrational_structure_problem.py
+++ b/qiskit_nature/second_q/problems/vibrational_structure_problem.py
@@ -42,6 +42,7 @@ class VibrationalStructureProblem(BaseProblem):
         hamiltonian: VibrationalEnergy,
         num_modes: int,
         num_modals: Union[int, List[int]] = None,
+        *,
         truncation_order: int = None,
     ):
         """

--- a/test/second_q/circuit/library/ansatzes/test_ucc.py
+++ b/test/second_q/circuit/library/ansatzes/test_ucc.py
@@ -272,7 +272,7 @@ class TestUCC(QiskitNatureTestCase):
         with self.subTest("Change qubit converter"):
             ucc.qubit_converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)
             # Has not been used to convert so we need to force it to do two qubit reduction
-            ucc.qubit_converter.force_match(ucc.num_particles)
+            ucc.qubit_converter.force_match(num_particles=ucc.num_particles)
             self.assertIsNotNone(ucc.operators)
             self.assertEqual(ucc.num_qubits, 4)
 

--- a/test/second_q/mappers/test_logarithmic_mapper.py
+++ b/test/second_q/mappers/test_logarithmic_mapper.py
@@ -68,7 +68,7 @@ class TestLogarithmicMapper(QiskitNatureTestCase):
     @unpack
     def test_mapping(self, spin_op, ref_qubit_op, padding=1, embed_upper=True):
         """Test mapping to qubit operator"""
-        mapper = LogarithmicMapper(padding, embed_upper)
+        mapper = LogarithmicMapper(padding=padding, embed_upper=embed_upper)
         qubit_op = mapper.map(spin_op)
         self.assertEqual(qubit_op, ref_qubit_op)
 

--- a/test/second_q/mappers/test_qubit_converter.py
+++ b/test/second_q/mappers/test_qubit_converter.py
@@ -122,7 +122,7 @@ class TestQubitConverter(QiskitNatureTestCase):
             self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY)
 
         with self.subTest("Force match set num particles"):
-            qubit_conv.force_match(self.num_particles)
+            qubit_conv.force_match(num_particles=self.num_particles)
             qubit_op = qubit_conv.convert_match(self.h2_op)
             self.assertEqual(qubit_op, TestQubitConverter.REF_H2_PARITY_2Q_REDUCED)
 

--- a/test/second_q/operators/test_sparse_label_op.py
+++ b/test/second_q/operators/test_sparse_label_op.py
@@ -82,7 +82,7 @@ class DummySparseLabelOp(SparseLabelOp):
         return self
 
     # pylint: disable=unused-argument
-    def simplify(self, *, atol: float | None = None) -> SparseLabelOp:
+    def simplify(self, atol: float | None = None) -> SparseLabelOp:
         return self
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I did a pass of all public methods and class initializers and made some choices of restricting certain arguments to be kwarg-only.
This is a biased suggestion but is inline with what we have been doing elsewhere already.

### Details and comments

The only files I did not look at are those still being refactored:
- `SpinOp`
- `VibrationalOp`
- `VibrationalEnergy`
- `VibrationalIntegrals`
- `VibrationalStructureProblem`
