### PR TITLE
fix: ElectronicEnergy.fock should be one-body term

### DIFF
--- a/qiskit_nature/second_q/hamiltonians/electronic_energy.py
+++ b/qiskit_nature/second_q/hamiltonians/electronic_energy.py
@@ -271,4 +271,4 @@ class ElectronicEnergy(Hamiltonian):
         Returns:
             The Fock operator coefficients.
         """
-        return self.electronic_integrals + self.coulomb(density) - self.exchange(density)
+        return self.electronic_integrals.one_body + self.coulomb(density) - self.exchange(density)

--- a/test/second_q/hamiltonians/test_electronic_energy.py
+++ b/test/second_q/hamiltonians/test_electronic_energy.py
@@ -55,6 +55,9 @@ class TestElectronicEnergy(PropertyTest):
 
         expected = np.asarray([[-0.34436786423711596, 0.0], [0.0, 0.4515069814257469]])
         self.assertTrue(np.allclose(fock_op.alpha["+-"], expected))
+        self.assertNotIn("++--", fock_op.alpha)
+        self.assertNotIn("++--", fock_op.beta)
+        self.assertNotIn("++--", fock_op.beta_alpha)
 
     def test_from_raw_integrals(self):
         """Test from_raw_integrals utility method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `ElectronicEnergy.fock` method should return an object which only contains one-body terms.
This PR fixes and tests that.

### Details and comments


