### PR TITLE
Suppress warning messages on deprecated unit test methods

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -12,6 +12,6 @@
 
 """ Qiskit Nature test packages """
 
-from .nature_test_case import QiskitNatureTestCase
+from .nature_test_case import QiskitNatureTestCase, QiskitNatureDeprecatedTestCase
 
-__all__ = ["QiskitNatureTestCase"]
+__all__ = ["QiskitNatureTestCase", "QiskitNatureDeprecatedTestCase"]

--- a/test/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
+++ b/test/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 """ Test NumPyMinimumEigensolver Factory """
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 
 from qiskit.algorithms import NumPyEigensolver
@@ -22,7 +22,7 @@ from qiskit_nature.problems.second_quantization import ElectronicStructureProble
 import qiskit_nature.optionals as _optionals
 
 
-class TestNumPyEigensolverFactory(QiskitNatureTestCase):
+class TestNumPyEigensolverFactory(QiskitNatureDeprecatedTestCase):
     """Test NumPyMinimumEigensovler Factory"""
 
     # NOTE: The actual usage of this class is mostly tested in combination with the ground-state

--- a/test/algorithms/excited_state_solvers/test_bosonic_esc_calculation.py
+++ b/test/algorithms/excited_state_solvers/test_bosonic_esc_calculation.py
@@ -17,7 +17,7 @@ import io
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -70,7 +70,7 @@ class _DummyBosonicDriver(VibrationalStructureDriver):
         return self._driver_result
 
 
-class TestBosonicESCCalculation(QiskitNatureTestCase):
+class TestBosonicESCCalculation(QiskitNatureDeprecatedTestCase):
     """Test Numerical QEOM excited states calculation"""
 
     def setUp(self):

--- a/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -13,7 +13,7 @@
 """ Test Numerical qEOM excited states calculation """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 from qiskit import BasicAer
 from qiskit.utils import algorithm_globals, QuantumInstance
