### PR TITLE
fix: problem attribute propagation in transformers

### DIFF
--- a/qiskit_nature/second_q/problems/electronic_structure_problem.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_problem.py
@@ -171,6 +171,9 @@ class ElectronicStructureProblem(BaseProblem):
         if self._orbital_occupations is not None:
             return self._orbital_occupations
 
+        if self.basis != ElectronicBasis.MO:
+            return None
+
         num_orbs = self.num_spatial_orbitals
         if num_orbs is None:
             return None
@@ -189,6 +192,9 @@ class ElectronicStructureProblem(BaseProblem):
         """The occupations of the beta-spin orbitals."""
         if self._orbital_occupations_b is not None:
             return self._orbital_occupations_b
+
+        if self.basis != ElectronicBasis.MO:
+            return None
 
         num_orbs = self.num_spatial_orbitals
         if num_orbs is None:

--- a/qiskit_nature/second_q/transformers/basis_transformer.py
+++ b/qiskit_nature/second_q/transformers/basis_transformer.py
@@ -25,6 +25,7 @@ from qiskit_nature.second_q.operators import ElectronicIntegrals, PolynomialTens
 from qiskit_nature.second_q.problems import BaseProblem, ElectronicBasis, ElectronicStructureProblem
 from qiskit_nature.second_q.properties import (
     AngularMomentum,
+    ElectronicDensity,
     ElectronicDipoleMoment,
     Magnetization,
     ParticleNumber,
@@ -136,11 +137,18 @@ class BasisTransformer(BaseTransformer):
         )
         new_problem.basis = self.final_basis
         new_problem.molecule = problem.molecule
+        new_problem.reference_energy = problem.reference_energy
+        new_problem.num_particles = problem.num_particles
+        new_problem.num_spatial_orbitals = problem.num_spatial_orbitals
 
         for prop in problem.properties:
             if isinstance(prop, ElectronicDipoleMoment):
                 new_problem.properties.electronic_dipole_moment = (
                     self._transform_electronic_dipole_moment(prop)
+                )
+            elif isinstance(prop, ElectronicDensity):
+                new_problem.properties.electronic_density = self.transform_electronic_integrals(
+                    prop
                 )
             elif isinstance(prop, (AngularMomentum, Magnetization, ParticleNumber)):
                 new_problem.properties.add(prop)

--- a/test/second_q/transformers/test_active_space_transformer.py
+++ b/test/second_q/transformers/test_active_space_transformer.py
@@ -81,6 +81,26 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
             with self.subTest("ElectronicDensity"):
                 self.assertTrue(density.equiv(expected_density))
 
+        with self.subTest("attributes"):
+            self.assertEqual(driver_result.num_particles, expected.num_particles)
+            self.assertEqual(driver_result.num_spatial_orbitals, expected.num_spatial_orbitals)
+            if expected.orbital_energies is not None:
+                self.assertTrue(
+                    np.allclose(driver_result.orbital_energies, expected.orbital_energies)
+                )
+            if expected.orbital_energies_b is not None:
+                self.assertTrue(
+                    np.allclose(driver_result.orbital_energies_b, expected.orbital_energies_b)
+                )
+            if expected.orbital_occupations is not None:
+                self.assertTrue(
+                    np.allclose(driver_result.orbital_occupations, expected.orbital_occupations)
+                )
+            if expected.orbital_occupations_b is not None:
+                self.assertTrue(
+                    np.allclose(driver_result.orbital_occupations_b, expected.orbital_occupations_b)
+                )
+
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
     @idata(
         [
@@ -134,6 +154,8 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         )
         electronic_energy.constants["ActiveSpaceTransformer"] = 0.0
         expected = ElectronicStructureProblem(electronic_energy)
+        expected.num_particles = (1, 1)
+        expected.num_spatial_orbitals = 2
         dipole_moment = ElectronicDipoleMoment(
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),
@@ -154,7 +176,9 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         driver = PySCFDriver(atom="Be 0 0 0; H 0 0 1.3", basis="sto3g", spin=1)
         driver_result = driver.run()
 
-        trafo = ActiveSpaceTransformer((2, 1), 3)
+        nelec = (2, 1)
+        norb = 3
+        trafo = ActiveSpaceTransformer(nelec, norb)
         driver_result_reduced = trafo.transform(driver_result)
 
         expected = qcschema_to_problem(
@@ -165,6 +189,8 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         )
         # add energy shift, which currently cannot be stored in the QCSchema
         expected.hamiltonian.constants["ActiveSpaceTransformer"] = -14.253802923103054
+        expected.num_particles = nelec
+        expected.num_spatial_orbitals = norb
 
         self.assertDriverResult(driver_result_reduced, expected)
 
@@ -194,6 +220,8 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         )
         electronic_energy.constants["ActiveSpaceTransformer"] = 0.0
         expected = ElectronicStructureProblem(electronic_energy)
