### PR TITLE
Qeom refactoring and upgrades

### DIFF
--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Union, Optional, Tuple, Dict
+from typing import Any, Callable, List, Sequence, Union, Optional, Tuple, Dict
 import itertools
 import logging
 import sys
@@ -25,27 +25,32 @@ from qiskit.algorithms.observables_evaluator import estimate_observables
 from qiskit.tools import parallel_map
 from qiskit.tools.events import TextProgressBar
 from qiskit.utils import algorithm_globals
-from qiskit.algorithms import AlgorithmResult
+from qiskit.algorithms.eigensolvers import EigensolverResult
+from qiskit.circuit import QuantumCircuit
+
 from qiskit.opflow import (
     Z2Symmetries,
     commutator,
     double_commutator,
     PauliSumOp,
 )
+from qiskit.quantum_info import SparsePauliOp
 from qiskit.primitives import BaseEstimator
-
+from qiskit_nature.converters.second_quantization.utils import ListOrDict
 from qiskit_nature.second_q.operators import SparseLabelOp
 from qiskit_nature.second_q.problems import (
     BaseProblem,
     ElectronicStructureProblem,
     VibrationalStructureProblem,
 )
-from qiskit_nature.second_q.problems import EigenstateResult
+from qiskit_nature.second_q.problems import EigenstateResult, ElectronicStructureResult
 
 from .qeom_electronic_ops_builder import build_electronic_ops
 from .qeom_vibrational_ops_builder import build_vibrational_ops
 from .excited_states_solver import ExcitedStatesSolver
 from ..ground_state_solvers import GroundStateSolver
+from ..ground_state_solvers.ground_state_solver import QubitOperator
+from ..ground_state_solvers.minimum_eigensolver_factories import MinimumEigensolverFactory
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +69,7 @@ class QEOM(ExcitedStatesSolver):
             [int, tuple[int, int]],
             list[tuple[tuple[int, ...], tuple[int, ...]]],
         ] = "sd",
+        aux_eval_rules: str | dict[str, list[tuple[int, int]]] | None = None,
     ) -> None:
         """
         Args:
@@ -88,10 +94,20 @@ class QEOM(ExcitedStatesSolver):
                     :meth:`generate_vibrational_excitations`, when solving an
                     :class:`.ElectronicStructureProblem` or a :class:`.VibrationalStructureProblem`,
                     respectively.
+
+            aux_eval_rules: The rules determining how observables should be evaluated on excited states.
+
+                :`str`: specific predefined rules. Allowed strings are:
+                    + `all` to compute all expectation values and all transition amplitudes
+                    + `diag` to only compute expectation values
+                :`dict[str, list[tuple]]`: Dictionary mapping valid auxiliary operator's name to lists
+                of tuple (i, j) specifying the indices of the excited states to be evaluated on. By
+                default, none of the auxiliary operators are evaluated on none of the excited states.
         """
         self._gsc = ground_state_solver
         self._estimator = estimator
         self.excitations = excitations
+        self._aux_eval_rules = aux_eval_rules
 
         self._untapered_qubit_op_main: PauliSumOp = None
 
@@ -122,7 +138,13 @@ class QEOM(ExcitedStatesSolver):
         self._excitations = excitations
 
     @property
+    def qubit_converter(self):
+        """Returns the qubit_converter object defined in the ground state solver."""
+        return self._gsc.qubit_converter
+
+    @property
     def solver(self):
+        """Returns the solver object defined in the ground state solver."""
         return self._gsc.solver
 
     def get_qubit_operators(
@@ -130,7 +152,78 @@ class QEOM(ExcitedStatesSolver):
         problem: BaseProblem,
         aux_operators: Optional[dict[str, Union[SparseLabelOp, PauliSumOp]]] = None,
     ) -> Tuple[PauliSumOp, Optional[dict[str, PauliSumOp]]]:
+        """Construct qubit operators by getting the second quantized operators from the problem
+        (potentially running a driver in doing so [can be computationally expensive])
+        and using a QubitConverter to map and reduce the operators to qubit operators.
+
+        Args:
+            problem: A class encoding a problem to be solved.
+            aux_operators: Additional auxiliary operators to evaluate.
+
+        Returns:
+            Qubit operator.
+            Additional auxiliary operators.
+        """
         return self._gsc.get_qubit_operators(problem, aux_operators)