@@ -38,7 +38,7 @@ from qiskit_nature.algorithms import (
 import qiskit_nature.optionals as _optionals
 
 
-class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
+class TestNumericalQEOMESCCalculation(QiskitNatureDeprecatedTestCase):
     """Test Numerical qEOM excited states calculation"""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")

--- a/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
+++ b/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
@@ -15,7 +15,7 @@
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance
 from qiskit.opflow import AerPauliExpectation
@@ -29,7 +29,7 @@ from qiskit_nature.algorithms import VQEUCCFactory
 from qiskit_nature.algorithms.initial_points import HFInitialPoint
 
 
-class TestVQEUCCFactory(QiskitNatureTestCase):
+class TestVQEUCCFactory(QiskitNatureDeprecatedTestCase):
     """Test VQE UCC MinimumEigensolver Factory"""
 
     # NOTE: The actual usage of this class is mostly tested in combination with the ground-state

--- a/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
+++ b/test/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
@@ -14,7 +14,7 @@
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance
 from qiskit.opflow import AerPauliExpectation
@@ -26,7 +26,7 @@ from qiskit_nature.algorithms import VQEUVCCFactory
 from qiskit_nature.algorithms.initial_points import VSCFInitialPoint
 
 
-class TestVQEUVCCFactory(QiskitNatureTestCase):
+class TestVQEUVCCFactory(QiskitNatureDeprecatedTestCase):
     """Test VQE UVCC MinimumEigensolver Factory"""
 
     # NOTE: The actual usage of this class is mostly tested in combination with the ground-state

--- a/test/algorithms/ground_state_solvers/test_adapt_vqe.py
+++ b/test/algorithms/ground_state_solvers/test_adapt_vqe.py
@@ -19,7 +19,7 @@ import warnings
 
 from typing import cast
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -54,7 +54,7 @@ import qiskit_nature.optionals as _optionals
 
 
 @ddt
-class TestAdaptVQE(QiskitNatureTestCase):
+class TestAdaptVQE(QiskitNatureDeprecatedTestCase):
     """Test Adaptive VQE Ground State Calculation"""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")

--- a/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance
@@ -34,7 +34,7 @@ import qiskit_nature.optionals as _optionals
 # pylint: disable=invalid-name
 
 
-class TestUCCSDHartreeFock(QiskitNatureTestCase):
+class TestUCCSDHartreeFock(QiskitNatureDeprecatedTestCase):
     """Test for these extensions."""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -18,7 +18,7 @@ import io
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -50,7 +50,7 @@ from qiskit_nature import settings
 from qiskit_nature.algorithms.initial_points import MP2InitialPoint
 
 
-class TestGroundStateEigensolver(QiskitNatureTestCase):
+class TestGroundStateEigensolver(QiskitNatureDeprecatedTestCase):
     """Test GroundStateEigensolver"""
 
     def setUp(self):

--- a/test/algorithms/ground_state_solvers/test_swaprz.py
+++ b/test/algorithms/ground_state_solvers/test_swaprz.py
@@ -15,7 +15,7 @@
 from typing import cast
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit import BasicAer
 from qiskit.algorithms import VQE
@@ -32,7 +32,7 @@ from qiskit_nature.problems.second_quantization import ElectronicStructureProble
 from qiskit_nature.properties.second_quantization.electronic import ParticleNumber
 
 
-class TestExcitationPreserving(QiskitNatureTestCase):
+class TestExcitationPreserving(QiskitNatureDeprecatedTestCase):
     """The ExcitationPresering wavefunction was design to preserve the excitation of the system.
 
     We test it here from chemistry with JORDAN_WIGNER mapping (then the number of particles

--- a/test/algorithms/initial_points/test_hf_initial_point.py
+++ b/test/algorithms/initial_points/test_hf_initial_point.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import Mock
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -30,7 +30,7 @@ from qiskit_nature.properties.second_quantization.electronic.electronic_energy i
 )
 
 
-class TestHFInitialPoint(QiskitNatureTestCase):
+class TestHFInitialPoint(QiskitNatureDeprecatedTestCase):
     """Test HFInitialPoint."""
 
     def setUp(self) -> None:

--- a/test/algorithms/initial_points/test_initial_point.py
+++ b/test/algorithms/initial_points/test_initial_point.py
@@ -14,12 +14,12 @@
 
 import unittest
 from unittest.mock import patch
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit_nature.algorithms.initial_points import InitialPoint
 
 
-class TestInitialPoint(QiskitNatureTestCase):
+class TestInitialPoint(QiskitNatureDeprecatedTestCase):
     """Test Initial Point"""
 
     @patch.multiple(InitialPoint, __abstractmethods__=set())

--- a/test/algorithms/initial_points/test_mp2_initial_point.py
+++ b/test/algorithms/initial_points/test_mp2_initial_point.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import Mock
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 from ddt import ddt, file_data
@@ -46,7 +46,7 @@ from qiskit_nature.algorithms.initial_points import MP2InitialPoint
 
 
 @ddt
-class TestMP2InitialPoint(QiskitNatureTestCase):
+class TestMP2InitialPoint(QiskitNatureDeprecatedTestCase):
     """Test MP2InitialPoint."""
 
     def setUp(self):

--- a/test/algorithms/initial_points/test_vscf_initial_point.py
+++ b/test/algorithms/initial_points/test_vscf_initial_point.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import Mock
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -27,7 +27,7 @@ from qiskit_nature.properties.second_quantization.second_quantized_property impo
 )
 
 
-class TestVSCFInitialPoint(QiskitNatureTestCase):
+class TestVSCFInitialPoint(QiskitNatureDeprecatedTestCase):
     """Test VSCFInitialPoint."""
 
     def setUp(self) -> None:

--- a/test/algorithms/pes_samplers/potentials/test_potential.py
+++ b/test/algorithms/pes_samplers/potentials/test_potential.py
@@ -14,7 +14,7 @@
 
 import unittest
 from functools import partial
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 
 from qiskit_nature.algorithms.pes_samplers.potentials.harmonic_potential import (
@@ -27,7 +27,7 @@ from qiskit_nature.constants import HARTREE_TO_J_PER_MOL
 from qiskit_nature.drivers import Molecule
 
 
-class TestPotential(QiskitNatureTestCase):
+class TestPotential(QiskitNatureDeprecatedTestCase):
     """Test Potential"""
 
     @staticmethod

--- a/test/algorithms/pes_samplers/test_bopes_sampler.py
+++ b/test/algorithms/pes_samplers/test_bopes_sampler.py
@@ -14,7 +14,7 @@
 
 import unittest
 from functools import partial
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -46,7 +46,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.problems.second_quantization import ElectronicStructureProblem, BaseProblem
 
 
-class TestBOPES(QiskitNatureTestCase):
+class TestBOPES(QiskitNatureDeprecatedTestCase):
     """Tests of BOPES Sampler."""
 
     def setUp(self) -> None:

--- a/test/algorithms/pes_samplers/test_extrapolators.py
+++ b/test/algorithms/pes_samplers/test_extrapolators.py
@@ -16,7 +16,7 @@ parameter pairs.
 """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from sklearn import linear_model
 from qiskit_nature.exceptions import QiskitNatureError
 from qiskit_nature.algorithms.pes_samplers import (
@@ -213,7 +213,7 @@ PARAM_DICT = {
 }
 
 
-class TestExtrapolators(QiskitNatureTestCase):
+class TestExtrapolators(QiskitNatureDeprecatedTestCase):
     """Test Extrapolators."""
 
     def test_factory(self):

--- a/test/circuit/library/ansatzes/test_chc.py
+++ b/test/circuit/library/ansatzes/test_chc.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.circuit.library.ansatzes.utils.vibrational_op_label_creator import _create_labels
 
 from qiskit import BasicAer
@@ -30,7 +30,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.operators.second_quantization import VibrationalOp
 
 
-class TestCHCVSCF(QiskitNatureTestCase):
+class TestCHCVSCF(QiskitNatureDeprecatedTestCase):
     """Test for CHC and VSCF library circuits."""
 
     def setUp(self):

--- a/test/circuit/library/ansatzes/test_puccd.py
+++ b/test/circuit/library/ansatzes/test_puccd.py
@@ -12,7 +12,7 @@
 
 """Test the PUCCD Ansatz."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.circuit.library.ansatzes.test_ucc import assert_ucc_like_ansatz
 
 from ddt import ddt, data, unpack
@@ -25,7 +25,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 
 
 @ddt
-class TestPUCC(QiskitNatureTestCase):
+class TestPUCC(QiskitNatureDeprecatedTestCase):
     """Tests for the PUCCD Ansatz."""
 
     @unpack

--- a/test/circuit/library/ansatzes/test_succd.py
+++ b/test/circuit/library/ansatzes/test_succd.py
@@ -12,7 +12,7 @@
 
 """Test the SUCCD Ansatz."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.circuit.library.ansatzes.test_ucc import assert_ucc_like_ansatz
 
 from ddt import ddt, data, unpack
@@ -25,7 +25,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 
 
 @ddt
-class TestSUCCD(QiskitNatureTestCase):
+class TestSUCCD(QiskitNatureDeprecatedTestCase):
     """Tests for the SUCCD Ansatz."""
 
     @unpack

--- a/test/circuit/library/ansatzes/test_ucc.py
+++ b/test/circuit/library/ansatzes/test_ucc.py
@@ -12,7 +12,7 @@
 
 """Test the UCC Ansatz."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import data, ddt, unpack
 
@@ -37,7 +37,7 @@ def assert_ucc_like_ansatz(test_case, ansatz, num_spin_orbitals, expected_ops):
 
 
 @ddt
-class TestUCC(QiskitNatureTestCase):
+class TestUCC(QiskitNatureDeprecatedTestCase):
     """Tests for the UCC Ansatz."""
 
     # Note: many variations of this class are tested by its sub-classes UCCSD, PUCCD and SUCCD.

--- a/test/circuit/library/ansatzes/test_uccsd.py
+++ b/test/circuit/library/ansatzes/test_uccsd.py
@@ -12,7 +12,7 @@
 
 """Test the UCCSD Ansatz."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.circuit.library.ansatzes.test_ucc import assert_ucc_like_ansatz
 
 from ddt import ddt, data, unpack
@@ -24,7 +24,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 
 
 @ddt
-class TestUCCSD(QiskitNatureTestCase):
+class TestUCCSD(QiskitNatureDeprecatedTestCase):
     """Tests for the UCCSD Ansatz."""
 
     @unpack

--- a/test/circuit/library/ansatzes/test_uvcc.py
+++ b/test/circuit/library/ansatzes/test_uvcc.py
@@ -12,7 +12,7 @@
 
 """Test the UVCC Ansatz."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.circuit.library.ansatzes.utils.vibrational_op_label_creator import _create_labels
 
 import unittest
@@ -42,7 +42,7 @@ def assert_ucc_like_ansatz(test_case, ansatz, num_modals, expected_ops):
 
 
 @ddt
-class TestUVCC(QiskitNatureTestCase):
+class TestUVCC(QiskitNatureDeprecatedTestCase):
     """Tests for the UVCC Ansatz."""
 
     @unpack
@@ -75,7 +75,7 @@ class TestUVCC(QiskitNatureTestCase):
         self.assertEqual(ansatz.num_qubits, 2)
 
 
-class TestUVCCVSCF(QiskitNatureTestCase):
+class TestUVCCVSCF(QiskitNatureDeprecatedTestCase):
     """Test for these extensions."""
 
     def setUp(self):

--- a/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_fermionic_excitation_generator.py
@@ -12,7 +12,7 @@
 
 """Test the excitation generator."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import data, ddt, unpack
 
@@ -22,7 +22,7 @@ from qiskit_nature.circuit.library.ansatzes.utils.fermionic_excitation_generator
 
 
 @ddt
-class TestFermionicExcitationGenerator(QiskitNatureTestCase):
+class TestFermionicExcitationGenerator(QiskitNatureDeprecatedTestCase):
     """Tests for the default fermionic excitation generator method."""
 
     @unpack

--- a/test/circuit/library/ansatzes/utils/test_vibration_excitation_generator.py
+++ b/test/circuit/library/ansatzes/utils/test_vibration_excitation_generator.py
@@ -12,7 +12,7 @@
 
 """Test the excitation generator."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import data, ddt, unpack
 
@@ -22,7 +22,7 @@ from qiskit_nature.circuit.library.ansatzes.utils.vibration_excitation_generator
 
 
 @ddt
-class TestVibrationExcitationGenerator(QiskitNatureTestCase):
+class TestVibrationExcitationGenerator(QiskitNatureDeprecatedTestCase):
     """Tests for the default vibration excitation generator method."""
 
     @unpack

--- a/test/circuit/library/initial_states/test_fermionic_gaussian_state.py
+++ b/test/circuit/library/initial_states/test_fermionic_gaussian_state.py
@@ -12,7 +12,7 @@
 
 """Test fermionic Gaussian state preparation circuits."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.nature_random import random_legacy_quadratic_hamiltonian as random_quadratic_hamiltonian
 
 import numpy as np
@@ -23,7 +23,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.mappers.second_quantization import BravyiKitaevMapper, JordanWignerMapper
 
 
-class TestFermionicGaussianState(QiskitNatureTestCase):
+class TestFermionicGaussianState(QiskitNatureDeprecatedTestCase):
     """Tests for preparing fermionic Gaussian states determinants."""
 
     def test_fermionic_gaussian_state(self):

--- a/test/circuit/library/initial_states/test_hartree_fock.py
+++ b/test/circuit/library/initial_states/test_hartree_fock.py
@@ -13,7 +13,7 @@
 """Test Hartree Fock initial state circuit."""
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -32,7 +32,7 @@ from qiskit_nature.mappers.second_quantization import (
 from qiskit_nature.converters.second_quantization import QubitConverter
 
 
-class TestHartreeFock(QiskitNatureTestCase):
+class TestHartreeFock(QiskitNatureDeprecatedTestCase):
     """Initial State HartreeFock tests"""
 
     def test_bitstring(self):

--- a/test/circuit/library/initial_states/test_slater_determinant.py
+++ b/test/circuit/library/initial_states/test_slater_determinant.py
@@ -12,7 +12,7 @@
 
 """Test Slater determinant state preparation circuits."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.nature_random import random_legacy_quadratic_hamiltonian as random_quadratic_hamiltonian
 
 import numpy as np
@@ -23,7 +23,7 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.mappers.second_quantization import BravyiKitaevMapper, JordanWignerMapper
 
 
-class TestSlaterDeterminant(QiskitNatureTestCase):
+class TestSlaterDeterminant(QiskitNatureDeprecatedTestCase):
     """Tests for preparing Slater determinants."""
 
     def test_slater_determinant(self):

--- a/test/circuit/library/initial_states/test_vscf.py
+++ b/test/circuit/library/initial_states/test_vscf.py
@@ -13,7 +13,7 @@
 """Test the VSCF initial state."""
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 
 from qiskit import QuantumCircuit
@@ -21,7 +21,7 @@ from qiskit_nature.circuit.library import VSCF
 from qiskit_nature.circuit.library.initial_states.vscf import vscf_bitstring
 
 
-class TestVSCF(QiskitNatureTestCase):
+class TestVSCF(QiskitNatureDeprecatedTestCase):
     """Initial State vscf tests"""
 
     def test_bitstring(self):

--- a/test/circuit/library/test_bogoliubov_transform.py
+++ b/test/circuit/library/test_bogoliubov_transform.py
@@ -12,7 +12,7 @@
 
 """Test Bogoliubov transform circuits."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.nature_random import random_legacy_quadratic_hamiltonian as random_quadratic_hamiltonian
 
 import numpy as np
@@ -34,7 +34,7 @@ def _expand_transformation_matrix(mat: np.ndarray) -> np.ndarray:
 
 
 @ddt
-class TestBogoliubovTransform(QiskitNatureTestCase):
+class TestBogoliubovTransform(QiskitNatureDeprecatedTestCase):
     """Tests for BogoliubovTransform."""
 
     @unpack

--- a/test/drivers/second_quantization/fcidumpd/test_driver_fcidump.py
+++ b/test/drivers/second_quantization/fcidumpd/test_driver_fcidump.py
@@ -16,7 +16,7 @@ from typing import cast
 
 import unittest
 from abc import ABC, abstractmethod
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 from qiskit_nature.drivers.second_quantization import FCIDumpDriver
 from qiskit_nature.properties.second_quantization.electronic import ElectronicEnergy, ParticleNumber
@@ -136,7 +136,7 @@ class BaseTestDriverFCIDump(ABC):
             self.assertEqual(particle_number.num_beta, self.num_beta)
 
 
-class TestDriverFCIDumpH2(QiskitNatureTestCase, BaseTestDriverFCIDump):
+class TestDriverFCIDumpH2(QiskitNatureDeprecatedTestCase, BaseTestDriverFCIDump):
     """RHF FCIDump Driver tests."""
 
     def setUp(self):
@@ -163,7 +163,7 @@ class TestDriverFCIDumpH2(QiskitNatureTestCase, BaseTestDriverFCIDump):
         self.driver_result = driver.run()
 
 
-class TestDriverFCIDumpLiH(QiskitNatureTestCase, BaseTestDriverFCIDump):
+class TestDriverFCIDumpLiH(QiskitNatureDeprecatedTestCase, BaseTestDriverFCIDump):
     """RHF FCIDump Driver tests."""
 
     def setUp(self):
@@ -190,7 +190,7 @@ class TestDriverFCIDumpLiH(QiskitNatureTestCase, BaseTestDriverFCIDump):
         self.driver_result = driver.run()
 
 
-class TestDriverFCIDumpOH(QiskitNatureTestCase, BaseTestDriverFCIDump):
+class TestDriverFCIDumpOH(QiskitNatureDeprecatedTestCase, BaseTestDriverFCIDump):
     """RHF FCIDump Driver tests."""
 
     def setUp(self):

--- a/test/drivers/second_quantization/fcidumpd/test_driver_fcidump_dumper.py
+++ b/test/drivers/second_quantization/fcidumpd/test_driver_fcidump_dumper.py
@@ -15,7 +15,7 @@
 import tempfile
 import unittest
 from abc import ABC, abstractmethod
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import numpy as np
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.drivers import UnitsType
@@ -105,7 +105,7 @@ class BaseTestDriverFCIDumpDumper(ABC):
 
 
 @unittest.skip("Until the FCIDumpDriver can handle non-beta spin cases")
-class TestDriverFCIDumpDumpH2(QiskitNatureTestCase, BaseTestDriverFCIDumpDumper):
+class TestDriverFCIDumpDumpH2(QiskitNatureDeprecatedTestCase, BaseTestDriverFCIDumpDumper):
     """RHF FCIDump Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature.drivers.second_quantization import (
     GaussianDriver,
@@ -24,7 +24,7 @@ from qiskit_nature.drivers.second_quantization import (
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverGaussian(QiskitNatureTestCase, TestDriver):
+class TestDriverGaussian(QiskitNatureDeprecatedTestCase, TestDriver):
     """Gaussian Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_GAUSSIAN, "gaussian not available.")
@@ -45,7 +45,7 @@ class TestDriverGaussian(QiskitNatureTestCase, TestDriver):
         self.driver_result = driver.run()
 
 
-class TestDriverGaussianMolecule(QiskitNatureTestCase, TestDriver):
+class TestDriverGaussianMolecule(QiskitNatureDeprecatedTestCase, TestDriver):
     """Gaussian Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_GAUSSIAN, "gaussian not available.")

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian_extra.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian_extra.py
@@ -14,11 +14,11 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.drivers.second_quantization import GaussianDriver
 
 
-class TestDriverGaussianExtra(QiskitNatureTestCase):
+class TestDriverGaussianExtra(QiskitNatureDeprecatedTestCase):
     """Gaussian Driver extra tests for driver specifics, errors etc"""
 
     def test_cfg_augment(self):

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian_forces.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian_forces.py
@@ -17,7 +17,7 @@ import unittest
 import warnings
 from typing import cast
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from ddt import data, ddt, unpack
 
 from qiskit_nature.drivers import Molecule, WatsonHamiltonian
@@ -33,7 +33,7 @@ import qiskit_nature.optionals as _optionals
 
 
 @ddt
-class TestDriverGaussianForces(QiskitNatureTestCase):
+class TestDriverGaussianForces(QiskitNatureDeprecatedTestCase):
     """Gaussian Forces Driver tests."""
 
     _C01_REV_EXPECTED = [

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian_from_mat.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian_from_mat.py
@@ -14,13 +14,13 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.drivers.second_quantization import GaussianDriver
 
 
-class TestDriverGaussianFromMat(QiskitNatureTestCase, TestDriver):
+class TestDriverGaussianFromMat(QiskitNatureDeprecatedTestCase, TestDriver):
     """Gaussian Driver tests using a saved output matrix file."""
 
     def setUp(self):

--- a/test/drivers/second_quantization/gaussiand/test_driver_gaussian_log.py
+++ b/test/drivers/second_quantization/gaussiand/test_driver_gaussian_log.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 import warnings
 import numpy as np
 
@@ -25,7 +25,7 @@ from qiskit_nature.properties.second_quantization.vibrational.integrals import V
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverGaussianLog(QiskitNatureTestCase):
+class TestDriverGaussianLog(QiskitNatureDeprecatedTestCase):
     """Gaussian Log Driver tests."""
 
     def setUp(self):

--- a/test/drivers/second_quantization/hdf5d/test_driver_hdf5.py
+++ b/test/drivers/second_quantization/hdf5d/test_driver_hdf5.py
@@ -18,14 +18,14 @@ import shutil
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature.drivers.second_quantization import HDF5Driver
 from qiskit_nature.drivers import QMolecule
 from qiskit_nature.properties.second_quantization.electronic import ElectronicStructureDriverResult
 
 
-class TestDriverHDF5(QiskitNatureTestCase, TestDriver):
+class TestDriverHDF5(QiskitNatureDeprecatedTestCase, TestDriver):
     """HDF5 Driver tests."""
 
     def setUp(self):
@@ -73,7 +73,7 @@ class TestDriverHDF5(QiskitNatureTestCase, TestDriver):
                 HDF5Driver(new_file_name).run()
 
 
-class TestDriverHDF5Legacy(QiskitNatureTestCase, TestDriver):
+class TestDriverHDF5Legacy(QiskitNatureDeprecatedTestCase, TestDriver):
     """HDF5 Driver legacy file-support tests."""
 
     def setUp(self):

--- a/test/drivers/second_quantization/psi4d/test_driver_psi4.py
+++ b/test/drivers/second_quantization/psi4d/test_driver_psi4.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature.drivers.second_quantization import (
     PSI4Driver,
@@ -24,7 +24,7 @@ from qiskit_nature.drivers.second_quantization import (
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverPSI4(QiskitNatureTestCase, TestDriver):
+class TestDriverPSI4(QiskitNatureDeprecatedTestCase, TestDriver):
     """PSI4 Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_PSI4, "psi4 not available.")
@@ -49,7 +49,7 @@ class TestDriverPSI4(QiskitNatureTestCase, TestDriver):
         self.driver_result = driver.run()
 
 
-class TestDriverPSI4Molecule(QiskitNatureTestCase, TestDriver):
+class TestDriverPSI4Molecule(QiskitNatureDeprecatedTestCase, TestDriver):
     """PSI4 Driver molecule tests."""
 
     @unittest.skipIf(not _optionals.HAS_PSI4, "psi4 not available.")

--- a/test/drivers/second_quantization/psi4d/test_driver_psi4_extra.py
+++ b/test/drivers/second_quantization/psi4d/test_driver_psi4_extra.py
@@ -16,14 +16,14 @@ from typing import cast
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.drivers.second_quantization import PSI4Driver
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.properties.second_quantization.electronic import ElectronicEnergy
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverPSI4Extra(QiskitNatureTestCase):
+class TestDriverPSI4Extra(QiskitNatureDeprecatedTestCase):
     """PSI4 Driver extra tests for driver specifics, errors etc"""
 
     @unittest.skipIf(not _optionals.HAS_PSI4, "psi4 not available.")

--- a/test/drivers/second_quantization/pyquanted/test_driver_pyquante.py
+++ b/test/drivers/second_quantization/pyquanted/test_driver_pyquante.py
@@ -13,7 +13,7 @@
 """ Test Driver PyQuante """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature.drivers import UnitsType
 from qiskit_nature.drivers.second_quantization import (
@@ -25,7 +25,7 @@ from qiskit_nature.drivers.second_quantization import (
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverPyQuante(QiskitNatureTestCase, TestDriver):
+class TestDriverPyQuante(QiskitNatureDeprecatedTestCase, TestDriver):
     """PYQUANTE Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_PYQUANTE2, "pyquante2 not available.")
@@ -41,7 +41,7 @@ class TestDriverPyQuante(QiskitNatureTestCase, TestDriver):
         self.driver_result = driver.run()
 
 
-class TestDriverPyQuanteMolecule(QiskitNatureTestCase, TestDriver):
+class TestDriverPyQuanteMolecule(QiskitNatureDeprecatedTestCase, TestDriver):
     """PYQUANTE Driver molecule tests."""
 
     @unittest.skipIf(not _optionals.HAS_PYQUANTE2, "pyquante2 not available.")

--- a/test/drivers/second_quantization/pyscfd/test_driver_pyscf.py
+++ b/test/drivers/second_quantization/pyscfd/test_driver_pyscf.py
@@ -15,7 +15,7 @@
 from typing import cast
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.drivers.second_quantization.test_driver import TestDriver
 from qiskit_nature.drivers import UnitsType
 from qiskit_nature.drivers.second_quantization import (
@@ -28,7 +28,7 @@ from qiskit_nature.properties.second_quantization.electronic import ElectronicEn
 import qiskit_nature.optionals as _optionals
 
 
-class TestDriverPySCF(QiskitNatureTestCase, TestDriver):
+class TestDriverPySCF(QiskitNatureDeprecatedTestCase, TestDriver):
     """PYSCF Driver tests."""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
@@ -81,7 +81,7 @@ class TestDriverPySCF(QiskitNatureTestCase, TestDriver):
         self.assertAlmostEqual(electronic_energy.reference_energy, -1.0661086493179366, places=5)
 
 
-class TestDriverPySCFMolecule(QiskitNatureTestCase, TestDriver):
+class TestDriverPySCFMolecule(QiskitNatureDeprecatedTestCase, TestDriver):
     """PYSCF Driver Molecule tests."""
 
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")

--- a/test/drivers/second_quantization/test_driver_methods_gsc.py
+++ b/test/drivers/second_quantization/test_driver_methods_gsc.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit.algorithms import NumPyMinimumEigensolver
 from qiskit_nature.algorithms import GroundStateEigensolver
 from qiskit_nature.drivers.second_quantization import ElectronicStructureDriver
@@ -26,7 +26,7 @@ from qiskit_nature.problems.second_quantization import ElectronicStructureProble
 from qiskit_nature.transformers.second_quantization import BaseTransformer
 
 
-class TestDriverMethods(QiskitNatureTestCase):
+class TestDriverMethods(QiskitNatureDeprecatedTestCase):
     """Common driver tests. For H2 @ 0.735, sto3g"""
 
     def setUp(self):

--- a/test/drivers/second_quantization/test_driver_molecule.py
+++ b/test/drivers/second_quantization/test_driver_molecule.py
@@ -13,7 +13,7 @@
 """ Test Molecule """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from functools import partial
 import numpy as np
@@ -21,7 +21,7 @@ import numpy as np
 from qiskit_nature.drivers import Molecule, UnitsType
 
 
-class TestMolecule(QiskitNatureTestCase):
+class TestMolecule(QiskitNatureDeprecatedTestCase):
     """Test driver-independent molecule definition."""
 
     def test_construct(self):

--- a/test/drivers/second_quantization/test_molecule_driver.py
+++ b/test/drivers/second_quantization/test_molecule_driver.py
@@ -18,7 +18,7 @@ import re
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from ddt import ddt, data
 
 from qiskit.exceptions import MissingOptionalLibraryError
@@ -40,7 +40,7 @@ import qiskit_nature.optionals as _optionals
 
 
 @ddt
-class TestElectronicStructureMoleculeDriver(QiskitNatureTestCase):
+class TestElectronicStructureMoleculeDriver(QiskitNatureDeprecatedTestCase):
     """Electronic structure Molecule Driver tests."""
 
     def setUp(self):
@@ -102,7 +102,7 @@ class TestElectronicStructureMoleculeDriver(QiskitNatureTestCase):
 
 
 @ddt
-class TestVibrationalStructureMoleculeDriver(QiskitNatureTestCase):
+class TestVibrationalStructureMoleculeDriver(QiskitNatureDeprecatedTestCase):
     """Vibrational structure Molecule Driver tests."""
 
     _C01_REV_EXPECTED = [

--- a/test/mappers/second_quantization/test_bksf_mapper.py
+++ b/test/mappers/second_quantization/test_bksf_mapper.py
@@ -13,7 +13,7 @@
 """ Test Bravyi-Kitaev Super-Fast Mapper """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from test.mappers.second_quantization.resources.bksf_lih import (
     FERMIONIC_HAMILTONIAN,
@@ -37,7 +37,7 @@ def _sort_simplify(sparse_pauli):
     return sparse_pauli
 
 
-class TestBravyiKitaevSuperFastMapper(QiskitNatureTestCase):
+class TestBravyiKitaevSuperFastMapper(QiskitNatureDeprecatedTestCase):
     """Test Bravyi-Kitaev Super-Fast Mapper"""
 
     def test_bksf_edge_op_bi(self):

--- a/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
+++ b/test/mappers/second_quantization/test_bravyi_kitaev_mapper.py
@@ -13,7 +13,7 @@
 """ Test Bravyi-Kitaev Mapper """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit.opflow import I, PauliSumOp, X, Z
 
@@ -22,7 +22,7 @@ from qiskit_nature.mappers.second_quantization import BravyiKitaevMapper
 from qiskit_nature.operators.second_quantization import FermionicOp
 
 
-class TestBravyiKitaevMapper(QiskitNatureTestCase):
+class TestBravyiKitaevMapper(QiskitNatureDeprecatedTestCase):
     """Test Bravyi-Kitaev Mapper"""
 
     REF_H2 = (

--- a/test/mappers/second_quantization/test_direct_mapper.py
+++ b/test/mappers/second_quantization/test_direct_mapper.py
@@ -15,7 +15,7 @@
 import unittest
 import warnings
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit_nature.drivers.second_quantization import GaussianForcesDriver
 from qiskit_nature.mappers.second_quantization import DirectMapper
@@ -24,7 +24,7 @@ from qiskit_nature.properties.second_quantization.vibrational.bases import Harmo
 from .resources.reference_direct_mapper import _num_modals_2_q_op, _num_modals_3_q_op
 
 
-class TestDirectMapper(QiskitNatureTestCase):
+class TestDirectMapper(QiskitNatureDeprecatedTestCase):
     """Test Direct Mapper"""
 
     def setUp(self) -> None:

--- a/test/mappers/second_quantization/test_jordan_wigner_mapper.py
+++ b/test/mappers/second_quantization/test_jordan_wigner_mapper.py
@@ -13,7 +13,7 @@
 """ Test Jordan Wigner Mapper """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit.opflow import I, PauliSumOp, X, Y, Z
 
@@ -22,7 +22,7 @@ from qiskit_nature.mappers.second_quantization import JordanWignerMapper
 from qiskit_nature.operators.second_quantization import FermionicOp
 
 
-class TestJordanWignerMapper(QiskitNatureTestCase):
+class TestJordanWignerMapper(QiskitNatureDeprecatedTestCase):
     """Test Jordan Wigner Mapper"""
 
     REF_H2 = (

--- a/test/mappers/second_quantization/test_linear_mapper.py
+++ b/test/mappers/second_quantization/test_linear_mapper.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import ddt, data, unpack
 
@@ -24,7 +24,7 @@ from qiskit_nature.mappers.second_quantization import LinearMapper
 
 
 @ddt
-class TestLinearMapper(QiskitNatureTestCase):
+class TestLinearMapper(QiskitNatureDeprecatedTestCase):
     """Test Linear Mapper"""
 
     spin_op1 = SpinOp([("Y_0^2", -0.432 + 1.32j)], 0.5, 1)

--- a/test/mappers/second_quantization/test_logarithmic_mapper.py
+++ b/test/mappers/second_quantization/test_logarithmic_mapper.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import ddt, data, unpack
 
@@ -24,7 +24,7 @@ from qiskit_nature.mappers.second_quantization import LogarithmicMapper
 
 
 @ddt
-class TestLogarithmicMapper(QiskitNatureTestCase):
+class TestLogarithmicMapper(QiskitNatureDeprecatedTestCase):
     """Test Logarithmic Mapper"""
 
     spin_op1 = SpinOp([("Y_0", -0.432 + 1.32j)], 0.5, 1)

--- a/test/mappers/second_quantization/test_parity_mapper.py
+++ b/test/mappers/second_quantization/test_parity_mapper.py
@@ -13,7 +13,7 @@
 """ Test Parity Mapper """
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit.opflow import I, PauliSumOp, X, Z
 
@@ -22,7 +22,7 @@ from qiskit_nature.mappers.second_quantization import ParityMapper
 from qiskit_nature.operators.second_quantization import FermionicOp
 
 
-class TestParityMapper(QiskitNatureTestCase):
+class TestParityMapper(QiskitNatureDeprecatedTestCase):
     """Test Parity Mapper"""
 
     REF_H2 = (

--- a/test/nature_test_case.py
+++ b/test/nature_test_case.py
@@ -62,6 +62,8 @@ class QiskitNatureTestCase(unittest.TestCase, ABC):
             category=DeprecationWarning,
             module=".*second_q.transformers.*",
         )
+        # ignore opflow/gradients/natural_gradient
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="qiskit")
         self._started_at = time.time()
         self._class_location = __file__
 
@@ -104,3 +106,23 @@ class QiskitNatureTestCase(unittest.TestCase, ABC):
         root = os.path.dirname(self._class_location)
         path = root if path is None else os.path.join(root, path)
         return os.path.normpath(os.path.join(path, filename))
+
+
+class QiskitNatureDeprecatedTestCase(QiskitNatureTestCase):
+    """Nature Deprecated Test Case.
+    Used for tests that need to suppress deprecation messages.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # disable deprecation warnings
+        warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        warnings.filterwarnings("ignore", category=NatureDeprecationWarning)
+
+    def tearDown(self) -> None:
+        # enable deprecation warnings
+        warnings.filterwarnings("default", category=PendingDeprecationWarning)
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        warnings.filterwarnings("default", category=NatureDeprecationWarning)
+        super().tearDown()

--- a/test/operators/second_quantization/test_fermionic_op.py
+++ b/test/operators/second_quantization/test_fermionic_op.py
@@ -16,7 +16,7 @@ import unittest
 import warnings
 from functools import lru_cache
 from itertools import product
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 from ddt import data, ddt, unpack
@@ -45,7 +45,7 @@ def sparse_labels(length, only_plus_minus=False):
 
 
 @ddt
-class TestFermionicOp(QiskitNatureTestCase):
+class TestFermionicOp(QiskitNatureDeprecatedTestCase):
     """FermionicOp tests."""
 
     def assertFermionEqual(self, first: FermionicOp, second: FermionicOp):

--- a/test/operators/second_quantization/test_quadratic_hamiltonian.py
+++ b/test/operators/second_quantization/test_quadratic_hamiltonian.py
@@ -12,7 +12,7 @@
 
 """Tests for QuadraticHamiltonian"""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.nature_random import random_antisymmetric_matrix
 
 import numpy as np
@@ -26,7 +26,7 @@ from qiskit_nature.operators.second_quantization.fermionic_op import FermionicOp
 
 
 @ddt
-class TestQuadraticHamiltonian(QiskitNatureTestCase):
+class TestQuadraticHamiltonian(QiskitNatureDeprecatedTestCase):
     """QuadraticHamiltonian tests."""
 
     def test_init(self):

--- a/test/operators/second_quantization/test_spin_op.py
+++ b/test/operators/second_quantization/test_spin_op.py
@@ -16,7 +16,7 @@ import unittest
 from fractions import Fraction
 from functools import lru_cache
 from itertools import product
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 from ddt import data, ddt, unpack
@@ -43,7 +43,7 @@ def dense_labels(length):
 
 
 @ddt
-class TestSpinOp(QiskitNatureTestCase):
+class TestSpinOp(QiskitNatureDeprecatedTestCase):
     """SpinOp tests."""
 
     def setUp(self):

--- a/test/operators/second_quantization/test_vibrational_op.py
+++ b/test/operators/second_quantization/test_vibrational_op.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 """Test for VibrationalOp"""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 from ddt import data, ddt
@@ -20,7 +20,7 @@ from qiskit_nature.operators.second_quantization import VibrationalOp
 
 
 @ddt
-class TestVibrationalOp(QiskitNatureTestCase):
+class TestVibrationalOp(QiskitNatureDeprecatedTestCase):
     """VibrationalOp tests."""
 
     def setUp(self):

--- a/test/problems/sampling/protein_folding/bead_contacts/test_contact_map_builder.py
+++ b/test/problems/sampling/protein_folding/bead_contacts/test_contact_map_builder.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests ContactMapBuilder."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit_nature.problems.sampling.protein_folding.bead_contacts import contact_map_builder
 from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Peptide
@@ -18,7 +18,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Pept
 PATH = "problems/sampling/protein_folding/resources/test_contact_map_builder"
 
 
-class TestContactMapBuilder(QiskitNatureTestCase):
+class TestContactMapBuilder(QiskitNatureDeprecatedTestCase):
     """Tests ContactMapBuilder."""
 
     def test_create_pauli_for_contacts(self):

--- a/test/problems/sampling/protein_folding/bead_distances/test_distance_map.py
+++ b/test/problems/sampling/protein_folding/bead_distances/test_distance_map.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests DistanceMap."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit_nature.problems.sampling.protein_folding.interactions.miyazawa_jernigan_interaction import (
     MiyazawaJerniganInteraction,
@@ -22,7 +22,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Pept
 PATH = "problems/sampling/protein_folding/resources/test_distance_map"
 
 
-class TestDistanceMap(QiskitNatureTestCase):
+class TestDistanceMap(QiskitNatureDeprecatedTestCase):
     """Tests DistanceMap."""
 
     def test_first_neighbor(self):

--- a/test/problems/sampling/protein_folding/bead_distances/test_distance_map_builder.py
+++ b/test/problems/sampling/protein_folding/bead_distances/test_distance_map_builder.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests DistanceMapBuilder."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit_nature.problems.sampling.protein_folding.bead_distances.distance_map_builder import (
     DistanceMapBuilder,
@@ -21,7 +21,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Pept
 PATH = "problems/sampling/protein_folding/resources/test_distance_map_builder"
 
 
-class TestDistanceMapBuilder(QiskitNatureTestCase):
+class TestDistanceMapBuilder(QiskitNatureDeprecatedTestCase):
     """Tests DistanceMapBuilder."""
 
     def setUp(self):

--- a/test/problems/sampling/protein_folding/data_loaders/test_energy_matrix_loader.py
+++ b/test/problems/sampling/protein_folding/data_loaders/test_energy_matrix_loader.py
@@ -10,13 +10,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests EnergyMatrixLoader."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.data_loaders.energy_matrix_loader import (
     _load_energy_matrix_file,
 )
 
 
-class TestEnergyMatrixLoader(QiskitNatureTestCase):
+class TestEnergyMatrixLoader(QiskitNatureDeprecatedTestCase):
     """Tests EnergyMatrixLoader."""
 
     def test_load_energy_matrix_file(self):

--- a/test/problems/sampling/protein_folding/interactions/test_mixed_interaction.py
+++ b/test/problems/sampling/protein_folding/interactions/test_mixed_interaction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests MixedInteraction."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.exceptions.invalid_residue_exception import (
     InvalidResidueException,
 )
@@ -19,7 +19,7 @@ from qiskit_nature.problems.sampling.protein_folding.interactions.mixed_interact
 )
 
 
