### PR TITLE
feat: custom dipole support in QCSchema

### DIFF
--- a/qiskit_nature/second_q/drivers/electronic_structure_driver.py
+++ b/qiskit_nature/second_q/drivers/electronic_structure_driver.py
@@ -56,6 +56,17 @@ class _QCSchemaData:
     mo_energy_b: np.ndarray | None = None
     mo_occ: np.ndarray | None = None
     mo_occ_b: np.ndarray | None = None
+    dip_x: np.ndarray | None = None
+    dip_y: np.ndarray | None = None
+    dip_z: np.ndarray | None = None
+    dip_mo_x_a: np.ndarray | None = None
+    dip_mo_y_a: np.ndarray | None = None
+    dip_mo_z_a: np.ndarray | None = None
+    dip_mo_x_b: np.ndarray | None = None
+    dip_mo_y_b: np.ndarray | None = None
+    dip_mo_z_b: np.ndarray | None = None
+    dip_nuc: tuple[float, float, float] | None = None
+    dip_ref: tuple[float, float, float] | None = None
     symbols: Sequence[str] | None = None
     coords: Sequence[float] | None = None
     multiplicity: int | None = None
@@ -100,9 +111,12 @@ class ElectronicStructureDriver(BaseDriver):
         pass
 
     @abstractmethod
-    def to_qcschema(self) -> QCSchema:
+    def to_qcschema(self, *, include_dipole: bool = True) -> QCSchema:
         """Extracts all available information after the driver was run into a :class:`.QCSchema`
         object.
+
+        Args:
+            include_dipole: whether or not to include the custom dipole integrals in the QCSchema.
 
         Returns:
             A :class:`.QCSchema` storing all extracted system data computed by the driver.
@@ -147,6 +161,8 @@ class ElectronicStructureDriver(BaseDriver):
         properties.calcinfo_nbeta = data.nbeta
         properties.return_energy = data.e_ref
         properties.nuclear_repulsion_energy = data.e_nuc
+        properties.nuclear_dipole_moment = data.dip_nuc
+        properties.scf_dipole_moment = data.dip_ref
 
         def format_np_array(arr):
             return arr.ravel().tolist()
@@ -194,6 +210,33 @@ class ElectronicStructureDriver(BaseDriver):
         if data.eri_mo_bb is not None:
             wavefunction.eri_mo_bb = "scf_eri_mo_bb"
             wavefunction.scf_eri_mo_bb = format_np_array(data.eri_mo_bb)
+        if data.dip_x is not None:
+            wavefunction.dipole_x = "scf_dipole_x"
+            wavefunction.scf_dipole_x = format_np_array(data.dip_x)
+        if data.dip_y is not None:
+            wavefunction.dipole_y = "scf_dipole_y"
+            wavefunction.scf_dipole_y = format_np_array(data.dip_y)
+        if data.dip_z is not None:
+            wavefunction.dipole_z = "scf_dipole_z"
+            wavefunction.scf_dipole_z = format_np_array(data.dip_z)
+        if data.dip_mo_x_a is not None:
+            wavefunction.dipole_mo_x_a = "scf_dipole_mo_x_a"
+            wavefunction.scf_dipole_mo_x_a = format_np_array(data.dip_mo_x_a)
+        if data.dip_mo_y_a is not None:
+            wavefunction.dipole_mo_y_a = "scf_dipole_mo_y_a"
+            wavefunction.scf_dipole_mo_y_a = format_np_array(data.dip_mo_y_a)
+        if data.dip_mo_z_a is not None:
+            wavefunction.dipole_mo_z_a = "scf_dipole_mo_z_a"
+            wavefunction.scf_dipole_mo_z_a = format_np_array(data.dip_mo_z_a)
+        if data.dip_mo_x_b is not None:
+            wavefunction.dipole_mo_x_b = "scf_dipole_mo_x_b"
+            wavefunction.scf_dipole_mo_x_b = format_np_array(data.dip_mo_x_b)
+        if data.dip_mo_y_b is not None:
+            wavefunction.dipole_mo_y_b = "scf_dipole_mo_y_b"
+            wavefunction.scf_dipole_mo_y_b = format_np_array(data.dip_mo_y_b)
+        if data.dip_mo_z_b is not None:
+            wavefunction.dipole_mo_z_b = "scf_dipole_mo_z_b"
+            wavefunction.scf_dipole_mo_z_b = format_np_array(data.dip_mo_z_b)
 
         qcschema = QCSchema(
             schema_name="qcschema",

--- a/qiskit_nature/second_q/drivers/gaussiand/gaussiandriver.py
+++ b/qiskit_nature/second_q/drivers/gaussiand/gaussiandriver.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 
@@ -31,13 +31,8 @@ import qiskit_nature.optionals as _optionals
 from qiskit_nature.settings import settings
 from qiskit_nature.second_q.formats.molecule_info import MoleculeInfo
 from qiskit_nature.second_q.formats.qcschema import QCSchema
-from qiskit_nature.second_q.formats.qcschema_translator import (
-    qcschema_to_problem,
-    get_ao_to_mo_from_qcschema,
-)
-from qiskit_nature.second_q.operators import ElectronicIntegrals
+from qiskit_nature.second_q.formats.qcschema_translator import qcschema_to_problem
 from qiskit_nature.second_q.problems import ElectronicBasis, ElectronicStructureProblem
-from qiskit_nature.second_q.properties import ElectronicDipoleMoment
 
 from .gaussian_utils import run_g16
 from ..electronic_structure_driver import ElectronicStructureDriver, MethodType, _QCSchemaData
@@ -64,7 +59,7 @@ class GaussianDriver(ElectronicStructureDriver):
 
     def __init__(
         self,
-        config: Union[str, list[str]] = "# rhf/sto-3g scf(conventional)\n\n"
+        config: str | list[str] = "# rhf/sto-3g scf(conventional)\n\n"
         "h2 molecule\n\n0 1\nH   0.0  0.0    0.0\nH   0.0  0.0    0.735\n\n",
     ) -> None:
         """
