### PR TITLE
fix: take QCWavefunction.eri_mo_ab into account

### DIFF
--- a/qiskit_nature/second_q/formats/qcschema_translator.py
+++ b/qiskit_nature/second_q/formats/qcschema_translator.py
@@ -168,6 +168,8 @@ def _get_mo_hamiltonian_direct(qcschema) -> ElectronicEnergy:
         hijkl_bb = _reshape_4(qcschema.wavefunction.scf_eri_mo_bb, norb)
     if qcschema.wavefunction.scf_eri_mo_ba is not None:
         hijkl_ba = _reshape_4(qcschema.wavefunction.scf_eri_mo_ba, norb)
+    if qcschema.wavefunction.scf_eri_mo_ab is not None and hijkl_ba is None:
+        hijkl_ba = _reshape_4(qcschema.wavefunction.scf_eri_mo_ab, norb).T
 
     hamiltonian = ElectronicEnergy.from_raw_integrals(hij, hijkl, hij_b, hijkl_bb, hijkl_ba)
 

--- a/releasenotes/notes/fix-qcschema-reading-mixed-spin-eri-8baa797ec14f9dd5.yaml
+++ b/releasenotes/notes/fix-qcschema-reading-mixed-spin-eri-8baa797ec14f9dd5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the :meth:`.qcschema_to_problem` method to take :attr:`.QCWavefunction.eri_mo_ab`
+    into account when :attr:`.QCWavefunction.eri_mo_ba` is not available.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

The HDF5 interface of the QCSchema is not yet officially supported by the QCSchema and, as such, not being tested in detail yet. Thus, this PR comes without an extra unittest at this time.