-class TestMixedInteraction(QiskitNatureTestCase):
+class TestMixedInteraction(QiskitNatureDeprecatedTestCase):
     """Tests MixedInteraction."""
 
     def test_calc_energy_matrix(self):

--- a/test/problems/sampling/protein_folding/interactions/test_miyazawa_jernigan_interaction.py
+++ b/test/problems/sampling/protein_folding/interactions/test_miyazawa_jernigan_interaction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests MiyazawaJerniganInteraction."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.exceptions.invalid_residue_exception import (
     InvalidResidueException,
 )
@@ -19,7 +19,7 @@ from qiskit_nature.problems.sampling.protein_folding.interactions.miyazawa_jerni
 )
 
 
-class TestMiyazawaJerniganInteraction(QiskitNatureTestCase):
+class TestMiyazawaJerniganInteraction(QiskitNatureDeprecatedTestCase):
     """Tests MiyazawaJerniganInteraction."""
 
     def test_calc_energy_matrix(self):

--- a/test/problems/sampling/protein_folding/interactions/test_random_interaction.py
+++ b/test/problems/sampling/protein_folding/interactions/test_random_interaction.py
@@ -10,13 +10,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests RandomInteraction."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.interactions.random_interaction import (
     RandomInteraction,
 )
 
 