@@ -92,7 +87,7 @@ class GaussianDriver(ElectronicStructureDriver):
         *,
         basis: str = "sto-3g",
         method: MethodType = MethodType.RHF,
-        driver_kwargs: Optional[dict[str, Any]] = None,
+        driver_kwargs: dict[str, Any] | None = None,
     ) -> "GaussianDriver":
         """
         Args:
@@ -289,11 +284,11 @@ class GaussianDriver(ElectronicStructureDriver):
 
         return _mel
 
-    def to_qcschema(self) -> QCSchema:
-        return GaussianDriver._qcschema_from_matrix_file(self._mel)
+    def to_qcschema(self, *, include_dipole: bool = True) -> QCSchema:
+        return GaussianDriver._qcschema_from_matrix_file(self._mel, include_dipole=include_dipole)
 
     @staticmethod
-    def _qcschema_from_matrix_file(mel: MatEl) -> QCSchema:
+    def _qcschema_from_matrix_file(mel: MatEl, *, include_dipole: bool = True) -> QCSchema:
         data = _QCSchemaData()
 
         data.mo_coeff = GaussianDriver._get_matrix(mel, "ALPHA MO COEFFICIENTS")
@@ -406,6 +401,36 @@ class GaussianDriver(ElectronicStructureDriver):
         data.nalpha = (mel.ne + mel.multip - 1) // 2
         data.nbeta = (mel.ne - mel.multip + 1) // 2
 
+        if include_dipole:
+            # dipole moment
+            dipints = GaussianDriver._get_matrix(mel, "DIPOLE INTEGRALS")
+            dipints = np.einsum("ijk->kji", dipints)
+
+            data.dip_x = dipints[0]
+            data.dip_y = dipints[1]
+            data.dip_z = dipints[2]
+            data.dip_mo_x_a = np.dot(np.dot(data.mo_coeff.T, data.dip_x), data.mo_coeff)
+            data.dip_mo_y_a = np.dot(np.dot(data.mo_coeff.T, data.dip_y), data.mo_coeff)
+            data.dip_mo_z_a = np.dot(np.dot(data.mo_coeff.T, data.dip_z), data.mo_coeff)
+            if data.mo_coeff_b is not None:
+                data.dip_mo_x_b = np.dot(np.dot(data.mo_coeff_b.T, data.dip_x), data.mo_coeff_b)
+                data.dip_mo_y_b = np.dot(np.dot(data.mo_coeff_b.T, data.dip_y), data.mo_coeff_b)
+                data.dip_mo_z_b = np.dot(np.dot(data.mo_coeff_b.T, data.dip_z), data.mo_coeff_b)
+
+            coords = np.reshape(mel.c, (len(mel.ian), 3))
+            nucl_dip = np.einsum("i,ix->x", mel.ian, coords)
+            nucl_dip = np.round(nucl_dip, decimals=8)
+            ref_dip = GaussianDriver._get_matrix(mel, "ELECTRIC DIPOLE MOMENT")
+            ref_dip = np.round(ref_dip, decimals=8)
+            elec_dip = ref_dip - nucl_dip
+
+            logger.info("HF Electronic dipole moment: %s", elec_dip)
+            logger.info("Nuclear dipole moment: %s", nucl_dip)
+            logger.info("Total dipole moment: %s", ref_dip)
+
+            data.dip_nuc = nucl_dip
+            data.dip_ref = ref_dip  # type: ignore[assignment]
+
         return GaussianDriver._to_qcschema(data)
 
     def to_problem(
@@ -425,35 +450,12 @@ class GaussianDriver(ElectronicStructureDriver):
         basis: ElectronicBasis = ElectronicBasis.MO,
         include_dipole: bool = True,
     ) -> ElectronicStructureProblem:
-        qcschema = GaussianDriver._qcschema_from_matrix_file(mel)
+        qcschema = GaussianDriver._qcschema_from_matrix_file(mel, include_dipole=include_dipole)
 
-        problem = qcschema_to_problem(qcschema, basis=basis)
+        problem = qcschema_to_problem(qcschema, basis=basis, include_dipole=include_dipole)
 
-        if include_dipole:
-            # dipole moment
-            dipints = GaussianDriver._get_matrix(mel, "DIPOLE INTEGRALS")
-            dipints = np.einsum("ijk->kji", dipints)
-
-            x_dip = ElectronicIntegrals.from_raw_integrals(dipints[0])
-            y_dip = ElectronicIntegrals.from_raw_integrals(dipints[1])
-            z_dip = ElectronicIntegrals.from_raw_integrals(dipints[2])
-
-            if basis == ElectronicBasis.MO:
-                basis_transform = get_ao_to_mo_from_qcschema(qcschema)
-
-                x_dip = basis_transform.transform_electronic_integrals(x_dip)
-                y_dip = basis_transform.transform_electronic_integrals(y_dip)
-                z_dip = basis_transform.transform_electronic_integrals(z_dip)
-
-            coords = np.reshape(mel.c, (len(mel.ian), 3))
-            nucl_dip = np.einsum("i,ix->x", mel.ian, coords)
-            nucl_dip = np.round(nucl_dip, decimals=8)
-
-            dipole_moment = ElectronicDipoleMoment(x_dip, y_dip, z_dip)
-            dipole_moment.nuclear_dipole_moment = nucl_dip
-            dipole_moment.reverse_dipole_sign = True
-
-            problem.properties.electronic_dipole_moment = dipole_moment
+        if include_dipole and problem.properties.electronic_dipole_moment is not None:
+            problem.properties.electronic_dipole_moment.reverse_dipole_sign = True
 
         return problem
 

--- a/qiskit_nature/second_q/formats/qcschema/qc_properties.py
+++ b/qiskit_nature/second_q/formats/qcschema/qc_properties.py
@@ -48,6 +48,8 @@ class QCProperties(_QCBase):
     """The two-electron energy contribution to the total SCF energy."""
     nuclear_repulsion_energy: float | None = None
     """The nuclear repulsion energy contribution to the total SCF energy."""
+    nuclear_dipole_moment: tuple[float, float, float] | None = None
+    """The nuclear X, Y, and Z dipole components."""
     scf_vv10_energy: float | None = None
     """The VV10 functional energy contribution to the total SCF energy."""
     scf_xc_energy: float | None = None

--- a/qiskit_nature/second_q/formats/qcschema/qc_wavefunction.py
+++ b/qiskit_nature/second_q/formats/qcschema/qc_wavefunction.py
@@ -82,6 +82,24 @@ class QCWavefunction(_QCBase):
     """The name of the beta-alpha electron-repulsion integrals in the MO basis."""
     eri_mo_bb: str | None = None
     """The name of the beta-beta electron-repulsion integrals in the MO basis."""
+    dipole_x: str | None = None
+    """The name of x-axis dipole moment integrals in the AO basis."""
+    dipole_y: str | None = None
+    """The name of y-axis dipole moment integrals in the AO basis."""
+    dipole_z: str | None = None
+    """The name of z-axis dipole moment integrals in the AO basis."""
+    dipole_mo_x_a: str | None = None
+    """The name of alpha-spin x-axis dipole moment integrals in the MO basis."""
+    dipole_mo_y_a: str | None = None
+    """The name of alpha-spin y-axis dipole moment integrals in the MO basis."""
+    dipole_mo_z_a: str | None = None
+    """The name of alpha-spin z-axis dipole moment integrals in the MO basis."""
+    dipole_mo_x_b: str | None = None
+    """The name of beta-spin x-axis dipole moment integrals in the MO basis."""
+    dipole_mo_y_b: str | None = None
+    """The name of beta-spin y-axis dipole moment integrals in the MO basis."""
+    dipole_mo_z_b: str | None = None
+    """The name of beta-spin z-axis dipole moment integrals in the MO basis."""
 
     scf_orbitals_a: Sequence[float] | None = None
     """The SCF alpha-spin orbitals in the AO basis."""
@@ -119,16 +137,34 @@ class QCWavefunction(_QCBase):
     """The SCF alpha-spin orbital occupations."""
     scf_occupations_b: Sequence[float] | None = None
     """The SCF beta-spin orbital occupations."""
-    scf_eri: str | None = None
+    scf_eri: Sequence[float] | None = None
     """The SCF electron-repulsion integrals in the AO basis."""
-    scf_eri_mo_aa: str | None = None
+    scf_eri_mo_aa: Sequence[float] | None = None
     """The SCF alpha-alpha electron-repulsion integrals in the MO basis."""
-    scf_eri_mo_ab: str | None = None
+    scf_eri_mo_ab: Sequence[float] | None = None
     """The SCF alpha-beta electron-repulsion integrals in the MO basis."""
-    scf_eri_mo_ba: str | None = None
+    scf_eri_mo_ba: Sequence[float] | None = None
     """The SCF beta-alpha electron-repulsion integrals in the MO basis."""
-    scf_eri_mo_bb: str | None = None
+    scf_eri_mo_bb: Sequence[float] | None = None
     """The SCF beta-beta electron-repulsion integrals in the MO basis."""
+    scf_dipole_x: Sequence[float] | None = None
+    """The SCF x-axis dipole moment integrals in the AO basis."""
+    scf_dipole_y: Sequence[float] | None = None
+    """The SCF y-axis dipole moment integrals in the AO basis."""
+    scf_dipole_z: Sequence[float] | None = None
+    """The SCF z-axis dipole moment integrals in the AO basis."""
+    scf_dipole_mo_x_a: Sequence[float] | None = None
+    """The SCF alpha-spin x-axis dipole moment integrals in the MO basis."""
+    scf_dipole_mo_y_a: Sequence[float] | None = None
+    """The SCF alpha-spin y-axis dipole moment integrals in the MO basis."""
+    scf_dipole_mo_z_a: Sequence[float] | None = None
+    """The SCF alpha-spin z-axis dipole moment integrals in the MO basis."""
+    scf_dipole_mo_x_b: Sequence[float] | None = None
+    """The SCF beta-spin x-axis dipole moment integrals in the MO basis."""
+    scf_dipole_mo_y_b: Sequence[float] | None = None
+    """The SCF beta-spin y-axis dipole moment integrals in the MO basis."""
+    scf_dipole_mo_z_b: Sequence[float] | None = None
+    """The SCF beta-spin z-axis dipole moment integrals in the MO basis."""
 
     localized_orbitals_a: Sequence[float] | None = None
     """The localized alpha-spin orbitals. All `nmo` orbitals are included, even if only a subset