+        expected.num_particles = (1, 1)
+        expected.num_spatial_orbitals = 2
         dipole_moment = ElectronicDipoleMoment(
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),
@@ -236,7 +264,9 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         driver = PySCFDriver(basis="631g")
         driver_result = driver.run()
 
-        trafo = ActiveSpaceTransformer((1, 1), 2, [0, 1])
+        nelec = (1, 1)
+        norb = 2
+        trafo = ActiveSpaceTransformer(nelec, norb, [0, 1])
         driver_result_reduced = trafo.transform(driver_result)
 
         electronic_energy = ElectronicEnergy.from_raw_integrals(
@@ -256,6 +286,8 @@ class TestActiveSpaceTransformer(QiskitNatureTestCase):
         )
         electronic_energy.constants["ActiveSpaceTransformer"] = 0.0
         expected = ElectronicStructureProblem(electronic_energy)
+        expected.num_particles = nelec
+        expected.num_spatial_orbitals = norb
         dipole_moment = ElectronicDipoleMoment(
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),
             ElectronicIntegrals.from_raw_integrals(np.zeros((2, 2))),

--- a/test/second_q/transformers/test_basis_transformer.py
+++ b/test/second_q/transformers/test_basis_transformer.py
@@ -80,6 +80,15 @@ class TestBasisTransformer(QiskitNatureTestCase):
         with self.subTest("beta-alpha-spin is empty"):
             self.assertTrue(transformed_integrals.beta_alpha.is_empty())
 
+        with self.subTest("attributes"):
+            self.assertEqual(problem_ao.molecule, problem_mo.molecule)
+            self.assertEqual(problem_ao.reference_energy, problem_mo.reference_energy)
+            self.assertEqual(problem_ao.num_particles, problem_mo.num_particles)
+            self.assertEqual(problem_ao.num_spatial_orbitals, problem_mo.num_spatial_orbitals)
+            self.assertIsNone(problem_mo.orbital_energies)
+            self.assertIsNone(problem_mo.orbital_energies_b)
+            # orbital_occupations are not tested since in the MO basis they are auto-filled
+
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
     def test_unrestricted_spin(self):
         """A simple unrestricted-spin test case."""
@@ -153,6 +162,15 @@ class TestBasisTransformer(QiskitNatureTestCase):
                     optimize=True,
                 ),
             )
+
+        with self.subTest("attributes"):
+            self.assertEqual(problem_ao.molecule, problem_mo.molecule)
+            self.assertEqual(problem_ao.reference_energy, problem_mo.reference_energy)
+            self.assertEqual(problem_ao.num_particles, problem_mo.num_particles)
+            self.assertEqual(problem_ao.num_spatial_orbitals, problem_mo.num_spatial_orbitals)
+            self.assertIsNone(problem_mo.orbital_energies)
+            self.assertIsNone(problem_mo.orbital_energies_b)
+            # orbital_occupations are not tested since in the MO basis they are auto-filled
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I noticed that some attributes of the `ElectronicStructureProblem` were being dropped unintentionally during the transformers.
This PR fixes that and adds unittests to guard against a regression.

### Details and comments