-class TestRandomInteraction(QiskitNatureTestCase):
+class TestRandomInteraction(QiskitNatureDeprecatedTestCase):
     """Tests RandomInteraction."""
 
     def test_calc_energy_matrix(self):

--- a/test/problems/sampling/protein_folding/peptide/beads/test_bead_main.py
+++ b/test/problems/sampling/protein_folding/peptide/beads/test_bead_main.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests Main Bead."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit.opflow import I, Z
 
@@ -23,7 +23,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.chains.side_chain i
 PATH = "problems/sampling/protein_folding/resources/test_bead_main"
 
 
-class TestMainBead(QiskitNatureTestCase):
+class TestMainBead(QiskitNatureDeprecatedTestCase):
     """Tests Main Bead."""
 
     def test_main_bead_constructor(self):

--- a/test/problems/sampling/protein_folding/peptide/beads/test_bead_side.py
+++ b/test/problems/sampling/protein_folding/peptide/beads/test_bead_side.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests Side Bead."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit.opflow import I, Z
 
@@ -22,7 +22,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.beads.side_bead imp
 PATH = "problems/sampling/protein_folding/resources/test_bead_side"
 
 
-class TestSideBead(QiskitNatureTestCase):
+class TestSideBead(QiskitNatureDeprecatedTestCase):
     """Tests Side Bead."""
 
     def test_side_bead_constructor(self):