--- a/test/second_q/transformers/test_active_space_transformer.py
+++ b/test/second_q/transformers/test_active_space_transformer.py
@@ -160,7 +160,8 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         expected = qcschema_to_problem(
             QCSchema.from_json(
                 self.get_resource_path("BeH_sto3g_reduced.json", "second_q/transformers/resources")
-            )
+            ),
+            include_dipole=False,
         )
         # add energy shift, which currently cannot be stored in the QCSchema
         expected.hamiltonian.constants["ActiveSpaceTransformer"] = -14.253802923103054

--- a/test/second_q/transformers/test_freeze_core_transformer.py
+++ b/test/second_q/transformers/test_freeze_core_transformer.py
@@ -71,7 +71,8 @@ class TestFreezeCoreTransformer(QiskitNatureTestCase):
         expected = qcschema_to_problem(
             QCSchema.from_json(
                 self.get_resource_path("LiH_sto3g_reduced.json", "second_q/transformers/resources")
-            )
+            ),
+            include_dipole=False,
         )
         # add energy shift, which currently cannot be stored in the QCSchema
         expected.hamiltonian.constants["FreezeCoreTransformer"] = -7.796219568771229
@@ -90,7 +91,8 @@ class TestFreezeCoreTransformer(QiskitNatureTestCase):
         expected = qcschema_to_problem(
             QCSchema.from_json(
                 self.get_resource_path("BeH_sto3g_reduced.json", "second_q/transformers/resources")
-            )
+            ),
+            include_dipole=False,
         )
         # add energy shift, which currently cannot be stored in the QCSchema
         expected.hamiltonian.constants["FreezeCoreTransformer"] = -14.253802923103054


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds custom support to store dipole moment integrals in the QCSchema format. While this is not part of the official specification, it is aligned well with the remainder of the QCSchema and is not the only custom extension which we support.
This will allow us to achieve a more consistent and simple implementation of our classical drivers.

### Details and comments

The main motivator of this PR was seeing the state of #873 where the approach prior to this PR was to:
1. dump data into a private `_QMolecule` container
2. dump that into an HDF5 file
3. load the data back in Qiskit python's process and populate the `_QCSchemaData` utility
4. generate a `QCSchema` object from this data
5. load a problem from this data
6. possibly inject the dipole data loaded from `_QMolecule`

Using the changes from this PR will allow:
- all drivers to consistenly handle the dipole data via the `QCSchema` directly (and via `_QCSchemaData` if needed)
- simplify the Psi4 workflow as follows:
    1. in Psi4 template generate a `QCSchema` object (optionally via the `_QCSchemaData` utility)
    2. dump this to HDF5 using `QCSchema.to_hfd5()`
    3. load the problem directly from the HDF5 file in Qiskit's python process