+
+    def get_qeom_qubit_operators(
+        self,
+        problem: BaseProblem,
+        aux_operators: Optional[dict[str, Union[SparseLabelOp, PauliSumOp]]] = None,
+    ) -> Tuple[
+        QubitOperator, Optional[dict[str, QubitOperator]], Optional[dict[str, QubitOperator]]
+    ]:
+        """Gets the operator and auxiliary operators, and transforms the provided auxiliary operators.
+        Note that contrary to the method :meth:`get_qubit_oprators` from the
+        :class:`GroundStateEigensolver`, this returns three outputs: the hamiltonian, second quantization
+        default auxiliaries, and user defined auxiliaries.
+        Also note that this methods performs a specific treatment of the symmetries required by the qEOM
+        calculation."""
+
+        main_second_q_op, aux_second_q_ops = problem.second_q_ops()
+
+        # 1. Convert to PauliSumOp and apply two qubit reduction
+        # We apply the meth:`convert()` with the symmetries deliberately set to None
+        num_particles = getattr(problem, "num_particles", None)
+        main_operator = self.qubit_converter.convert_only(
+            main_second_q_op,
+            num_particles=num_particles,
+        )
+        self.qubit_converter.force_match(num_particles=num_particles)
+
+        aux_default_ops = self.qubit_converter.convert_match(aux_second_q_ops)
+        aux_custom_ops = {}
+        if aux_operators is not None:
+            for name_aux, aux_op in aux_operators.items():
+                if isinstance(aux_op, (SparseLabelOp)):
+                    converted_aux_op = self.qubit_converter.convert_match(aux_op)
+                else:
+                    converted_aux_op = aux_op
+
+                aux_custom_ops[name_aux] = converted_aux_op
+
+        # 2. Find the z2symmetries, set them in the qubit_converter, and apply the first step of the
+        # tapering.
+        _, z2symmetries = self.qubit_converter._find_taper_op(
+            main_operator, problem.symmetry_sector_locator
+        )
+        self.qubit_converter.force_match(z2symmetries=z2symmetries)
+
+        pre_tap_main_operator = self.qubit_converter._convert_clifford(main_operator)
+        pre_tap_default_aux_ops = self.qubit_converter._convert_clifford(aux_default_ops)
+        pre_tap_custom_aux_ops = self.qubit_converter._convert_clifford(aux_custom_ops)
+
+        # 3. If the eigensolver does not support auxiliary operators, reset them
+        if not self.solver.supports_aux_operators():
+            pre_tap_default_aux_ops = None
+            pre_tap_custom_aux_ops = None
+
+        # 4. If a MinimumEigensolverFactory was provided, then an additional call to get_solver() is
+        # required.
+        if isinstance(self.solver, MinimumEigensolverFactory):
+            self._gsc._solver = self.solver.get_solver(problem, self.qubit_converter)
+
+        return pre_tap_main_operator, pre_tap_default_aux_ops, pre_tap_custom_aux_ops
 
     def solve(
         self,
@@ -145,97 +238,77 @@ class QEOM(ExcitedStatesSolver):
         Args:
             problem: A class encoding a problem to be solved.
             aux_operators: Additional auxiliary operators to evaluate.
-
         Returns:
             An interpreted :class:`~.EigenstateResult`. For more information see also
             :meth:`~.BaseProblem.interpret`.
         """
 
-        if aux_operators is not None:
-            logger.warning(
-                "With qEOM the auxiliary operators can currently only be "
-                "evaluated on the ground state."
-            )
-
-        # 1. Run ground state calculation
-        groundstate_result = self._gsc.solve(problem, aux_operators)
-
-        # 2. Prepare the excitation operators
-        main_second_q_op, _ = problem.second_q_ops()
-
-        num_particles = getattr(problem, "num_particles", None)
-
-        self._untapered_qubit_op_main = self._gsc.qubit_converter.convert_only(
-            main_second_q_op, num_particles
-        )
-        matrix_operators_dict, size = self._prepare_matrix_operators(problem)
-
-        # 3. Evaluate eom operators
-        ground_state = groundstate_result.eigenstates[0]
-        measurement_results = estimate_observables(
-            self._estimator,
-            ground_state[0],
-            matrix_operators_dict,
-            ground_state[1],
-        )
-
-        # 4. Post-process ground_state_result to construct eom matrices
+        # 1. Prepare all operators
         (
-            m_mat,
-            v_mat,
-            q_mat,
-            w_mat,
-            m_mat_std,
-            v_mat_std,
-            q_mat_std,
-            w_mat_std,
-        ) = self._build_eom_matrices(measurement_results, size)
+            pre_tap_qubit_op_main,  # Hamiltonian
+            pre_tap_default_aux_ops,  # Default auxiliary observables
+            pre_tap_custom_aux_ops,  # User-defined auxiliary observables
+        ) = self.get_qeom_qubit_operators(problem, aux_operators)
 
-        # 5. solve pseudo-eigenvalue problem
-        energy_gaps, expansion_coefs = self._compute_excitation_energies(m_mat, v_mat, q_mat, w_mat)
-
-        qeom_result = QEOMResult()
-        qeom_result.ground_state_raw_result = groundstate_result.raw_result
-        qeom_result.expansion_coefficients = expansion_coefs
-        qeom_result.excitation_energies = energy_gaps
-        qeom_result.m_matrix = m_mat
-        qeom_result.v_matrix = v_mat
-        qeom_result.q_matrix = q_mat
-        qeom_result.w_matrix = w_mat
-        qeom_result.m_matrix_std = m_mat_std
-        qeom_result.v_matrix_std = v_mat_std
-        qeom_result.q_matrix_std = q_mat_std
-        qeom_result.w_matrix_std = w_mat_std
-
-        eigenstate_result = EigenstateResult.from_result(groundstate_result)
-        eigenstate_result.raw_result = qeom_result
-
-        eigenstate_result.eigenvalues = np.append(
-            groundstate_result.eigenvalues,
-            np.asarray([groundstate_result.eigenvalues[0] + gap for gap in energy_gaps]),
+        # 2. Run ground state calculation with fully tapered custom auxiliary operators
+        # Note that the solve() method includes the `second_q' auxiliary operators
+        tap_custom_aux_ops = self.qubit_converter._symmetry_reduce_clifford(
+            ListOrDict(pre_tap_custom_aux_ops), True
         )
 
-        result = problem.interpret(eigenstate_result)
+        groundstate_result = self._gsc.solve(problem, tap_custom_aux_ops)
+        ground_state = groundstate_result.eigenstates[0]
+
+        # 3. Prepare the expansion operators for the excited state calculation
+        expansion_basis_data = self._prepare_expansion_basis(problem)
+
+        # 4. Obtain the representation of the Hamiltonian in the linear subspace
+        h_mat, s_mat, h_mat_std, s_mat_std = self._build_qeom_pseudoeigenvalue_problem(
+            pre_tap_qubit_op_main, expansion_basis_data, ground_state
+        )
+
+        # 5. Solve the pseudo-eigenvalue problem
+        energy_gaps, expansion_coefs, commutator_metric = self._compute_excitation_energies(
+            h_mat, s_mat
+        )
+        gammas_square: np.ndarray = np.abs(np.diagonal(commutator_metric))
+        logger.debug("Gamma square... %s", gammas_square)
+        scaling_matrix: np.ndarray = np.diag(
+            np.divide(np.ones_like(gammas_square), np.sqrt(gammas_square))
+        )
+        expansion_coefs_rescaled: np.ndarray = expansion_coefs @ scaling_matrix
+
+        # 6. Evaluate auxiliary operators on the excited states
+        if pre_tap_custom_aux_ops is not None:
+            pre_tap_aux_observables = {**pre_tap_default_aux_ops, **pre_tap_custom_aux_ops}
+        else:
+            pre_tap_aux_observables = pre_tap_default_aux_ops
+
+        (
+            aux_operators_eigenvalues,
+            transition_amplitudes,
+        ) = self._evaluate_observables_excited_states(
+            pre_tap_aux_observables,
+            expansion_basis_data,
+            ground_state,
+            expansion_coefs_rescaled,
+        )
+
+        result = self._build_qeom_result(
+            problem,
+            groundstate_result,
+            expansion_coefs,
+            energy_gaps,
+            h_mat,
+            s_mat,
+            h_mat_std,
+            s_mat_std,
+            aux_operators_eigenvalues,
+            transition_amplitudes,
+            gammas_square,
+        )
 
         return result
-
-    def _prepare_matrix_operators(self, problem: BaseProblem) -> Tuple[dict, int]:
-        """Construct the excitation operators for each matrix element.
-
-        Returns:
-            A dictionary of all matrix elements operators and the number of excitations
-            (or the size of the qEOM pseudo-eigenvalue problem).
-        """
-        data = self._build_hopping_ops(problem)
-        hopping_operators, type_of_commutativities, excitation_indices = data
-
-        size = int(len(list(excitation_indices.keys())) // 2)
-
-        eom_matrix_operators = self._build_all_commutators(
-            hopping_operators, type_of_commutativities, size
-        )
-
-        return eom_matrix_operators, size
 
     def _build_hopping_ops(
         self, problem: BaseProblem
@@ -274,58 +347,36 @@ class QEOM(ExcitedStatesSolver):
                 f"type {type(problem)}"
             )
 
-    def _build_all_commutators(
-        self, hopping_operators: dict, type_of_commutativities: dict, size: int
+    def _build_all_eom_operators(
+        self,
+        pre_tap_operator: PauliSumOp,
+        expansion_basis_data: Tuple[dict[str, PauliSumOp], dict[str, List[bool]], int],
     ) -> dict:
         """Building all commutators for Q, W, M, V matrices.
 
         Args:
-            hopping_operators: All hopping operators based on excitations_list,
+            pre_tap_operator: Pre tapered Hamiltonian operator
+            expansion_basis_data: all hopping operators based on excitations_list,
                 key is the string of single/double excitation;
                 value is corresponding operator.
-            type_of_commutativities: If tapering is used, it records the commutativities of
-                hopping operators with the
-                Z2 symmetries found in the original operator.
-            size: The number of excitations (size of the qEOM pseudo-eigenvalue problem).
 
         Returns:
             A dictionary that contains the operators for each matrix element.
         """
 
+        pre_tap_hopping_ops, type_of_commutativities, size = expansion_basis_data
+        to_be_computed_list = []
         all_matrix_operators = {}
 
         mus, nus = np.triu_indices(size)
 
-        def _build_one_sector(available_hopping_ops, untapered_op, z2_symmetries):
-
-            to_be_computed_list = []
+        def _build_one_sector(available_hopping_ops):
             for idx, m_u in enumerate(mus):
                 n_u = nus[idx]
-                left_op = available_hopping_ops.get(f"E_{m_u}")
+                left_op_1 = available_hopping_ops.get(f"E_{m_u}")
                 right_op_1 = available_hopping_ops.get(f"E_{n_u}")
                 right_op_2 = available_hopping_ops.get(f"Edag_{n_u}")
-                to_be_computed_list.append((m_u, n_u, left_op, right_op_1, right_op_2))
-
-            if logger.isEnabledFor(logging.INFO):
-                logger.info("Building all commutators:")
-                TextProgressBar(sys.stderr)
-            results = parallel_map(
-                self._build_commutator_routine,
-                to_be_computed_list,
-                task_args=(untapered_op, z2_symmetries),
-                num_processes=algorithm_globals.num_processes,
-            )
-            for result in results:
-                m_u, n_u, q_mat_op, w_mat_op, m_mat_op, v_mat_op = result
-
-                if q_mat_op is not None:
-                    all_matrix_operators[f"q_{m_u}_{n_u}"] = q_mat_op
-                if w_mat_op is not None:
-                    all_matrix_operators[f"w_{m_u}_{n_u}"] = w_mat_op
-                if m_mat_op is not None:
-                    all_matrix_operators[f"m_{m_u}_{n_u}"] = m_mat_op
-                if v_mat_op is not None:
-                    all_matrix_operators[f"v_{m_u}_{n_u}"] = v_mat_op
+                to_be_computed_list.append((m_u, n_u, left_op_1, right_op_1, right_op_2))
 
         try:
             z2_symmetries = self._gsc.qubit_converter.z2symmetries
@@ -344,24 +395,35 @@ class QEOM(ExcitedStatesSolver):
                 available_hopping_ops = {}
                 targeted_sector = np.asarray(targeted_tapering_values) == 1
                 for key, value in type_of_commutativities.items():
-                    value = np.asarray(value)
-                    if np.all(value == targeted_sector):
-                        available_hopping_ops[key] = hopping_operators[key]
-                # untapered_qubit_op is a PauliSumOp and should not be exposed.
-                _build_one_sector(
-                    available_hopping_ops, self._untapered_qubit_op_main, z2_symmetries
-                )
+                    if np.all(np.asarray(value) == targeted_sector):
+                        available_hopping_ops[key] = pre_tap_hopping_ops[key]
+                _build_one_sector(available_hopping_ops)
 
         else:
-            # untapered_qubit_op is a PauliSumOp and should not be exposed.
-            _build_one_sector(hopping_operators, self._untapered_qubit_op_main, z2_symmetries)
+            _build_one_sector(pre_tap_hopping_ops)
+
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("Building all commutators:")
+            TextProgressBar(sys.stderr)
+        results = parallel_map(
+            self._build_commutator_routine,
+            to_be_computed_list,
+            task_args=(pre_tap_operator, z2_symmetries),
+            num_processes=algorithm_globals.num_processes,
+        )
+        for result in results:
+            m_u, n_u, eom_operators = result
+
+            for index_op, op in eom_operators.items():
+                if op is not None:
+                    all_matrix_operators[f"{index_op}_{m_u}_{n_u}"] = op
 
         return all_matrix_operators
 
     @staticmethod
     def _build_commutator_routine(
         params: List, operator: PauliSumOp, z2_symmetries: Z2Symmetries
-    ) -> Tuple[int, int, PauliSumOp, PauliSumOp, PauliSumOp, PauliSumOp]:
+    ) -> Tuple[int, int, dict[str, PauliSumOp]]:
         """Numerically computes the commutator / double commutator between operators.
 
         Args:
@@ -374,8 +436,8 @@ class QEOM(ExcitedStatesSolver):
             The indices of the matrix element and the corresponding qubit
             operator for each of the EOM matrices.
         """
-        m_u, n_u, left_op, right_op_1, right_op_2 = params
-        if left_op is None or right_op_1 is None and right_op_2 is None:
+        m_u, n_u, left_op1, right_op_1, right_op_2 = params
+        if left_op1 is None or right_op_1 is None and right_op_2 is None:
             q_mat_op = None
             w_mat_op = None
             m_mat_op = None
@@ -387,11 +449,11 @@ class QEOM(ExcitedStatesSolver):
                 # theory, one would choose this according to the nature of the problem (i.e.
                 # whether it is fermionic or bosonic), but in practice, always choosing the
                 # anti-commutator has proven to be more robust.
-                q_mat_op = double_commutator(left_op, operator, right_op_1, sign=False)
+                q_mat_op = -double_commutator(left_op1, operator, right_op_1, sign=False)
                 # In the case of the single commutator, we are always interested in the energy
                 # difference of two states. Thus, regardless of the problem's nature, we will
                 # always use the commutator.
-                w_mat_op = commutator(left_op, right_op_1)
+                w_mat_op = -commutator(left_op1, right_op_1)
                 q_mat_op = None if len(q_mat_op) == 0 else q_mat_op
                 w_mat_op = None if len(w_mat_op) == 0 else w_mat_op
             else:
@@ -401,37 +463,34 @@ class QEOM(ExcitedStatesSolver):
             if right_op_2 is not None:
                 # For explanations on the choice of commutation relation, please refer to the
                 # comments above.
-                m_mat_op = double_commutator(left_op, operator, right_op_2, sign=False)
-                v_mat_op = commutator(left_op, right_op_2)
+                m_mat_op = double_commutator(left_op1, operator, right_op_2, sign=False)
+                v_mat_op = commutator(left_op1, right_op_2)
                 m_mat_op = None if len(m_mat_op) == 0 else m_mat_op
                 v_mat_op = None if len(v_mat_op) == 0 else v_mat_op
             else:
                 m_mat_op = None
                 v_mat_op = None
 
-            if not z2_symmetries.is_empty():
-                if q_mat_op is not None and len(q_mat_op) > 0:
-                    q_mat_op = z2_symmetries.taper(q_mat_op)
-                if w_mat_op is not None and len(w_mat_op) > 0:
-                    w_mat_op = z2_symmetries.taper(w_mat_op)
-                if m_mat_op is not None and len(m_mat_op) > 0:
-                    m_mat_op = z2_symmetries.taper(m_mat_op)
-                if v_mat_op is not None and len(v_mat_op) > 0:
-                    v_mat_op = z2_symmetries.taper(v_mat_op)
+        eom_operators = {"q": q_mat_op, "w": w_mat_op, "m": m_mat_op, "v": v_mat_op}
 
-        return m_u, n_u, q_mat_op, w_mat_op, m_mat_op, v_mat_op
+        if not z2_symmetries.is_empty():
+            for index_op, eom_op in eom_operators.items():
+                if eom_op is not None and len(eom_op) > 0:
+                    eom_operators[index_op] = z2_symmetries.taper_clifford(eom_op)
+
+        return m_u, n_u, eom_operators
 
     def _build_eom_matrices(
         self, gs_results: dict[str, tuple[complex, dict[str, Any]]], size: int
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, float, float]:
-        """Constructs the M, V, Q and W matrices from the results on the ground state
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Constructs the H and S matrices from the results on the ground state.
 
         Args:
             gs_results: A ground state result object.
             size: Size of eigenvalue problem.
 
         Returns:
-            The matrices and their standard deviation.
+            H and S matrices and their standard deviation
         """
 
         mus, nus = np.triu_indices(size)
@@ -443,56 +502,32 @@ class QEOM(ExcitedStatesSolver):
         m_mat_std, v_mat_std, q_mat_std, w_mat_std = 0.0, 0.0, 0.0, 0.0
 
         # evaluate results
-        for idx, m_u in enumerate(mus):
-            n_u = nus[idx]
+        for m_u, n_u in zip(mus, nus):
 
-            q_mat[m_u][n_u] = (
-                gs_results[f"q_{m_u}_{n_u}"][0]
-                if gs_results.get(f"q_{m_u}_{n_u}") is not None
-                else q_mat[m_u][n_u]
-            )
-            w_mat[m_u][n_u] = (
-                gs_results[f"w_{m_u}_{n_u}"][0]
-                if gs_results.get(f"w_{m_u}_{n_u}") is not None
-                else w_mat[m_u][n_u]
-            )
-            m_mat[m_u][n_u] = (
-                gs_results[f"m_{m_u}_{n_u}"][0]
-                if gs_results.get(f"m_{m_u}_{n_u}") is not None
-                else m_mat[m_u][n_u]
-            )
-            v_mat[m_u][n_u] = (
-                gs_results[f"v_{m_u}_{n_u}"][0]
-                if gs_results.get(f"v_{m_u}_{n_u}") is not None
-                else v_mat[m_u][n_u]
-            )
+            if gs_results.get(f"q_{m_u}_{n_u}") is not None:
+                q_mat[m_u][n_u] = gs_results[f"q_{m_u}_{n_u}"][0]
+                q_mat_std += gs_results[f"q_{m_u}_{n_u}"][1].get("variance", 0)
 
-            q_mat_std += (
-                gs_results[f"q_{m_u}_{n_u}_std"][0].real
-                if gs_results.get(f"q_{m_u}_{n_u}_std") is not None
-                else 0
-            )
-            w_mat_std += (
-                gs_results[f"w_{m_u}_{n_u}_std"][0].real
-                if gs_results.get(f"w_{m_u}_{n_u}_std") is not None
-                else 0
-            )
-            m_mat_std += (
-                gs_results[f"m_{m_u}_{n_u}_std"][0].real
-                if gs_results.get(f"m_{m_u}_{n_u}_std") is not None
-                else 0
-            )
-            v_mat_std += (
-                gs_results[f"v_{m_u}_{n_u}_std"][0].real
-                if gs_results.get(f"v_{m_u}_{n_u}_std") is not None
-                else 0
-            )
+            if gs_results.get(f"w_{m_u}_{n_u}") is not None:
+                w_mat[m_u][n_u] = gs_results[f"w_{m_u}_{n_u}"][0]
+                w_mat_std += gs_results[f"w_{m_u}_{n_u}"][1].get("variance", 0)
+
+            if gs_results.get(f"m_{m_u}_{n_u}") is not None:
+                m_mat[m_u][n_u] = gs_results[f"m_{m_u}_{n_u}"][0]
+                m_mat_std += gs_results[f"m_{m_u}_{n_u}"][1].get("variance", 0)
+
+            if gs_results.get(f"v_{m_u}_{n_u}") is not None:
+                v_mat[m_u][n_u] = gs_results[f"v_{m_u}_{n_u}"][0]
+                v_mat_std += gs_results[f"v_{m_u}_{n_u}"][1].get("variance", 0)
 
         # these matrices are numpy arrays and therefore have the ``shape`` attribute
+        # Matrix building rules
+        # M.adjoint() = M, V.adjoint() = V
+        # Q.T = Q, W.T = -W
         q_mat = q_mat + q_mat.T - np.identity(q_mat.shape[0]) * q_mat
-        w_mat = w_mat + w_mat.T - np.identity(w_mat.shape[0]) * w_mat
-        m_mat = m_mat + m_mat.T - np.identity(m_mat.shape[0]) * m_mat
-        v_mat = v_mat + v_mat.T - np.identity(v_mat.shape[0]) * v_mat
+        w_mat = w_mat - w_mat.T - np.identity(w_mat.shape[0]) * w_mat
+        m_mat = m_mat + m_mat.T.conj() - np.identity(m_mat.shape[0]) * m_mat
+        v_mat = v_mat + v_mat.T.conj() - np.identity(v_mat.shape[0]) * v_mat
 
         q_mat = np.real(q_mat)
         w_mat = np.real(w_mat)
@@ -509,28 +544,109 @@ class QEOM(ExcitedStatesSolver):
         logger.debug("\nM:=========================\n%s", m_mat)
         logger.debug("\nV:=========================\n%s", v_mat)
 
-        return m_mat, v_mat, q_mat, w_mat, m_mat_std, v_mat_std, q_mat_std, w_mat_std
+        # Matrix building rules
+        # h_mat = [[M, Q], [P, N]] and s_mat = [[V, W], [T, U]]
+        # N = M.conj() = M.T
+        # P = Q.adjoint() = Q.conj()
+        # U = -V.conj() = -V.T
+        # T = W.adjoint()
+        h_mat: np.ndarray = np.array(
+            np.matrixlib.bmat([[m_mat, q_mat], [q_mat.T.conj(), m_mat.T]])
+        )
+        s_mat: np.ndarray = np.array(
+            np.matrixlib.bmat([[v_mat, w_mat], [w_mat.T.conj(), -v_mat.T]])
+        )
+
+        h_mat_std: np.ndarray = np.array([[m_mat_std, q_mat_std], [q_mat_std, m_mat_std]])
+        s_mat_std: np.ndarray = np.array([[v_mat_std, w_mat_std], [w_mat_std, v_mat_std]])
+
+        return h_mat, s_mat, h_mat_std, s_mat_std
+
+    def _prepare_expansion_basis(
+        self, problem: BaseProblem
+    ) -> Tuple[Dict[str, PauliSumOp], Dict[str, List[bool]], int]:
+        """Prepares the basis expansion operators by calling the builder for second quantized operator
+        and applying transformations (Mapping, Reduction, First step of the tapering).
+
+
+        Args:
+            problem: the problem for which to build out the operators.
+
+        Returns:
+            Dict of transformed hopping operators, dict of commutativity types, size of the qEOM problem
+        """
+
+        logger.debug("Building expansion basis data...")
+
+        data = self._build_hopping_ops(problem)
+        hopping_operators, type_of_commutativities, excitation_indices = data
+        size = int(len(list(excitation_indices.keys())) // 2)
+
+        reduced_hopping_ops = self.qubit_converter.two_qubit_reduce(hopping_operators)
+        pre_tap_hopping_ops = self.qubit_converter._convert_clifford(reduced_hopping_ops)
+
+        return pre_tap_hopping_ops, type_of_commutativities, size
+
+    def _build_qeom_pseudoeigenvalue_problem(
+        self,
+        pre_tap_operator: PauliSumOp,
+        expansion_basis_data: Tuple[Dict[str, PauliSumOp], Dict[str, List[bool]], int],
+        reference_state: Tuple[QuantumCircuit, Sequence[float]],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Builds the matrices for the qEOM pseudo-eigenvalue problem
+
+        Args:
+            pre_tap_operator: Partially tapered hamiltonian
+            expansion_basis_data: Dict of transformed hopping operators, dict of commutativity types,
+            size of the qEOM problem
+            reference_state: Reference state (often the VQE ground state) to be used for the evaluation
+            of EOM operators.
+
+        Returns:
+            Matrices of the Pseudo-eigenvalue problem H @ X = S @ X @ E with the associated standard
+            deviation errors.
+        """
+
+        logger.debug("Build QEOM pseudoeigenvalue problem...")
+
+        # 1. Build all EOM operators to evaluate on the ground state
+        tap_eom_matrix_ops = self._build_all_eom_operators(
+            pre_tap_operator,
+            expansion_basis_data,
+        )
+
+        # 2. Evaluate all EOM operators on the ground state
+        measurement_results = estimate_observables(
+            self._estimator,
+            reference_state[0],
+            tap_eom_matrix_ops,
+            reference_state[1],
+        )
+
+        # 4. Post-process the measurement results to construct eom matrices
+        _, _, size = expansion_basis_data
+
+        h_mat, s_mat, h_mat_std, s_mat_std = self._build_eom_matrices(measurement_results, size)
+
+        return h_mat, s_mat, h_mat_std, s_mat_std
 
     @staticmethod
     def _compute_excitation_energies(
-        m_mat: np.ndarray, v_mat: np.ndarray, q_mat: np.ndarray, w_mat: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        """Diagonalizing M, V, Q, W matrices for excitation energies.
+        h_mat: np.ndarray, s_mat: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Diagonalizing H, S matrices for excitation energies.
 
         Args:
-            m_mat : M matrices
-            v_mat : V matrices
-            q_mat : Q matrices
-            w_mat : W matrices
+            h_mat : H matrix
+            s_mat : S matrix
 
         Returns:
             1-D vector stores all energy gap to reference state.
             2-D array storing the X and Y expansion coefficients.
         """
         logger.debug("Diagonalizing qeom matrices for excited states...")
-        a_mat = np.matrixlib.bmat([[m_mat, q_mat], [q_mat.T.conj(), m_mat.T.conj()]])
-        b_mat = np.matrixlib.bmat([[v_mat, w_mat], [-w_mat.T.conj(), -v_mat.T.conj()]])
-        res = linalg.eig(a_mat, b_mat)
+
+        res = linalg.eig(h_mat, s_mat)
         # convert nan value into 0
         res[0][np.where(np.isnan(res[0]))] = 0.0
         # Only the positive eigenvalues are physical. We need to take care
@@ -542,16 +658,249 @@ class QEOM(ExcitedStatesSolver):
         # Since we may now have
         # small values (positive or negative) take the absolute and then threshold zero.
         logger.debug("... %s", res[0])
-        w = np.sort(np.real(res[0]))
+        order = np.argsort(np.real(res[0]))[::-1][len(res[0]) // 2 : :]
+        w = np.real(res[0])[order]
         logger.debug("Sorted real parts %s", w)
-        w = np.abs(w[len(w) // 2 :])
+        w = np.abs(w)
         w[w < 1e-06] = 0
         excitation_energies_gap = w
+        expansion_coefs = res[1][:, order]
 
-        return excitation_energies_gap, res[1]
+        commutator_metric = expansion_coefs.T.conj() @ s_mat @ expansion_coefs
+
+        return excitation_energies_gap, expansion_coefs, commutator_metric
+
+    def _build_excitation_operators(
+        self,
+        expansion_basis_data: Tuple[
+            dict[str, PauliSumOp],
+            dict[str, List[bool]],
+            int,
+        ],
+        reference_state: Tuple[QuantumCircuit, Sequence[float]],
+        expansion_coefs_rescaled: np.ndarray,
+    ) -> list[PauliSumOp]:
+        """Build the excitation operators O_k such that O_k applied on the reference ground state gives
+        the k-th excited state.
+
+        Args:
+            expansion_basis_data: Dict of transformed hopping operators, dict of commutativity types,
+            size of the qEOM problem.
+            reference_state : Reference ground state
+            expansion_coefs_rescaled: Expansion coefficient matrix X such that H @ X = S @ X @ E and
+            X^dag @ S @ X is the identity
+
+        Returns:
+            List of excitation operators [Identity, O_1, O_2, ...]
+        """
+
+        pre_tap_hopping_ops, _, size = expansion_basis_data
+        tap_hopping_ops = self.qubit_converter._symmetry_reduce_clifford(
+            ListOrDict(pre_tap_hopping_ops), True
+        )
+
+        additionnal_measurements = estimate_observables(
+            self._estimator, reference_state[0], tap_hopping_ops, reference_state[1]
+        )
+
+        num_qubits = list(pre_tap_hopping_ops.values())[0].num_qubits
+        identity_op = PauliSumOp(SparsePauliOp(["I" * num_qubits], [1.0]))
+
+        ordered_keys = [f"E_{k}" for k in range(size)] + [f"Edag_{k}" for k in range(size)]
+        ordered_signs = [1 for k in range(size)] + [-1 for k in range(size)]
+
+        translated_hopping_ops = {}
+        for key, sign in zip(ordered_keys, ordered_signs):
+            tap_hopping_ops_eval = (
+                additionnal_measurements.get(key)[0]
+                if additionnal_measurements.get(key) is not None
+                else 0.0
+            )
+            translated_hopping_ops[key] = sign * (
+                pre_tap_hopping_ops[key] - identity_op * tap_hopping_ops_eval
+            )
+
+        hopping_ops_vector = list(translated_hopping_ops.values())
+        excitations_ops = np.array(hopping_ops_vector, dtype=object) @ expansion_coefs_rescaled
+        excitations_ops_reduced = [identity_op] + [op.reduce() for op in excitations_ops]
+
+        return excitations_ops_reduced
+
+    def _prepare_excited_states_observables(
+        self,
+        pre_tap_aux_observables: dict[str, PauliSumOp],
+        operators_reduced: list[PauliSumOp],
+        size: int,
+    ) -> dict[Tuple[str, int, int], PauliSumOp]:
+        """Prepare the operators O_k^dag @ Aux @ O_l associated to properties of the excited states k,l
+        defined in the aux_eval_rules. By default, the expectation value of all observables on all
+        excited states are evaluated while no transition amplitudes are computed.
+
+        Args:
+            pre_tap_aux_observables: Dict of auxiliary operators for which properties will be computed.
+            expansion_basis_data: Dict of transformed hopping operators, dict of commutativity types,
+            size of the qEOM problem.
+            operators_reduced: list of excitation operators [Identity, O_1, O_2, ...]
+            size: size of the qEOM problem.
+
+        Raises:
+            ValueError: For when the aux_eval_rules do not correspond to any previously defined
+            observable and excited state.
+
+        Returns:
+            Dict of operators of the form O_k^dag @ Aux @ O_l as specified in the constraints.
+        """
+
+        indices = np.diag_indices(size + 1)
+        eval_rules: Dict[str, List[Tuple[Any, Any]]]
+
+        if self._aux_eval_rules is None:
+            eval_rules = {}
+        elif isinstance(self._aux_eval_rules, Dict):
+            eval_rules = self._aux_eval_rules
+        elif self._aux_eval_rules == "all":
+            indices = np.triu_indices(size + 1)
+            aux_names = pre_tap_aux_observables.keys()
+            indices_list = list(zip(indices[0], indices[1]))
+            eval_rules = {aux_name: indices_list for aux_name in aux_names}
+        elif self._aux_eval_rules == "diag":
+            indices = np.diag_indices(size + 1)
+            aux_names = pre_tap_aux_observables.keys()
+            indices_list = list(zip(indices[0], indices[1]))
+            eval_rules = {aux_name: indices_list for aux_name in aux_names}
+        else:
+            raise ValueError("Aux evaluation rules are ill-defined")
+
+        op_aux_op_dict: dict[Tuple[str, int, int], PauliSumOp] = {}
+
+        for op_name, indices_constraint in eval_rules.items():
+            if op_name not in pre_tap_aux_observables.keys():
+                raise ValueError("Evaluation constrains cannot be satisfied")
+            aux_op = pre_tap_aux_observables[op_name]
+
+            for i, j in indices_constraint:
+                if i >= len(operators_reduced) or j >= len(operators_reduced):
+                    raise ValueError("Evaluation constrains cannot be satisfied")
+
+                opi, opj = operators_reduced[i], operators_reduced[j]
+                op_aux_op_dict[(op_name, i, j)] = (opi.adjoint() @ aux_op @ opj).reduce()
+
+        return op_aux_op_dict
+
+    def _evaluate_observables_excited_states(
+        self,
+        pre_tap_aux_observables: dict[str, PauliSumOp],
+        expansion_basis_data: Tuple[dict[str, PauliSumOp], dict[str, List[bool]], int],
+        reference_state: Tuple[QuantumCircuit, Sequence[float]],
+        expansion_coefs_rescaled: np.ndarray,
+    ) -> Tuple[Dict[Tuple[int, int], Dict[str, Any]], Dict[Tuple[int, int], Dict[str, Any]]]:
+        """Evaluate the expectation values and transition amplitudes of the auxiliary operators on the
+        excited states. Custom rules can be used to define which expectation values and transition
+        amplitudes to compute. A typical rule is specified in the form of a nary
+        {'hamiltonian':[(1,1)]}
+
+        Args:
+            pre_tap_aux_observables: Dict of auxiliary operators for which properties will be computed.
+            expansion_basis_data: Dict of transformed hopping operators, dict of commutativity types,
+            size of the qEOM problem.
+            reference_state: Reference ground state.
+            expansion_coefs_rescaled: Expansion coefficient matrix X such that H @ X = S @ X @ E and
+            X^dag @ S @ X is the identity.
+
+        Returns:
+            List of excitation operators [Identity, O_1, O_2, ...]
+        """
+
+        aux_operators_eigenvalues: Dict[Tuple[int, int], Dict[str, Any]] = {}
+        transition_amplitudes: Dict[Tuple[int, int], Dict[str, Any]] = {}
+
+        _, _, size = expansion_basis_data
+
+        if pre_tap_aux_observables is not None:
+
+            # 1. Build excitation operators O_l such that O_l |0> = |l>
+            excitations_ops_reduced = self._build_excitation_operators(
+                expansion_basis_data, reference_state, expansion_coefs_rescaled
+            )
+
+            # 2. Prepare observables O_k^\dag @ Aux @ O_l
+            op_aux_op_dict = self._prepare_excited_states_observables(
+                pre_tap_aux_observables, excitations_ops_reduced, size
+            )
+
+            # 3. Measure observables
+            tap_op_aux_op_dict = self.qubit_converter._symmetry_reduce_clifford(
+                op_aux_op_dict, True
+            )
+            aux_measurements = estimate_observables(
+                self._estimator, reference_state[0], tap_op_aux_op_dict, reference_state[1]
+            )
+
+            # 4. Format aux_operators_eigenvalues
+            indices_diag = np.diag_indices(size + 1)
+            indices_diag_as_list = list(zip(indices_diag[0], indices_diag[1]))
+            for indice in indices_diag_as_list:
+                aux_operators_eigenvalues[indice] = {}
+                for aux_name in pre_tap_aux_observables.keys():
+                    aux_operators_eigenvalues[indice][aux_name] = aux_measurements.get(
+                        (aux_name, indice[0], indice[1]), (0.0, {})
+                    )
+
+            # 5. Format transition_amplitudes
+            indices_offdiag = np.triu_indices(size + 1, k=1)
+            indices_offdiag_as_list = list(zip(indices_offdiag[0], indices_offdiag[1]))
+            for indice in indices_offdiag_as_list:
+                transition_amplitudes[indice] = {}
+                for aux_name in pre_tap_aux_observables.keys():
+                    transition_amplitudes[indice][aux_name] = aux_measurements.get(
+                        (aux_name, indice[0], indice[1]), (0.0, {})
+                    )
+
+        return aux_operators_eigenvalues, transition_amplitudes
+
+    def _build_qeom_result(
+        self,
+        problem,
+        groundstate_result,
+        expansion_coefs,
+        energy_gaps,
+        h_mat,
+        s_mat,
+        h_mat_std,
+        s_mat_std,
+        aux_operators_eigenvalues,
+        transition_amplitudes,
+        gammas_square,
+    ) -> ElectronicStructureResult:
+
+        qeom_result = QEOMResult()
+        qeom_result.ground_state_raw_result = groundstate_result.raw_result
+        qeom_result.expansion_coefficients = expansion_coefs
+        qeom_result.excitation_energies = energy_gaps
+        qeom_result.h_matrix = h_mat
+        qeom_result.s_matrix = s_mat
+        qeom_result.h_matrix_std = h_mat_std
+        qeom_result.s_matrix_std = s_mat_std
+        qeom_result.gamma_square = gammas_square
+
+        qeom_result.aux_operators_evaluated = list(aux_operators_eigenvalues.values())
+        qeom_result.transition_amplitudes = transition_amplitudes
+
+        groundstate_energy_reference = groundstate_result.eigenvalues[0]
+        excited_eigenenergies = energy_gaps + groundstate_energy_reference
+        qeom_result.eigenvalues = np.append(
+            groundstate_result.eigenvalues[0], excited_eigenenergies
+        )
+
+        qeom_result.eigenstates = np.array([])
+
+        eigenstate_result = EigenstateResult.from_result(qeom_result)
+        result = problem.interpret(eigenstate_result)
+
+        return result
 
 
-class QEOMResult(AlgorithmResult):
+class QEOMResult(EigensolverResult):
     """The results class for the QEOM algorithm."""
 
     def __init__(self) -> None:
@@ -559,13 +908,15 @@ class QEOMResult(AlgorithmResult):
         self._ground_state_raw_result = None
         self._excitation_energies: Optional[np.ndarray] = None
         self._expansion_coefficients: Optional[np.ndarray] = None
-        self._m_matrix: Optional[np.ndarray] = None
-        self._v_matrix: Optional[np.ndarray] = None
-        self._q_matrix: Optional[np.ndarray] = None
-        self._w_matrix: Optional[np.ndarray] = None
-        self._v_matrix_std: float = 0.0
-        self._q_matrix_std: float = 0.0
-        self._w_matrix_std: float = 0.0
+        self._eigenvalues: Optional[np.ndarray] = None
+        self._eigenstates: Optional[np.ndarray] = None
+        self._h_matrix: Optional[np.ndarray] = None
+        self._s_matrix: Optional[np.ndarray] = None
+        self._h_matrix_std: np.ndarray = np.zeros((2, 2))
+        self._s_matrix_std: np.ndarray = np.zeros((2, 2))
+        self._aux_operators_evaluated: Optional[List[ListOrDict[Tuple[complex, complex]]]] = None
+        self._transition_amplitudes: Optional[List[ListOrDict[Tuple[complex, complex]]]] = None
+        self._gamma_square: np.ndarray = None
 
     @property
     def ground_state_raw_result(self):
@@ -598,81 +949,101 @@ class QEOMResult(AlgorithmResult):
         self._expansion_coefficients = value
 
     @property
-    def m_matrix(self) -> Optional[np.ndarray]:
-        """returns the M matrix"""
-        return self._m_matrix
+    def h_matrix(self) -> Optional[np.ndarray]:
+        """returns the H matrix"""
+        return self._h_matrix
 
-    @m_matrix.setter
-    def m_matrix(self, value: np.ndarray) -> None:
-        """sets the M matrix"""
-        self._m_matrix = value
-
-    @property
-    def v_matrix(self) -> Optional[np.ndarray]:
-        """returns the V matrix"""
-        return self._v_matrix
-
-    @v_matrix.setter
-    def v_matrix(self, value: np.ndarray) -> None:
-        """sets the V matrix"""
-        self._v_matrix = value
+    @h_matrix.setter
+    def h_matrix(self, value: np.ndarray) -> None:
+        """sets the H matrix"""
+        self._h_matrix = value
 
     @property
-    def q_matrix(self) -> Optional[np.ndarray]:
-        """returns the Q matrix"""
-        return self._q_matrix
+    def s_matrix(self) -> Optional[np.ndarray]:
+        """returns the S matrix"""
+        return self._s_matrix
 
-    @q_matrix.setter
-    def q_matrix(self, value: np.ndarray) -> None:
-        """sets the Q matrix"""
-        self._q_matrix = value
-
-    @property
-    def w_matrix(self) -> Optional[np.ndarray]:
-        """returns the W matrix"""
-        return self._w_matrix
-
-    @w_matrix.setter
-    def w_matrix(self, value: np.ndarray) -> None:
-        """sets the W matrix"""
-        self._w_matrix = value
+    @s_matrix.setter
+    def s_matrix(self, value: np.ndarray) -> None:
+        """sets the S matrix"""
+        self._s_matrix = value
 
     @property
-    def m_matrix_std(self) -> float:
-        """returns the M matrix standard deviation"""
-        return self._m_matrix_std
+    def h_matrix_std(self) -> Optional[np.ndarray]:
+        """returns the H matrix standard deviation"""
+        return self._h_matrix_std
 
-    @m_matrix_std.setter
-    def m_matrix_std(self, value: float) -> None:
-        """sets the M matrix standard deviation"""
-        self._m_matrix_std = value
-
-    @property
-    def v_matrix_std(self) -> float:
-        """returns the V matrix standard deviation"""
-        return self._v_matrix_std
-
-    @v_matrix_std.setter
-    def v_matrix_std(self, value: float) -> None:
-        """sets the V matrix standard deviation"""
-        self._v_matrix_std = value
+    @h_matrix_std.setter
+    def h_matrix_std(self, value: Optional[np.ndarray]) -> None:
+        """sets the H matrix standard deviation"""
+        self._h_matrix_std = value
 
     @property
-    def q_matrix_std(self) -> float:
-        """returns the Q matrix standard deviation"""
-        return self._q_matrix_std
+    def s_matrix_std(self) -> Optional[np.ndarray]:
+        """returns the S matrix standard deviation"""
+        return self._s_matrix_std
 
-    @q_matrix_std.setter
-    def q_matrix_std(self, value: float) -> None:
-        """sets the Q matrix standard deviation"""
-        self._q_matrix_std = value
+    @s_matrix_std.setter
+    def s_matrix_std(self, value: Optional[np.ndarray]) -> None:
+        """sets the S matrix standard deviation"""
+        self._s_matrix_std = value
 
     @property
-    def w_matrix_std(self) -> float:
-        """returns the W matrix standard deviation"""
-        return self._w_matrix_std
+    def eigenvalues(self) -> Optional[np.ndarray]:
+        """returns eigen values"""
+        return self._eigenvalues
 
-    @w_matrix_std.setter
-    def w_matrix_std(self, value: float) -> None:
-        """sets the W matrix standard deviation"""
-        self._w_matrix_std = value
+    @eigenvalues.setter
+    def eigenvalues(self, value: np.ndarray) -> None:
+        """set eigen values"""
+        self._eigenvalues = value
+
+    @property
+    def eigenstates(self) -> Optional[np.ndarray]:
+        """return eigen states"""
+        return self._eigenstates
+
+    @eigenstates.setter
+    def eigenstates(self, value: np.ndarray) -> None:
+        """set eigen states"""
+        self._eigenstates = value
+
+    @property
+    def alphas(self) -> Optional[np.ndarray]:
+        """return alphas"""
+        return self._alphas
+
+    @alphas.setter
+    def alphas(self, value: np.ndarray) -> None:
+        """set alphas"""
+        self._alphas = value
+
+    @property
+    def gamma_square(self) -> Optional[np.ndarray]:
+        """return gamma_square"""
+        return self._gamma_square
+
+    @gamma_square.setter
+    def gamma_square(self, value: np.ndarray) -> None:
+        """set gamma_square"""
+        self._gamma_square = value
+
+    @property
+    def aux_operators_evaluated(self) -> Optional[List[ListOrDict[Tuple[complex, complex]]]]:
+        """Return aux operator expectation values."""
+        return self._aux_operators_evaluated
+
+    @aux_operators_evaluated.setter
+    def aux_operators_evaluated(self, value: List[ListOrDict[Tuple[complex, complex]]]) -> None:
+        """set aux operator eigen values"""
+        self._aux_operators_evaluated = value
+
+    @property
+    def transition_amplitudes(self) -> Optional[List[ListOrDict[Tuple[complex, complex]]]]:
+        """Return the transition amplitudes."""
+        return self._transition_amplitudes
+
+    @transition_amplitudes.setter
+    def transition_amplitudes(self, value: List[ListOrDict[Tuple[complex, complex]]]) -> None:
+        """set transition amplitudes"""
+        self._transition_amplitudes = value

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_electronic_ops_builder.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_electronic_ops_builder.py
@@ -107,9 +107,7 @@ def _build_single_hopping_operator(
         label.append(f"+_{occ}")
     for unocc in excitation[1]:
         label.append(f"-_{unocc}")
-    fer_op = FermionicOp(
-        {" ".join(label): 4.0 ** len(excitation[0])}, num_spin_orbitals=2 * num_spatial_orbitals
-    )
+    fer_op = FermionicOp({" ".join(label): 1.0}, num_spin_orbitals=2 * num_spatial_orbitals)
 
     qubit_op = qubit_converter.convert_only(fer_op, qubit_converter.num_particles)
     z2_symmetries = qubit_converter.z2symmetries

--- a/qiskit_nature/second_q/mappers/qubit_converter.py
+++ b/qiskit_nature/second_q/mappers/qubit_converter.py
@@ -428,6 +428,37 @@ class QubitConverter:
 
         return reduced_op
 
+    def two_qubit_reduce(
+        self,
+        second_q_ops: PauliSumOp | ListOrDictType[PauliSumOp],
+    ) -> Union[PauliSumOp, ListOrDictType[PauliSumOp]]:
+        """A convenience method to apply the two qubit reduction to all second quantized operators.
+
+        Args:
+            second_q_ops: A second quantized operator, or list thereof
+
+        Returns:
+            A qubit operator in the form of a PauliSumOp, or list thereof if a list of
+            second quantized operators was supplied
+        """
+        if isinstance(second_q_ops, SparseLabelOp):
+            qubit_ops = self._map(second_q_ops)
+        else:
+            wrapped_type = type(second_q_ops)
+
+            wrapped_second_q_ops: _ListOrDict[PauliSumOp] = _ListOrDict(second_q_ops)
+
+            qubit_ops = _ListOrDict()
+            for name, second_q_op in iter(wrapped_second_q_ops):
+                qubit_ops[name] = self._two_qubit_reduce(second_q_op, self._num_particles)
+
+            if wrapped_type == list:
+                qubit_ops = [op for _, op in iter(qubit_ops)]
+            elif wrapped_type == dict:
+                qubit_ops = dict(iter(qubit_ops))
+
+        return qubit_ops
+
     def _find_taper_op(
         self,
         qubit_op: PauliSumOp,
@@ -520,6 +551,64 @@ class QubitConverter:
                     tapered_qubit_ops[name] = self._z2symmetries.taper(qubit_ops[name])
 
         return tapered_qubit_ops
+
+    def _symmetry_reduce_clifford(
+        self,
+        converted_ops: _ListOrDict[PauliSumOp],
+        check_commutes: bool,
+    ) -> _ListOrDict[PauliSumOp]:
+        if converted_ops is None or self._z2symmetries is None or self._z2symmetries.is_empty():
+            tapered_qubit_ops = converted_ops
+        else:
+            if check_commutes:
+                logger.debug("Checking operators commute with symmetry:")
+                symmetry_ops = []
+                for sq_pauli in self._z2symmetries._sq_paulis:
+                    symmetry_ops.append(PauliSumOp.from_list([(sq_pauli.to_label(), 1.0)]))
+                commuted = {}
+                for name, qubit_op in iter(converted_ops):
+                    commutes = QubitConverter._check_commutes(symmetry_ops, qubit_op)
+                    commuted[name] = commutes
+                    logger.debug("Qubit operator '%s' commuted with symmetry: %s", name, commutes)
+
+                # Tapering values were set from prior convert, so we go ahead and taper operators
+                tapered_qubit_ops = _ListOrDict()
+                for name, commutes in commuted.items():
+                    if commutes:
+                        tapered_qubit_ops[name] = self._z2symmetries.taper_clifford(
+                            converted_ops[name]
+                        )
+            else:
+                logger.debug("Tapering operators whether they commute with symmetry or not:")
+                tapered_qubit_ops = _ListOrDict()
+                for name, qubit_op in iter(converted_ops):
+                    tapered_qubit_ops[name] = self._z2symmetries.taper_clifford(converted_ops[name])
+
+        return tapered_qubit_ops
+
+    def _convert_clifford(
+        self,
+        qubit_ops: PauliSumOp | ListOrDictType[PauliSumOp],
+    ):
+        if qubit_ops is None or self._z2symmetries is None or self._z2symmetries.is_empty():
+            converted_ops = qubit_ops
+        else:
+            if isinstance(qubit_ops, (PauliSumOp)):
+                converted_ops = self._z2symmetries.convert_clifford(qubit_ops)
+            else:
+                wrapped_type = type(qubit_ops)
+                wrapped_second_q_ops: _ListOrDict[PauliSumOp] = _ListOrDict(qubit_ops)
+
+                converted_ops = _ListOrDict()
+                for name, second_q_op in iter(wrapped_second_q_ops):
+                    converted_ops[name] = self._z2symmetries.convert_clifford(second_q_op)
+
+                if wrapped_type == list:
+                    converted_ops = [op for _, op in iter(converted_ops)]
+                elif wrapped_type == dict:
+                    converted_ops = dict(iter(converted_ops))
+
+        return converted_ops
 
     @staticmethod
     def _check_commutes(cliffords: List[PauliSumOp], qubit_op: PauliSumOp) -> bool:

--- a/releasenotes/notes/refactors-and-upgrades-qeom-aedffc628e21df19.yaml
+++ b/releasenotes/notes/refactors-and-upgrades-qeom-aedffc628e21df19.yaml
@@ -1,0 +1,65 @@
+---
+features:
+  - |
+    Improves readability of the QEOM code and implements the calculation of 
+    excited state properties and transition 
+    amplitudes with QEOM.
+
+    The new functionalities can be used as follows:
+
+    .. code-block:: python
+
+      from qiskit.algorithms.optimizers import COBYLA
+      from qiskit.primitives import Estimator
+
+      from qiskit_nature.units import DistanceUnit
+      from qiskit_nature.second_q.algorithms import (
+        VQEUCCFactory, 
+        GroundStateEigensolver
+      )
+      from qiskit_nature.second_q.algorithms.excited_states_solvers import QEOM
+      from qiskit_nature.second_q.circuit.library import UCCSD
+      from qiskit_nature.second_q.drivers import PySCFDriver
+      from qiskit_nature.second_q.mappers import QubitConverter
+      from qiskit_nature.second_q.mappers import JordanWignerMapper
+
+      import numpy as np
+
+      optimizer = COBYLA(maxiter=500,disp=False)
+      qubit_converter = QubitConverter(
+        JordanWignerMapper(), 
+        z2symmetry_reduction=None, 
+        two_qubit_reduction=False
+        )
+
+      new_driver = PySCFDriver(
+          atom="H 0 0 0; H 0 0 1.735",
+          basis="sto3g",
+          charge=0,
+          spin=0,
+          unit=DistanceUnit.ANGSTROM,
+      )
+      new_es_problem = new_driver.run()
+      hamiltonian_op, _ = new_es_problem.second_q_ops()
+      aux_ops = {'hamiltonian':hamiltonian_op}
+
+      # Qeom results
+      vqe_solver = VQEUCCFactory(Estimator(), UCCSD(), optimizer)
+      me_gsc = GroundStateEigensolver(qubit_converter, vqe_solver)
+      qeom_solver = QEOM(
+        me_gsc, 
+        estimator=Estimator(), 
+        excitations='sd', 
+        aux_eval_rules="all"
+      )
+      results_qeom = qeom_solver.solve(new_es_problem, aux_operators=aux_ops)
+
+      print("Aux QEOM")
+      for aux_op_eval in results_qeom.aux_operators_evaluated:
+          print(aux_op_eval)
+
+upgrade:
+  - |
+    Refactors the treatment of symmetries in the QEOM to reduce the classical overhead.
+    The parallelism was also reworked to improve the performances of the current hybrid 
+    sequential+parallel approach.

--- a/test/second_q/algorithms/excited_state_solvers/resources/__init__.py
+++ b/test/second_q/algorithms/excited_state_solvers/resources/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021, 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/test/second_q/algorithms/excited_state_solvers/resources/expected_qeom_ops.py
+++ b/test/second_q/algorithms/excited_state_solvers/resources/expected_qeom_ops.py
@@ -1,0 +1,149 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Reference PauliSumOp for testing."""
+
+from typing import Any
+from qiskit.opflow import PauliSumOp
+
+expected_hopping_operators_electronic: dict[str, PauliSumOp] = {
+    "E_0": 1 / 4 * PauliSumOp.from_list([("IIXY", -1j), ("IIYY", 1), ("IIXX", 1), ("IIYX", 1j)]),
+    "Edag_0": 1 / 4 * PauliSumOp.from_list([("IIXY", 1j), ("IIXX", 1), ("IIYY", 1), ("IIYX", -1j)]),
+    "E_1": 1 / 4 * PauliSumOp.from_list([("XYII", -1j), ("YYII", 1), ("XXII", 1), ("YXII", 1j)]),
+    "Edag_1": 1 / 4 * PauliSumOp.from_list([("XYII", 1j), ("YYII", 1), ("XXII", 1), ("YXII", -1j)]),
+    "E_2": 1
+    / 16
+    * PauliSumOp.from_list(
+        [
+            ("XYXY", 1),
+            ("YYXY", 1j),
+            ("XYYY", 1j),
+            ("YYYY", -1),
+            ("XXXY", 1j),
+            ("YXXY", -1),
+            ("XXYY", -1),
+            ("YXYY", -1j),
+            ("XYXX", 1j),
+            ("YYXX", -1),
+            ("XYYX", -1),
+            ("YYYX", -1j),
+            ("XXXX", -1),
+            ("YXXX", -1j),
+            ("XXYX", -1j),
+            ("YXYX", 1),
+        ]
+    ),
+    "Edag_2": 1
+    / 16
+    * PauliSumOp.from_list(
+        [
+            ("XYXY", 1),
+            ("XXXY", -1j),
+            ("XYXX", -1j),
+            ("XXXX", -1),
+            ("YYXY", -1j),
+            ("YXXY", -1),
+            ("YYXX", -1),
+            ("YXXX", 1j),
+            ("XYYY", -1j),
+            ("XXYY", -1),
+            ("XYYX", -1),
+            ("XXYX", 1j),
+            ("YYYY", -1),
+            ("YXYY", 1j),
+            ("YYYX", 1j),
+            ("YXYX", 1),
+        ]
+    ),
+}
+
+expected_commutativies_electronic: dict[str, list[bool]] = {
+    "E_0": [],
+    "Edag_0": [],
+    "E_1": [],
+    "Edag_1": [],
+    "E_2": [],
+    "Edag_2": [],
+}
+
+expected_indices_electronic: dict[str, Any] = {
+    "E_0": ((0,), (1,)),
+    "Edag_0": ((1,), (0,)),
+    "E_1": ((2,), (3,)),
+    "Edag_1": ((3,), (2,)),
+    "E_2": ((0, 2), (1, 3)),
+    "Edag_2": ((1, 3), (0, 2)),
+}
+
+expected_hopping_operators_vibrational: dict[str, PauliSumOp] = {
+    "E_0": PauliSumOp.from_list(
+        [("IIXX", 0.25), ("IIYX", 0.25j), ("IIXY", -0.25j), ("IIYY", 0.25)]
+    ),
+    "Edag_0": PauliSumOp.from_list(
+        [("IIXX", 0.25), ("IIYX", -0.25j), ("IIXY", 0.25j), ("IIYY", 0.25)]
+    ),
+    "E_1": PauliSumOp.from_list(
+        [("XXII", 0.25), ("YXII", 0.25j), ("XYII", -0.25j), ("YYII", 0.25)]
+    ),
+    "Edag_1": PauliSumOp.from_list(
+        [("XXII", 0.25), ("YXII", -0.25j), ("XYII", 0.25j), ("YYII", 0.25)]
+    ),
+    "E_2": PauliSumOp.from_list(
+        [
+            ("XXXX", 0.0625),
+            ("YXXX", 0.0625j),
+            ("XYXX", -0.0625j),
+            ("YYXX", 0.0625),
+            ("XXYX", 0.0625j),
+            ("YXYX", -0.0625),
+            ("XYYX", 0.0625),
+            ("YYYX", 0.0625j),
+            ("XXXY", -0.0625j),
+            ("YXXY", 0.0625),
+            ("XYXY", -0.0625),
+            ("YYXY", -0.0625j),
+            ("XXYY", 0.0625),
+            ("YXYY", 0.0625j),
+            ("XYYY", -0.0625j),
+            ("YYYY", 0.0625),
+        ]
+    ),
+    "Edag_2": PauliSumOp.from_list(
+        [
+            ("XXXX", 0.0625),
+            ("YXXX", -0.0625j),
+            ("XYXX", 0.0625j),
+            ("YYXX", 0.0625),
+            ("XXYX", -0.0625j),
+            ("YXYX", -0.0625),
+            ("XYYX", 0.0625),
+            ("YYYX", -0.0625j),
+            ("XXXY", 0.0625j),
+            ("YXXY", 0.0625),
+            ("XYXY", -0.0625),
+            ("YYXY", 0.0625j),
+            ("XXYY", 0.0625),
+            ("YXYY", -0.0625j),
+            ("XYYY", 0.0625j),
+            ("YYYY", 0.0625),
+        ]
+    ),
+}
+expected_commutativies_vibrational: dict[str, list[bool]] = {}
+expected_indices_vibrational: dict[str, Any] = {
+    "E_0": ((0,), (1,)),
+    "Edag_0": ((1,), (0,)),
+    "E_1": ((2,), (3,)),
+    "Edag_1": ((3,), (2,)),
+    "E_2": ((0, 2), (1, 3)),
+    "Edag_2": ((1, 3), (0, 2)),
+}

--- a/test/second_q/algorithms/excited_state_solvers/resources/expected_transition_amplitudes.py
+++ b/test/second_q/algorithms/excited_state_solvers/resources/expected_transition_amplitudes.py
@@ -1,0 +1,70 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Reference Transition amplitudes for testing."""
+
+reference_trans_amps = {
+    (0, 1): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": (0.0, {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+    (0, 2): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": ((-1.1633636825848008 + 0j), {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+    (0, 3): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": (0.0, {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+    (1, 2): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": (0.0, {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+    (1, 3): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": (0.0, {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+    (2, 3): {
+        "AngularMomentum": (0.0, {"variance": 0.0}),
+        "Magnetization": (0.0, {"variance": 0.0}),
+        "ParticleNumber": (0.0, {"variance": 0.0}),
+        "XDipole": (0.0, {"variance": 0.0}),
+        "YDipole": (0.0, {"variance": 0.0}),
+        "ZDipole": ((1.4667186749299648 + 0j), {"variance": 0.0}),
+        "hamiltonian": (0.0, {"variance": 0.0}),
+    },
+}

--- a/test/second_q/algorithms/excited_state_solvers/test_excited_states_solver_auxiliaries.py
+++ b/test/second_q/algorithms/excited_state_solvers/test_excited_states_solver_auxiliaries.py
@@ -1,0 +1,182 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test Numerical qEOM excited states calculation """
+
+import unittest
+
+from test import QiskitNatureTestCase
+from typing import List, Dict
+
+import numpy as np
+
+from qiskit.algorithms.eigensolvers import NumPyEigensolver
+from qiskit.algorithms.optimizers import SLSQP
+from qiskit.primitives import Estimator
+from qiskit.utils import algorithm_globals
+
+from qiskit_nature.units import DistanceUnit
+from qiskit_nature.second_q.circuit.library import UCCSD
+from qiskit_nature.second_q.drivers import PySCFDriver
+from qiskit_nature.second_q.mappers import (
+    BravyiKitaevMapper,
+    JordanWignerMapper,
+    ParityMapper,
+)
+from qiskit_nature.second_q.mappers import QubitConverter
+from qiskit_nature.second_q.algorithms import (
+    GroundStateEigensolver,
+    VQEUCCFactory,
+    QEOM,
+)
+import qiskit_nature.optionals as _optionals
+from .resources.expected_transition_amplitudes import reference_trans_amps
+
+
+class TestNumericalQEOMOBScalculation(QiskitNatureTestCase):
+    """Test qEOM excited state observables calculation"""
+
+    @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
+    def setUp(self):
+        super().setUp()
+        algorithm_globals.random_seed = 8
+        self.driver = PySCFDriver(
+            atom="H .0 .0 .0; H .0 .0 0.75",
+            unit=DistanceUnit.ANGSTROM,
+            charge=0,
+            spin=0,
+            basis="sto3g",
+        )
+
+        self.reference_energies = [
+            -1.8427016,
+            -1.8427016 + 0.5943372,
+            -1.8427016 + 0.95788352,
+            -1.8427016 + 1.5969296,
+        ]
+
+        self.reference_trans_amps = reference_trans_amps
+
+        self.qubit_converter = QubitConverter(JordanWignerMapper())
+        self.electronic_structure_problem = self.driver.run()
+        hamiltonian_op, _ = self.electronic_structure_problem.second_q_ops()
+        self.aux_ops = {"hamiltonian": hamiltonian_op}
+
+        solver = NumPyEigensolver()
+        self.ref = solver
+
+    def _assert_energies(self, computed, references, *, places=4):
+        with self.subTest("same number of energies"):
+            self.assertEqual(len(computed), len(references))
+
+        with self.subTest("ground state"):
+            self.assertAlmostEqual(computed[0], references[0], places=places)
+
+        for i in range(1, len(computed)):
+            with self.subTest(f"{i}. excited state"):
+                self.assertAlmostEqual(computed[i], references[i], places=places)
+
+    def _assert_transition_amplitudes(self, computed, references, *, places=4):
+        with self.subTest("same number of indices"):
+            self.assertEqual(len(computed), len(references))
+
+        with self.subTest("operators computed are reference operators"):
+            for key, key_ref in zip(computed.keys(), references.keys()):
+                self.assertTrue(key == key_ref)
+
+        with self.subTest("same transition amplitude values"):
+            for key in computed.keys():
+                for opkey in computed[key].keys():
+                    trans_amp = computed[key][opkey][0]
+                    trans_amp_expected = references[key][opkey][0]
+                    self.assertAlmostEqual(trans_amp, trans_amp_expected, places=places)
+
+    def test_vqe_mes_jw(self):
+        """Test VQEUCCSDFactory with QEOM + Jordan Wigner mapping"""
+        converter = QubitConverter(JordanWignerMapper())
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_jw_auto(self):
+        """Test VQEUCCSDFactory with QEOM + Jordan Wigner mapping + auto symmetry"""
+        converter = QubitConverter(JordanWignerMapper(), z2symmetry_reduction="auto")
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_parity(self):
+        """Test VQEUCCSDFactory with QEOM + Parity mapping"""
+        converter = QubitConverter(ParityMapper())
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_parity_2q(self):
+        """Test VQEUCCSDFactory with QEOM + Parity mapping + reduction"""
+        converter = QubitConverter(ParityMapper(), two_qubit_reduction=True)
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_parity_auto(self):
+        """Test VQEUCCSDFactory with QEOM + Parity mapping + auto symmetry"""
+        converter = QubitConverter(ParityMapper(), z2symmetry_reduction="auto")
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_parity_2q_auto(self):
+        """Test VQEUCCSDFactory with QEOM + Parity mapping + reduction + auto symmetry"""
+        converter = QubitConverter(
+            ParityMapper(), two_qubit_reduction=True, z2symmetry_reduction="auto"
+        )
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_bk(self):
+        """Test VQEUCCSDFactory with QEOM + Bravyi-Kitaev mapping"""
+        converter = QubitConverter(BravyiKitaevMapper())
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def test_vqe_mes_bk_auto(self):
+        """Test VQEUCCSDFactory with QEOM + Bravyi-Kitaev mapping + auto symmetry"""
+        converter = QubitConverter(BravyiKitaevMapper(), z2symmetry_reduction="auto")
+        self._aux_ops_with_vqe_mes(converter)
+        self._trans_amps_with_vqe_mes(converter)
+
+    def _aux_ops_with_vqe_mes(self, converter: QubitConverter):
+        estimator = Estimator()
+        solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+        gsc = GroundStateEigensolver(converter, solver)
+        esc = QEOM(gsc, estimator, "sd", aux_eval_rules="diag")
+        results = esc.solve(self.electronic_structure_problem, aux_operators=self.aux_ops)
+
+        energies_recalculated = np.zeros_like(results.computed_energies)
+        for estate, aux_op in enumerate(results.aux_operators_evaluated):
+            energies_recalculated[estate] = aux_op["hamiltonian"]
+
+        self._assert_energies(results.computed_energies, self.reference_energies)
+        self._assert_energies(energies_recalculated, self.reference_energies)
+
+    def _trans_amps_with_vqe_mes(self, converter: QubitConverter):
+        estimator = Estimator()
+        solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+        gsc = GroundStateEigensolver(converter, solver)
+        esc = QEOM(gsc, estimator, "sd", aux_eval_rules="all")
+        results = esc.solve(self.electronic_structure_problem, aux_operators=self.aux_ops)
+
+        transition_amplitudes = results.raw_result.transition_amplitudes
+
+        self._assert_transition_amplitudes(
+            transition_amplitudes, self.reference_trans_amps, places=4
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/second_q/algorithms/excited_state_solvers/test_qeom_electronic_ops.py
+++ b/test/second_q/algorithms/excited_state_solvers/test_qeom_electronic_ops.py
@@ -14,7 +14,6 @@
 import unittest
 from test import QiskitNatureTestCase
 
-from qiskit.opflow import PauliSumOp
 from qiskit.utils import algorithm_globals
 
 from qiskit_nature.units import DistanceUnit
@@ -24,6 +23,11 @@ from qiskit_nature.second_q.algorithms.excited_states_solvers.qeom_electronic_op
     build_electronic_ops,
 )
 import qiskit_nature.optionals as _optionals
+from .resources.expected_qeom_ops import (
+    expected_hopping_operators_electronic,
+    expected_commutativies_electronic,
+    expected_indices_electronic,
+)
 
 
 class TestHoppingOpsBuilder(QiskitNatureTestCase):
@@ -46,70 +50,7 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         self.electronic_structure_problem.second_q_ops()
 
     def test_build_hopping_operators(self):
-        """Tests that the correct hopping operator is built."""
-        # TODO extract it somewhere
-        expected_hopping_operators = {
-            "E_0": PauliSumOp.from_list([("IIXY", -1j), ("IIYY", 1), ("IIXX", 1), ("IIYX", 1j)]),
-            "Edag_0": PauliSumOp.from_list([("IIXY", 1j), ("IIXX", 1), ("IIYY", 1), ("IIYX", -1j)]),
-            "E_1": PauliSumOp.from_list([("XYII", -1j), ("YYII", 1), ("XXII", 1), ("YXII", 1j)]),
-            "Edag_1": PauliSumOp.from_list([("XYII", 1j), ("YYII", 1), ("XXII", 1), ("YXII", -1j)]),
-            "E_2": PauliSumOp.from_list(
-                [
-                    ("XYXY", 1),
-                    ("YYXY", 1j),
-                    ("XYYY", 1j),
-                    ("YYYY", -1),
-                    ("XXXY", 1j),
-                    ("YXXY", -1),
-                    ("XXYY", -1),
-                    ("YXYY", -1j),
-                    ("XYXX", 1j),
-                    ("YYXX", -1),
-                    ("XYYX", -1),
-                    ("YYYX", -1j),
-                    ("XXXX", -1),
-                    ("YXXX", -1j),
-                    ("XXYX", -1j),
-                    ("YXYX", 1),
-                ]
-            ),
-            "Edag_2": PauliSumOp.from_list(
-                [
-                    ("XYXY", 1),
-                    ("XXXY", -1j),
-                    ("XYXX", -1j),
-                    ("XXXX", -1),
-                    ("YYXY", -1j),
-                    ("YXXY", -1),
-                    ("YYXX", -1),
-                    ("YXXX", 1j),
-                    ("XYYY", -1j),
-                    ("XXYY", -1),
-                    ("XYYX", -1),
-                    ("XXYX", 1j),
-                    ("YYYY", -1),
-                    ("YXYY", 1j),
-                    ("YYYX", 1j),
-                    ("YXYX", 1),
-                ]
-            ),
-        }
-        expected_commutativies = {
-            "E_0": [],
-            "Edag_0": [],
-            "E_1": [],
-            "Edag_1": [],
-            "E_2": [],
-            "Edag_2": [],
-        }
-        expected_indices = {
-            "E_0": ((0,), (1,)),
-            "Edag_0": ((1,), (0,)),
-            "E_1": ((2,), (3,)),
-            "Edag_1": ((3,), (2,)),
-            "E_2": ((0, 2), (1, 3)),
-            "Edag_2": ((1, 3), (0, 2)),
-        }
+        """Tests that the correct hopping operators are built."""
 
         hopping_operators, commutativities, indices = build_electronic_ops(
             self.electronic_structure_problem.num_spatial_orbitals,
@@ -119,21 +60,23 @@ class TestHoppingOpsBuilder(QiskitNatureTestCase):
         )
 
         with self.subTest("hopping operators"):
-            self.assertEqual(hopping_operators.keys(), expected_hopping_operators.keys())
-            for key, exp_key in zip(hopping_operators.keys(), expected_hopping_operators.keys()):
+            self.assertEqual(hopping_operators.keys(), expected_hopping_operators_electronic.keys())
+            for key, exp_key in zip(
+                hopping_operators.keys(), expected_hopping_operators_electronic.keys()
+            ):
                 self.assertEqual(key, exp_key)
                 val = hopping_operators[key]
-                exp_val = expected_hopping_operators[exp_key]
+                exp_val = expected_hopping_operators_electronic[exp_key]
                 if not val.equals(exp_val):
                     print(val)
                     print(exp_val)
-                self.assertTrue(val.equals(exp_val))
+                self.assertTrue(val.equals(exp_val), msg=(val, exp_val))
 
         with self.subTest("commutativities"):
-            self.assertEqual(commutativities, expected_commutativies)
+            self.assertEqual(commutativities, expected_commutativies_electronic)
 
         with self.subTest("excitation indices"):
-            self.assertEqual(indices, expected_indices)
+            self.assertEqual(indices, expected_indices_electronic)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Closes #769
Closes #415
Closes #403
Closes #52 

### Summary
Proposition for a modification to QEOM internals to :
- Make the code easier to follow
- Improve the potential for parallelism
- Improve the performances of the classical calculations by using a custom treatment of the tapering.

A new functionality is also added to compute excited state properties and transition amplitudes of arbitrary observables.

The typical interface to use it would be the following:

```
from qiskit.algorithms.optimizers import COBYLA
from qiskit.primitives import Estimator

from qiskit_nature.units import DistanceUnit
from qiskit_nature.second_q.algorithms import VQEUCCFactory, GroundStateEigensolver
from qiskit_nature.second_q.algorithms.excited_states_solvers import QEOM
from qiskit_nature.second_q.circuit.library import UCCSD
from qiskit_nature.second_q.drivers import PySCFDriver
from qiskit_nature.second_q.mappers import QubitConverter
from qiskit_nature.second_q.mappers import JordanWignerMapper

import numpy as np

optimizer = COBYLA(maxiter=500,disp=False)
qubit_converter = QubitConverter(JordanWignerMapper(), z2symmetry_reduction=None, two_qubit_reduction=False)

new_driver = PySCFDriver(
    atom="H 0 0 0; H 0 0 1.735",
    basis="sto3g",
    charge=0,
    spin=0,
    unit=DistanceUnit.ANGSTROM,
)
new_es_problem = new_driver.run()
hamiltonian_op, _ = new_es_problem.second_q_ops()
aux_ops = {'hamiltonian':hamiltonian_op}

# Qeom results
vqe_solver = VQEUCCFactory(Estimator(), UCCSD(), optimizer)
me_gsc = GroundStateEigensolver(qubit_converter, vqe_solver)
qeom_solver = QEOM(me_gsc, estimator=Estimator(), excitations='sd', aux_eval_rules="all")
results_qeom = qeom_solver.solve(new_es_problem, aux_operators=aux_ops)

print("Aux QEOM")
for aux_op_eval in results_qeom.aux_operators_evaluated:
    print(aux_op_eval)

print("Transi QEOM")
for indice, value in results_qeom.raw_result.transition_amplitudes.items():
    print(indice, value)

```

### Details and comments

The following guides details some of the changes that are proposed
[QEOM_refactoring-3.pdf](https://github.com/Qiskit/qiskit-nature/files/10014630/QEOM_refactoring-3.pdf)