--- a/test/problems/sampling/protein_folding/peptide/chains/test_chain_main.py
+++ b/test/problems/sampling/protein_folding/peptide/chains/test_chain_main.py
@@ -10,14 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests MainChain."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.exceptions.invalid_side_chain_exception import (
     InvalidSideChainException,
 )
 from qiskit_nature.problems.sampling.protein_folding.peptide.chains.main_chain import MainChain
 
 
-class TestMainChain(QiskitNatureTestCase):
+class TestMainChain(QiskitNatureDeprecatedTestCase):
     """Tests MainChain."""
 
     def test_main_chain_constructor(self):

--- a/test/problems/sampling/protein_folding/peptide/chains/test_chain_side.py
+++ b/test/problems/sampling/protein_folding/peptide/chains/test_chain_side.py
@@ -10,14 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests SideChain."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.exceptions.invalid_side_chain_exception import (
     InvalidSideChainException,
 )
 from qiskit_nature.problems.sampling.protein_folding.peptide.chains.side_chain import SideChain
 
 
-class TestSideChain(QiskitNatureTestCase):
+class TestSideChain(QiskitNatureDeprecatedTestCase):
     """Tests SideChain."""
 
     def test_side_chain_constructor(self):

--- a/test/problems/sampling/protein_folding/peptide/test_peptide.py
+++ b/test/problems/sampling/protein_folding/peptide/test_peptide.py
@@ -10,11 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests Peptide."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Peptide
 
 
-class TestPeptide(QiskitNatureTestCase):
+class TestPeptide(QiskitNatureDeprecatedTestCase):
     """Tests Peptide."""
 
     def test_peptide_constructor(self):

