### PR TITLE
refactor: avoid index order conversion for MP2

### DIFF
--- a/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
+++ b/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
@@ -19,7 +19,6 @@ import numpy as np
 from qiskit_nature.exceptions import QiskitNatureError
 from qiskit_nature.second_q.circuit.library import UCC
 from qiskit_nature.second_q.operators import ElectronicIntegrals
-from qiskit_nature.second_q.operators.tensor_ordering import IndexType, to_chemist_ordering
 from qiskit_nature.second_q.problems import BaseProblem, ElectronicStructureProblem
 from qiskit_nature.utils import get_einsum
 
@@ -33,7 +32,7 @@ def _compute_mp2(
 
     Args:
         num_occ: The number of occupied molecular orbitals.
-        integral_matrix: The two-body molecular orbitals matrix.
+        integral_matrix: The two-body molecular orbitals matrix in physicist' index order.
         orbital_energies: The orbital energies.
 
     Returns:
@@ -45,7 +44,7 @@ def _compute_mp2(
     # We use NumPy broadcasting to compute the matrix of occupied - virtual energy deltas with
     # shape (num_occ, num_vir), such that
     # energy_deltas[i, a] = orbital_energy[i] - orbital_energy[a].
-    # NOTE In the unrestricted-spin calculation, the orbital energies will be a 2D array, and this
+    # NOTE: In the unrestricted-spin calculation, the orbital energies will be a 2D array, and this
     # logic will need to be revisited.
     energy_deltas = orbital_energies[:num_occ, np.newaxis] - orbital_energies[num_occ:]
 
@@ -56,16 +55,22 @@ def _compute_mp2(
     # Again we can use NumPy broadcasting to speed this up.
     double_deltas = energy_deltas[:, :, np.newaxis, np.newaxis] + energy_deltas
 
+    # Now we transpose this matrix into (num_occ, num_occ, num_vir, num_vir) such that it matches
+    # the ordering of our integral matrix below, which is in physicist' index order.
+    double_deltas = double_deltas.transpose(0, 2, 1, 3)
+
     # Create integral matrix that uses occupied and virtual indices rather than MO indices.
-    integral_matrix_ovov = integral_matrix[:num_occ, num_occ:, :num_occ, num_occ:]
+    integral_matrix_oovv = integral_matrix[:num_occ, :num_occ, num_occ:, num_occ:]
+    # NOTE: we must swap the last two axes in order to match the ordering of double_deltas
+    integral_matrix_oovv = integral_matrix_oovv.transpose(0, 1, 3, 2)
 
     # Compute T2 amplitudes and transpose to num_occ, num_occ, num_vir, num_vir.
-    t2_amplitudes = (integral_matrix_ovov / double_deltas).transpose(0, 2, 1, 3)
+    t2_amplitudes = integral_matrix_oovv / double_deltas
 
     # Compute MP2 energy correction.
     einsum_func, _ = get_einsum()
-    energy_correction = einsum_func("ijab,iajb", t2_amplitudes, integral_matrix_ovov) * 2
-    energy_correction -= einsum_func("ijab,ibja", t2_amplitudes, integral_matrix_ovov)
+    energy_correction = einsum_func("ijab,ijab", t2_amplitudes, integral_matrix_oovv) * 2
+    energy_correction -= einsum_func("ijab,ijba", t2_amplitudes, integral_matrix_oovv)
 
     return t2_amplitudes, energy_correction
 
@@ -179,9 +184,7 @@ class MP2InitialPoint(InitialPoint):
                 "the MP2InitialPoint."
             )
 
-        integral_matrix = to_chemist_ordering(
-            two_body_mo_integral.alpha.get("++--"), index_order=IndexType.PHYSICIST
-        )
+        integral_matrix = two_body_mo_integral.alpha.get("++--")
 
         reference_energy = problem.reference_energy if not None else 0.0
 

--- a/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
+++ b/qiskit_nature/second_q/algorithms/initial_points/mp2_initial_point.py
@@ -32,7 +32,7 @@ def _compute_mp2(
 
     Args:
         num_occ: The number of occupied molecular orbitals.
-        integral_matrix: The two-body molecular orbitals matrix in physicist' index order.
+        integral_matrix: The two-body molecular orbitals matrix in physicists' index order.
         orbital_energies: The orbital energies.
 
     Returns:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I want to be able to reuse the MP2 computing functionality elsewhere and would like to avoid the physicist-to-chemist conversion. So this PR refactores the internal `_compute_mp2` utility to rely on physicist-ordered two-body terms instead.

### Details and comments