--- a/test/problems/sampling/protein_folding/qubit_utils/test_qubit_fixing.py
+++ b/test/problems/sampling/protein_folding/qubit_utils/test_qubit_fixing.py
@@ -10,12 +10,12 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests QubitFixing."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit.opflow import I, Z, PauliSumOp
 from qiskit_nature.problems.sampling.protein_folding.qubit_utils.qubit_fixing import _fix_qubits
 
 
-class TestQubitFixing(QiskitNatureTestCase):
+class TestQubitFixing(QiskitNatureDeprecatedTestCase):
     """Tests QubitFixing."""
 
     def test_fix_qubits_small(self):

--- a/test/problems/sampling/protein_folding/qubit_utils/test_qubit_number_reducer.py
+++ b/test/problems/sampling/protein_folding/qubit_utils/test_qubit_number_reducer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests QubitNumberReducer."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from qiskit.opflow import I, Z
 from qiskit_nature.problems.sampling.protein_folding.qubit_utils.qubit_number_reducer import (
     _find_unused_qubits,
@@ -18,7 +18,7 @@ from qiskit_nature.problems.sampling.protein_folding.qubit_utils.qubit_number_re
 )
 
 
-class TestQubitNumberReducer(QiskitNatureTestCase):
+class TestQubitNumberReducer(QiskitNatureDeprecatedTestCase):
     """Tests ContactQubitsBuilder."""
 
     def test_find_unused_qubits(self):

--- a/test/problems/sampling/protein_folding/test_protein_folding_problem.py
+++ b/test/problems/sampling/protein_folding/test_protein_folding_problem.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests ProteinFoldingProblem."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit_nature.problems.sampling.protein_folding.interactions.miyazawa_jernigan_interaction import (
     MiyazawaJerniganInteraction,
@@ -24,7 +24,7 @@ from qiskit_nature.problems.sampling.protein_folding.penalty_parameters import P
 PATH = "problems/sampling/protein_folding/resources/test_protein_folding_problem"
 
 
-class TestProteinFoldingProblem(QiskitNatureTestCase):
+class TestProteinFoldingProblem(QiskitNatureDeprecatedTestCase):
     """Tests ProteinFoldingProblem."""
 
     def test_protein_folding_problem(self):

--- a/test/problems/sampling/protein_folding/test_qubit_op_builder.py
+++ b/test/problems/sampling/protein_folding/test_qubit_op_builder.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests QubitOpBuilder."""
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from test.problems.sampling.protein_folding.resources.file_parser import read_expected_file
 from qiskit.opflow import PauliSumOp
 from qiskit_nature.problems.sampling.protein_folding.qubit_op_builder import QubitOpBuilder
@@ -23,7 +23,7 @@ from qiskit_nature.problems.sampling.protein_folding.peptide.peptide import Pept
 PATH = "problems/sampling/protein_folding/resources/test_qubit_op_builder"
 
 
-class TestQubitOpBuilder(QiskitNatureTestCase):
+class TestQubitOpBuilder(QiskitNatureDeprecatedTestCase):
     """Tests QubitOpBuilder."""
 
     def test_check_turns(self):

--- a/test/problems/second_quantization/lattice/test_lattice_model_problem.py
+++ b/test/problems/second_quantization/lattice/test_lattice_model_problem.py
@@ -12,7 +12,7 @@
 
 """Tests Lattice Model Problem."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -27,7 +27,7 @@ from qiskit_nature.problems.second_quantization.lattice import (
 from qiskit_nature.results import EigenstateResult
 
 
-class TestLatticeModelProblem(QiskitNatureTestCase):
+class TestLatticeModelProblem(QiskitNatureDeprecatedTestCase):
     """Tests Lattice Model Problem."""
 
     def _compare_second_q_op(self, first: SecondQuantizedOp, second: SecondQuantizedOp):

--- a/test/properties/property_test.py
+++ b/test/properties/property_test.py
@@ -12,7 +12,7 @@
 
 """PropertyTest class"""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 import numpy as np
 
@@ -38,7 +38,7 @@ from qiskit_nature.properties.second_quantization.vibrational import (
 from qiskit_nature.properties.second_quantization.vibrational.integrals import VibrationalIntegrals
 
 
-class PropertyTest(QiskitNatureTestCase):
+class PropertyTest(QiskitNatureDeprecatedTestCase):
     """Property instance tester"""
 
     def compare_angular_momentum(

--- a/test/results/test_protein_folding_result.py
+++ b/test/results/test_protein_folding_result.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 """Tests ProteinFoldingResult."""
 from typing import List
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from ddt import ddt, data, unpack
 
 from qiskit.utils import algorithm_globals
@@ -61,7 +61,7 @@ def create_protein_folding_result(
 
 
 @ddt
-class TestProteinFoldingResult(QiskitNatureTestCase):
+class TestProteinFoldingResult(QiskitNatureDeprecatedTestCase):
     """Tests ProteinFoldingResult."""
 
     @unpack

--- a/test/runtime/test_vqeprogram.py
+++ b/test/runtime/test_vqeprogram.py
@@ -12,7 +12,8 @@
 
 """Test the VQE program."""
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
+from test.runtime.fake_vqeruntime import FakeRuntimeProvider
 
 import unittest
 from ddt import ddt, data
@@ -28,11 +29,9 @@ from qiskit_nature.converters.second_quantization import QubitConverter
 from qiskit_nature.mappers.second_quantization import JordanWignerMapper
 from qiskit_nature.runtime import VQEClient, VQERuntimeResult
 
-from .fake_vqeruntime import FakeRuntimeProvider
-
 
 @ddt
-class TestVQEClient(QiskitNatureTestCase):
+class TestVQEClient(QiskitNatureDeprecatedTestCase):
     """Test the VQE program."""
 
     def get_standard_program(self):

--- a/test/second_q/mappers/test_bksf_mapper.py
+++ b/test/second_q/mappers/test_bksf_mapper.py
@@ -14,6 +14,10 @@
 
 import unittest
 from test import QiskitNatureTestCase
+from test.second_q.mappers.resources.bksf_lih import (
+    FERMIONIC_HAMILTONIAN,
+    QUBIT_HAMILTONIAN,
+)
 
 import numpy as np
 from qiskit.quantum_info import SparsePauliOp, PauliList
@@ -24,11 +28,6 @@ from qiskit_nature.second_q.mappers.bksf import (
     _edge_operator_aij,
     _edge_operator_bi,
     _bksf_edge_list_fermionic_op,
-)
-
-from .resources.bksf_lih import (
-    FERMIONIC_HAMILTONIAN,
-    QUBIT_HAMILTONIAN,
 )
 
 

--- a/test/second_q/mappers/test_direct_mapper.py
+++ b/test/second_q/mappers/test_direct_mapper.py
@@ -15,15 +15,14 @@
 import unittest
 
 from test import QiskitNatureTestCase
+from test.second_q.mappers.resources.reference_direct_mapper import (
+    _num_modals_2_q_op,
+    _num_modals_3_q_op,
+)
 
 from qiskit_nature.second_q.drivers import GaussianForcesDriver
 from qiskit_nature.second_q.mappers import DirectMapper
 from qiskit_nature.second_q.properties.bases import HarmonicBasis
-
-from .resources.reference_direct_mapper import (
-    _num_modals_2_q_op,
-    _num_modals_3_q_op,
-)
 
 
 class TestDirectMapper(QiskitNatureTestCase):

--- a/test/second_q/problems/test_vibrational_structure_problem.py
+++ b/test/second_q/problems/test_vibrational_structure_problem.py
@@ -14,13 +14,15 @@
 
 import unittest
 from test import QiskitNatureTestCase
+from test.second_q.problems.resources.expected_ops import (
+    _truncation_order_1_op,
+    _truncation_order_2_op,
+)
 
 import numpy as np
 
 from qiskit_nature.second_q.drivers import GaussianForcesDriver
 from qiskit_nature.second_q.operators import VibrationalOp
-
-from .resources.expected_ops import _truncation_order_1_op, _truncation_order_2_op
 
 
 class TestVibrationalStructureProblem(QiskitNatureTestCase):

--- a/test/test_end2end_with_vqe.py
+++ b/test/test_end2end_with_vqe.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from qiskit import BasicAer
 from qiskit.algorithms import VQE
@@ -27,7 +27,7 @@ from qiskit_nature.second_q.mappers import ParityMapper, QubitConverter
 
 
 @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
-class TestEnd2End(QiskitNatureTestCase):
+class TestEnd2End(QiskitNatureDeprecatedTestCase):
     """End2End VQE tests."""
 
     def setUp(self):

--- a/test/transformers/second_quantization/electronic/test_active_space_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_active_space_transformer.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 
 from ddt import ddt, idata, unpack
 import numpy as np
@@ -36,7 +36,7 @@ from qiskit_nature.transformers.second_quantization.electronic import ActiveSpac
 
 
 @ddt
-class TestActiveSpaceTransformer(QiskitNatureTestCase):
+class TestActiveSpaceTransformer(QiskitNatureDeprecatedTestCase):
     """ActiveSpaceTransformer tests."""
 
     def assertDriverResult(self, driver_result, expected, dict_key="ActiveSpaceTransformer"):

--- a/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
+++ b/test/transformers/second_quantization/electronic/test_freeze_core_transformer.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureDeprecatedTestCase
 from ddt import ddt, idata
 import numpy as np
 
@@ -24,7 +24,7 @@ from qiskit_nature.properties.second_quantization.electronic.bases import Electr
 
 
 @ddt
-class TestFreezeCoreTransformer(QiskitNatureTestCase):
+class TestFreezeCoreTransformer(QiskitNatureDeprecatedTestCase):
     """FreezeCoreTransformer tests."""
 
     # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The unit tests that test deprecated functions should not emit deprecate messages.


### Details and comments


