### PR TITLE
Implement the `Tensor` class

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -242,6 +242,7 @@ intel
 intelvem
 interatomic
 internuclear
+interoperability
 interpretable
 ints
 io
@@ -354,6 +355,7 @@ natom
 nbasis
 nd
 ndarray
+ndim
 nelec
 neq
 networkx
@@ -583,6 +585,7 @@ uccsd
 ucrx
 ucry
 ucrz
+ufuncs
 uhf
 ulimit
 un

--- a/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -30,7 +30,7 @@ class HyperCubicLattice(Lattice):
     tuples of `size`, `edge_parameters`, and `boundary_conditions`.
     For example,
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.hamiltonians.lattices import (
             BoundaryCondition,

--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -28,6 +28,7 @@ Operators and mappers for different systems such as fermionic, vibrational and s
    VibrationalOp
    VibrationalIntegrals
    PolynomialTensor
+   Tensor
 
 Modules
 -------
@@ -46,6 +47,7 @@ from .vibrational_op import VibrationalOp
 from .vibrational_integrals import VibrationalIntegrals
 from .polynomial_tensor import PolynomialTensor
 from .sparse_label_op import SparseLabelOp
+from .tensor import Tensor
 
 __all__ = [
     "ElectronicIntegrals",
@@ -55,4 +57,5 @@ __all__ = [
     "VibrationalIntegrals",
     "PolynomialTensor",
     "SparseLabelOp",
+    "Tensor",
 ]

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -25,7 +25,8 @@ from qiskit.quantum_info.operators.mixins import LinearMixin
 from qiskit_nature.exceptions import QiskitNatureError
 import qiskit_nature.optionals as _optionals
 
-from .polynomial_tensor import ARRAY_TYPE, PolynomialTensor
+from .polynomial_tensor import PolynomialTensor
+from .tensor import Tensor
 from .tensor_ordering import (
     IndexType,
     find_index_order,
@@ -256,8 +257,7 @@ class ElectronicIntegrals(LinearMixin):
         if self.beta_alpha.is_empty():
             return self.beta_alpha
 
-        beta_alpha = cast(ARRAY_TYPE, self.beta_alpha["++--"])
-        alpha_beta = np.moveaxis(beta_alpha, (0, 1), (2, 3))
+        alpha_beta = Tensor(np.moveaxis(self.beta_alpha["++--"], (0, 1), (2, 3)))
         return PolynomialTensor({"++--": alpha_beta}, validate=False)
 
     @property
@@ -378,7 +378,7 @@ class ElectronicIntegrals(LinearMixin):
     @classmethod
     def apply(
         cls,
-        function: Callable[..., np.ndarray | SparseArray | Number],
+        function: Callable[..., np.ndarray | SparseArray | complex],
         *operands: ElectronicIntegrals,
         validate: bool = True,
     ) -> ElectronicIntegrals:
@@ -568,9 +568,7 @@ class ElectronicIntegrals(LinearMixin):
 
         kron_one_body = np.zeros((2, 2))
         kron_two_body = np.zeros((2, 2, 2, 2))
-        kron_tensor = PolynomialTensor(
-            {"": cast(Number, 1.0), "+-": kron_one_body, "++--": kron_two_body}
-        )
+        kron_tensor = PolynomialTensor({"": 1.0, "+-": kron_one_body, "++--": kron_two_body})
 
         if beta_empty and beta_alpha_empty:
             kron_one_body[(0, 0)] = 1

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -257,7 +257,8 @@ class ElectronicIntegrals(LinearMixin):
         if self.beta_alpha.is_empty():
             return self.beta_alpha
 
-        alpha_beta = Tensor(np.moveaxis(self.beta_alpha["++--"], (0, 1), (2, 3)))
+        # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+        alpha_beta = Tensor(np.moveaxis(Tensor(self.beta_alpha["++--"]), (0, 1), (2, 3)))
         return PolynomialTensor({"++--": alpha_beta}, validate=False)
 
     @property

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -257,7 +257,7 @@ class ElectronicIntegrals(LinearMixin):
         if self.beta_alpha.is_empty():
             return self.beta_alpha
 
-        # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+        # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
         alpha_beta = Tensor(np.moveaxis(Tensor(self.beta_alpha["++--"]), (0, 1), (2, 3)))
         return PolynomialTensor({"++--": alpha_beta}, validate=False)
 

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -264,7 +264,7 @@ class FermionicOp(SparseLabelOp):
             # PERF: the following matrix unpacking is a performance bottleneck!
             # We could consider using Rust in the future to improve upon this.
 
-            mat = tensor[key].array
+            mat = tensor[key]
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*index)] = mat[index]

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -46,7 +46,7 @@ class FermionicOp(SparseLabelOp):
     A ``FermionicOp`` is initialized with a dictionary, mapping terms to their respective
     coefficients:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import FermionicOp
 
@@ -62,7 +62,7 @@ class FermionicOp(SparseLabelOp):
     If you have very restricted memory resources available, or would like to avoid the additional
     copy, the dictionary will be stored by reference if you disable ``copy`` like so:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         some_big_data = {
             "+_0 -_0": 1.0,
@@ -91,25 +91,25 @@ class FermionicOp(SparseLabelOp):
 
     Addition
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       FermionicOp({"+_1": 1}, num_spin_orbitals=2) + FermionicOp({"+_0": 1}, num_spin_orbitals=2)
 
     Sum
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       sum(FermionicOp({label: 1}, num_spin_orbitals=3) for label in ["+_0", "-_1", "+_2 -_2"])
 
     Scalar multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       0.5 * FermionicOp({"+_1": 1}, num_spin_orbitals=2)
 
     Operator multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       op1 = FermionicOp({"+_0 -_1": 1}, num_spin_orbitals=2)
       op2 = FermionicOp({"-_0 +_0 +_1": 1}, num_spin_orbitals=2)
@@ -117,14 +117,14 @@ class FermionicOp(SparseLabelOp):
 
     Tensor multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       op = FermionicOp({"+_0 -_1": 1}, num_spin_orbitals=2)
       print(op ^ op)
 
     Adjoint
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       FermionicOp({"+_0 -_1": 1j}, num_spin_orbitals=2).adjoint()
 

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -258,12 +258,13 @@ class FermionicOp(SparseLabelOp):
                 data[""] = cast(float, tensor[key])
                 continue
 
+            # TODO: extract label_template into Tensor class
             label_template = " ".join(f"{op}_{{}}" for op in key)
 
             # PERF: the following matrix unpacking is a performance bottleneck!
             # We could consider using Rust in the future to improve upon this.
 
-            mat = tensor[key]
+            mat = tensor[key].array
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*index)] = mat[index]

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -79,7 +79,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
     made about the *contents* of the keys. However, the length of each key determines the dimension
     of the matrix which it maps, too. For example:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         import numpy as np
 
@@ -96,7 +96,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
     axis of the matrix, when an operator gets built from the tensor. This means, that the previous
     example would expand for example like so:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import FermionicOp, PolynomialTensor
 
@@ -113,28 +113,28 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
 
     Addition
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       matrix = np.array([[0, 1], [2, 3]], dtype=float)
       0.5 * PolynomialTensor({"+-": matrix}) + PolynomialTensor({"+-": matrix})
 
     Operator multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       tensor = PolynomialTensor({"+-": matrix})
       print(tensor @ tensor)
 
     Tensor multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       print(tensor ^ tensor)
 
     You can also implement more advanced arithmetic via the :meth:`apply` and :meth:`einsum`
     methods.
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       print(PolynomialTensor.apply(np.transpose, tensor))
       print(PolynomialTensor.apply(np.conjugate, 1j * tensor))
@@ -148,7 +148,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
     it needs to support more than 2-dimensional arrays, we rely on the
     `sparse <https://sparse.pydata.org/en/stable/index.html>`_ library.
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         import sparse as sp
 

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -310,7 +310,7 @@ class SpinOp(SparseLabelOp):
             # PERF: the following matrix unpacking is a performance bottleneck!
             # We could consider using Rust in the future to improve upon this.
 
-            mat = tensor[key].array
+            mat = tensor[key]
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*index)] = mat[index]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -304,12 +304,13 @@ class SpinOp(SparseLabelOp):
                 data[""] = cast(float, tensor[key])
                 continue
 
+            # TODO: extract label_template into Tensor class
             label_template = " ".join(f"{op}_{{}}" for op in key)
 
             # PERF: the following matrix unpacking is a performance bottleneck!
             # We could consider using Rust in the future to improve upon this.
 
-            mat = tensor[key]
+            mat = tensor[key].array
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*index)] = mat[index]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -61,7 +61,7 @@ class SpinOp(SparseLabelOp):
     A ``SpinOp`` is initialized with a dictionary, mapping terms to their respective
     coefficients. For example:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import SpinOp
 
@@ -72,7 +72,7 @@ class SpinOp(SparseLabelOp):
     are :math:`S^x, S^y, S^z` for spin 3/2 system.
     The two qutrit Heisenberg model with transverse magnetic field is
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         SpinOp({
                 "X_0 X_1": -1,
@@ -88,7 +88,7 @@ class SpinOp(SparseLabelOp):
 
     An example using labels with powers would be:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import SpinOp
 
@@ -99,7 +99,7 @@ class SpinOp(SparseLabelOp):
     If you have very restricted memory resources available, or would like to avoid the additional
     copy, the dictionary will be stored by reference if you disable ``copy`` like so:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         some_big_data = {
             "X_0 Y_0": 1.0,
@@ -133,25 +133,25 @@ class SpinOp(SparseLabelOp):
 
     Addition
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         SpinOp({"X_1": 1}, num_spins=2) + SpinOp({"X_0": 1}, num_spins=2)
 
     Sum
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         sum(SpinOp({label: 1}, num_spins=3) for label in ["X_0", "Z_1", "X_2 Z_2"])
 
     Scalar multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         0.5 * SpinOp({"X_1": 1}, num_spins=2)
 
     Operator multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         op1 = SpinOp({"X_0 Z_1": 1}, num_spins=2)
         op2 = SpinOp({"Z_0 X_0 X_1": 1}, num_spins=2)
@@ -159,14 +159,14 @@ class SpinOp(SparseLabelOp):
 
     Tensor multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         op = SpinOp({"X_0 Z_1": 1}, num_spins=2)
         print(op ^ op)
 
     Adjoint
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         SpinOp({"X_0 Z_1": 1j}, num_spins=2).adjoint()
 

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -1,0 +1,458 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tensor class"""
+
+from __future__ import annotations
+
+import math
+import string
+from numbers import Number
+from typing import Any, Sequence, Type, Union, cast
+
+import numpy as np
+from qiskit.quantum_info.operators.mixins import TolerancesMixin
+
+import qiskit_nature.optionals as _optionals
+
+if _optionals.HAS_SPARSE:
+    # pylint: disable=import-error
+    from sparse import COO, DOK, GCXS, SparseArray, zeros_like
+else:
+
+    def zeros_like(*args):
+        """Empty zeros_like function
+        Replacement if sparse.zeros_like is not present.
+        """
+        del args
+
+    class COO:  # type: ignore
+        """Empty COO class
+        Replacement if sparse.COO is not present.
+        """
+
+        pass
+
+    class DOK:  # type: ignore
+        """Empty DOK class
+        Replacement if sparse.DOK is not present.
+        """
+
+        pass
+
+    class GCXS:  # type: ignore
+        """Empty GCXS class
+        Replacement if sparse.GCXS is not present.
+        """
+
+        pass
+
+    class SparseArray:  # type: ignore
+        """Empty SparseArray class
+        Replacement if sparse.SparseArray is not present.
+        """
+
+        pass
+
+
+# pylint: disable=invalid-name
+ARRAY_TYPE = Union[np.ndarray, SparseArray]
+
+
+def _scalar_dunder(ufunc):
+    def func(self, *args, **kwargs):
+        if isinstance(self._array, Number):
+            return ufunc(self._array, *args, **kwargs)
+        raise TypeError()
+
+    func.__name__ = f"__{ufunc.__name__}__"
+    return func
+
+
+def _unpack_args(sequence: Sequence) -> Sequence[ARRAY_TYPE]:
+    """An internal utility to recursively unpack a sequence of array-like objects."""
+    seq: list[ARRAY_TYPE] = []
+    for obj in sequence:
+        if isinstance(obj, Sequence):
+            seq.append(_unpack_args(obj))
+        elif isinstance(obj, Tensor):
+            seq.append(obj.array)
+        else:
+            seq.append(obj)
+    return seq
+
+
+class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
+    """A tensor representation wrapping single numeric values, dense or sparse arrays.
+
+    This class is designed to unify the usage of tensors throughout the stack. It provides a central
+    entry point for the handling of arrays enabling seamless interchange of dense and sparse arrays
+    in any use-case. This is done by implementing this class as an ``np.ndarray`` container as
+    described `here <https://numpy.org/doc/stable/user/basics.dispatch.html>`_. At the same time
+    this class can also wrap a ``sparse.SparseArray`` (which in turn implements the ``np.ndarray``
+    interface).
+    """
+
+    def __init__(self, array: Number | ARRAY_TYPE | Tensor) -> None:
+        """
+        Args:
+            array: the wrapped array object. This can be any of the following objects:
+
+                :`numpy.ndarray`: a dense matrix
+                :`sparse.SparseArray`: a sparse matrix
+                :`numbers.Number`: any numeric singular value
+                :`Tensor`: another Tensor whose ``array`` attribute will be extracted
+        """
+        if isinstance(array, Tensor):
+            array = array._array
+
+        self._array: Number | ARRAY_TYPE = array
+
+    @property
+    def array(self) -> Number | ARRAY_TYPE:
+        """Returns the wrapped array object."""
+        return self._array
+
+    def __repr__(self) -> str:
+        return repr(self._array)
+
+    def __array__(self, dtype=None) -> ARRAY_TYPE:
+        """Makes this class behave like a numpy ndarray.
+
+        See also https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array__
+        """
+        if isinstance(self._array, Number):
+            return np.asarray(self._array, dtype=dtype)
+
+        if dtype is None:
+            return self._array
+
+        return self._array.astype(dtype=dtype)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Makes this class work with numpy ufuncs.
+
+        See also
+        https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_ufunc__
+        """
+        if method == "__call__":
+            new_inputs = []
+            for i in inputs:
+                if isinstance(i, self.__class__):
+                    new_inputs.append(i._array)
+                else:
+                    new_inputs.append(i)
+            return ufunc(*new_inputs, **kwargs)
+        else:
+            return NotImplemented
+
+    # pylint: disable=unused-argument
+    def __array_function__(self, func, types, args, kwargs):
+        """Another numpy function wrapper necessary for interoperability with numpy.
+
+        See also
+        https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_function__
+        """
+        new_args = _unpack_args(args)
+        return self.__array_wrap__(func(*new_args, **kwargs))
+
+    # pylint: disable=unused-argument
+    def __array_wrap__(self, array: ARRAY_TYPE, context=None) -> Tensor:
+        """Ensures the returned objects of a numpy function are wrapped again by this class.
+
+        See also
+        https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_wrap__
+        """
+        return self.__class__(array)
+
+    def __getattr__(self, name: str) -> Any:
+        array = self.__array__()
+        if hasattr(array, name):
+            # expose any attribute of the internally wrapped array object
+            return getattr(array, name)
+        return None
+
+    def __getitem__(self, key: Any) -> Any:
+        array = self.__array__()
+        if hasattr(array, "__getitem__"):
+            # expose any item of the internally wrapped array object
+            return array.__getitem__(key)
+        return None
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        array = self.__array__()
+        if hasattr(array, "__setitem__"):
+            # expose any item setting of the internally wrapped array object
+            array.__setitem__(key, value)
+
+    __int__ = _scalar_dunder(int)
+    __float__ = _scalar_dunder(float)
+    __complex__ = _scalar_dunder(complex)
+    __round__ = _scalar_dunder(round)
+    __trunc__ = _scalar_dunder(math.trunc)
+    __floor__ = _scalar_dunder(math.floor)
+    __ceil__ = _scalar_dunder(math.ceil)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Returns the shape of the wrapped array object.
+
+        If the internal object is a ``Number``, an empty tuple is returned (which is equivalent to
+        the result of ``numpy.asarray(number).shape``).
+        """
+        if isinstance(self._array, Number):
+            return ()
+
+        return self._array.shape
+
+    @property
+    def ndim(self) -> int:
+        """Returns the number of dimensions of the wrapped array object.
+
+        If the internal object is a ``Number``, 0 is returned (which is equivalent to the result of
+        ``numpy.asarray(number).ndim``).
+        """
+        if isinstance(self._array, Number):
+            return 0
+
+        return len(self._array.shape)
+
+    @_optionals.HAS_SPARSE.require_in_call
+    def is_sparse(self) -> bool:
+        """Returns whether this tensor is sparse."""
+        return isinstance(self._array, (SparseArray, Number))
+
+    def is_dense(self) -> bool:
+        """Returns whether this tensor is dense."""
+        return isinstance(self._array, (np.ndarray, Number))
+
+    # TODO: change the following type-hint if/when SparseArray dictates the existence of from_numpy
+    @_optionals.HAS_SPARSE.require_in_call
+    def to_sparse(self, *, sparse_type: Type[COO] | Type[DOK] | Type[GCXS] = COO) -> Tensor:
+        """Returns a new instance with the internal array converted to a sparse array.
+
+        If the instance on which this method was called already fulfilled this requirement, it is
+        returned unchanged.
+
+        Args:
+            sparse_type: the type to use for the conversion to sparse array. Note, that this will
+            only be applied if the wrapped array object was dense. Converting an already sparse
+            array to another sparse type needs to be done explicitly.
+
+        Returns:
+            A new ``Tensor`` with the internal array converted to the requested sparse array type.
+        """
+        if self.is_sparse():
+            return self
+
+        return self.__array_wrap__(sparse_type.from_numpy(self._array))
+
+    def to_dense(self) -> Tensor:
+        """Returns a new instance with the internal array converted to a dense numpy array.
+
+        If the instance on which this method was called already fulfilled this requirement, it is
+        returned unchanged.
+        """
+        if self.is_dense():
+            return self
+
+        return self.__array_wrap__(cast(SparseArray, self._array).todense())
+
+    # pylint: disable=too-many-return-statements
+    def __eq__(self, other: object) -> bool:
+        """Check equality of ``Tensor`` instances.
+
+        .. note::
+            This check only asserts the internal matrix elements for equivalence but ignores the
+            type of the matrices. As such, it will indicate equality of two ``Tensor`` instances
+            even if one contains sparse and the other dense numpy arrays, as long as their elements
+            are identical.
+
+        Args:
+            other: the second ``Tensor`` object to be compared with the first.
+
+        Returns:
+            True when the ``Tensor`` objects are equal, False when not.
+        """
+        if not isinstance(other, (Tensor, Number, np.ndarray, SparseArray)):
+            return False
+
+        value = Tensor(self)._array
+        other_value = Tensor(other)._array
+
+        self_is_sparse = isinstance(value, SparseArray)
+        other_is_sparse = isinstance(other_value, SparseArray)
+
+        if self_is_sparse:
+            if other_is_sparse:
+                if value.ndim != other_value.ndim:  # type: ignore[union-attr]
+                    return False
+                if value.nnz != other_value.nnz:  # type: ignore[union-attr]
+                    return False
+                if value.size != other_value.size:  # type: ignore[union-attr]
+                    return False
+                diff = value - other_value  # type: ignore[operator]
+                if diff.nnz != 0:
+                    return False
+                return True
+            value = value.todense()  # type: ignore[union-attr]
+        elif other_is_sparse:
+            other_value = cast(SparseArray, other_value).todense()
+
+        if not np.array_equal(value, other_value):  # type: ignore[arg-type]
+            return False
+
+        return True
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
+    def equiv(self, other: object) -> bool:
+        """Check equivalence of ``Tensor`` instances.
+
+        .. note::
+            This check only asserts the internal matrix elements for equivalence but ignores the
+            type of the matrices. As such, it will indicate equivalence of two ``Tensor`` instances
+            even if one contains sparse and the other dense numpy arrays, as long as their elements
+            match.
+
+        Args:
+            other: the second ``Tensor`` object to be compared with the first.
+
+        Returns:
+            True when the ``Tensor`` objects are equivalent, False when not.
+        """
+        if not isinstance(other, (Tensor, Number, np.ndarray, SparseArray)):
+            return False
+
+        value = Tensor(self)._array
+        other_value = Tensor(other)._array
+
+        self_is_sparse = isinstance(value, SparseArray)
+        other_is_sparse = isinstance(other_value, SparseArray)
+
+        if self_is_sparse:
+            if other_is_sparse:
+                if value.ndim != other_value.ndim:  # type: ignore[union-attr]
+                    return False
+                diff = (value - other_value).todense()  # type: ignore[operator]
+                if not np.allclose(
+                    diff,
+                    zeros_like(diff).todense(),
+                    atol=self.atol,
+                    rtol=self.rtol,
+                ):
+                    return False
+                return True
+            value = value.todense()  # type: ignore[union-attr]
+        elif other_is_sparse:
+            other_value = cast(SparseArray, other_value).todense()
+
+        if not np.allclose(value, other_value, atol=self.atol, rtol=self.rtol):  # type: ignore[arg-type]
+            return False
+
+        return True
+
+    def compose(self, other: Tensor, qargs: None = None, front: bool = False) -> Tensor:
+        r"""Returns the matrix multiplication with another ``Tensor``.
+
+        Args:
+            other: the other Tensor.
+            qargs: UNUSED.
+            front: If ``True``, composition uses right matrix multiplication, otherwise left
+                multiplication is used (the default).
+
+        Returns:
+            The tensor resulting from the composition.
+        """
+        a = self if front else other
+        b = other if front else self
+
+        a_is_number = isinstance(a._array, Number)
+        b_is_number = isinstance(b._array, Number)
+
+        if a_is_number:
+            if b_is_number:
+                return a.__class__(a._array * b._array)  # type: ignore[operator]
+
+            result = cast(ARRAY_TYPE, (a._array * b._array)).reshape(b.shape)  # type: ignore[operator]
+            return a.__class__(result)
+        elif b_is_number:
+            result = cast(ARRAY_TYPE, (b._array * a._array)).reshape(a.shape)  # type: ignore[operator]
+            return a.__class__(result)
+
+        return a.__class__(
+            np.outer(a._array, b._array).reshape(a.shape + b.shape)  # type: ignore[arg-type]
+        )
+
+    def tensor(self, other: Tensor) -> Tensor:
+        r"""Returns the tensor product with another ``Tensor``.
+
+        Args:
+            other: the other Tensor.
+
+        Returns:
+            The tensor resulting from the tensor product, :math:`self \otimes other`.
+
+        .. note::
+            Tensor uses reversed operator ordering to :meth:`expand`.
+            For two tensors of the same type ``a.tensor(b) = b.expand(a)``.
+        """
+        return self._tensor(self, other)
+
+    def expand(self, other: Tensor) -> Tensor:
+        r"""Returns the reverse-order tensor product with another ``Tensor``.
+
+        Args:
+            other: the other Tensor.
+
+        Returns:
+            The tensor resulting from the tensor product, :math:`other \otimes self`.
+
+        .. note::
+            Expand uses reversed operator ordering to :meth:`tensor`.
+            For two tensors of the same type ``a.expand(b) = b.tensor(a)``.
+        """
+        return self._tensor(other, self)
+
+    @classmethod
+    def _tensor(cls, a: Tensor, b: Tensor) -> Tensor:
+        # expand a-matrix into upper left sector
+        amat = cast(ARRAY_TYPE, a._array)
+        adim = len(a.shape)
+        aones = np.zeros((2,) * adim)
+        aones[(0,) * adim] = 1.0
+        amat = np.kron(aones, amat)
+        aeinsum = string.ascii_lowercase[:adim] if adim > 0 else ""
+
+        # expand b-matrix into lower right sector
+        bmat = cast(ARRAY_TYPE, b._array)
+        bdim = len(b.shape)
+        bones = np.zeros((2,) * bdim)
+        bones[(1,) * bdim] = 1.0
+        bmat = np.kron(bones, bmat)
+        beinsum = string.ascii_lowercase[-bdim:] if bdim > 0 else ""
+
+        make_sparse = False
+        if isinstance(amat, SparseArray):
+            # pylint: disable=no-member
+            amat = amat.todense()
+            make_sparse = True
+        if isinstance(bmat, SparseArray):
+            # pylint: disable=no-member
+            bmat = bmat.todense()
+            make_sparse = True
+        einsum = np.einsum(f"{aeinsum},{beinsum}", amat, bmat)
+        if make_sparse:
+            einsum = COO(einsum)
+
+        return cls(einsum)

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -49,7 +49,7 @@ class VibrationalOp(SparseLabelOp):
     A ``VibrationalOp`` is initialized with a dictionary, mapping terms to their respective
     coefficients:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import VibrationalOp
 
@@ -67,7 +67,7 @@ class VibrationalOp(SparseLabelOp):
     If you have very restricted memory resources available, or would like to avoid the additional
     copy, the dictionary will be stored by reference if you disable ``copy`` like so:
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         some_big_data = {
             "+_0_0 -_0_0": 1.0,
@@ -90,7 +90,7 @@ class VibrationalOp(SparseLabelOp):
     If :code:`num_modals` is not provided then the maximum :code:`modal_index` per
     mode will determine the :code:`num_modals` for that mode.
 
-    .. jupyter-execute::
+    .. code-block:: python
 
         from qiskit_nature.second_q.operators import VibrationalOp
 
@@ -112,25 +112,25 @@ class VibrationalOp(SparseLabelOp):
 
     Addition
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       VibrationalOp({"+_1_0": 1}, num_modals=[2, 2]) + VibrationalOp({"+_0_0": 1}, num_modals=[2, 2])
 
     Sum
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       sum(VibrationalOp({label: 1}, num_modals=[1, 1, 1]) for label in ["+_0_0", "-_1_0", "+_2_0 -_2_0"])
 
     Scalar multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       0.5 * VibrationalOp({"+_1_0": 1}, num_modals=[1, 1])
 
     Operator multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       op1 = VibrationalOp({"+_0_0 -_1_0": 1}, num_modals=[1, 1])
       op2 = VibrationalOp({"-_0_0 +_0_0 +_1_0": 1}, num_modals=[1, 1])
@@ -138,14 +138,14 @@ class VibrationalOp(SparseLabelOp):
 
     Tensor multiplication
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       op = VibrationalOp({"+_0_0 -_1_0": 1}, num_modals=[1, 1])
       print(op ^ op)
 
     Adjoint
 
-    .. jupyter-execute::
+    .. code-block:: python
 
       VibrationalOp({"+_0_0 -_1_0": 1j}, num_modals=[1, 1]).adjoint()
 

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -302,7 +302,7 @@ class VibrationalOp(SparseLabelOp):
             # TODO: extract label_template into Tensor class
             label_template = " ".join(f"{op}_{{}}_{{}}" for op in key.replace("_", ""))
 
-            mat = tensor[key].array
+            mat = tensor[key]
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*_reshape_index(index))] = mat[index]

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -299,9 +299,10 @@ class VibrationalOp(SparseLabelOp):
                 data[""] = cast(float, tensor[key])
                 continue
 
+            # TODO: extract label_template into Tensor class
             label_template = " ".join(f"{op}_{{}}_{{}}" for op in key.replace("_", ""))
 
-            mat = tensor[key]
+            mat = tensor[key].array
             if isinstance(mat, np.ndarray):
                 for index in np.ndindex(*mat.shape):
                     data[label_template.format(*_reshape_index(index))] = mat[index]

--- a/qiskit_nature/settings.py
+++ b/qiskit_nature/settings.py
@@ -12,6 +12,8 @@
 
 """Qiskit Nature Settings."""
 
+from __future__ import annotations
+
 import warnings
 
 
@@ -25,14 +27,15 @@ class QiskitNatureSettings:
     """Global settings for Qiskit Nature."""
 
     def __init__(self) -> None:
-        self._dict_aux_operators: bool = True
-        self._optimize_einsum: bool = True
-        self._deprecation_shown: bool = False
+        self._dict_aux_operators = True
+        self._optimize_einsum = True
+        self._deprecation_shown: set[str] = set()
+        self._tensor_wrapping = False
 
     @property
     def dict_aux_operators(self) -> bool:
         """Return whether `aux_operators` are dictionary- or list-based."""
-        if not self._dict_aux_operators and not self._deprecation_shown:
+        if not self._dict_aux_operators and "ListAuxOps" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=ListAuxOpsDeprecationWarning)
             warnings.warn(
                 ListAuxOpsDeprecationWarning(
@@ -44,14 +47,14 @@ class QiskitNatureSettings:
                 stacklevel=3,
             )
             warnings.filterwarnings("ignore", category=ListAuxOpsDeprecationWarning)
-            self._deprecation_shown = True
+            self._deprecation_shown.add("ListAuxOps")
 
         return self._dict_aux_operators
 
     @dict_aux_operators.setter
     def dict_aux_operators(self, dict_aux_operators: bool) -> None:
         """Set whether `aux_operators` are dictionary- or list-based."""
-        if not dict_aux_operators and not self._deprecation_shown:
+        if not dict_aux_operators and "ListAuxOps" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=ListAuxOpsDeprecationWarning)
             warnings.warn(
                 ListAuxOpsDeprecationWarning(
@@ -63,7 +66,7 @@ class QiskitNatureSettings:
                 stacklevel=3,
             )
             warnings.filterwarnings("ignore", category=ListAuxOpsDeprecationWarning)
-            self._deprecation_shown = True
+            self._deprecation_shown.add("ListAuxOps")
 
         self._dict_aux_operators = dict_aux_operators
 
@@ -84,6 +87,56 @@ class QiskitNatureSettings:
         https://numpy.org/doc/stable/reference/generated/numpy.einsum.html
         """
         self._optimize_einsum = optimize_einsum
+
+    @property
+    def tensor_wrapping(self) -> bool:
+        """Returns whether tensors in Nature should be wrapped.
+
+        More specifically, if this setting is enabled, tensors stored in a
+        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be wrapped into instances
+        of :class:`~qiskit_nature.second_q.operators.Tensor`.
+        """
+        if not self._tensor_wrapping and "Tensor" not in self._deprecation_shown:
+            warnings.filterwarnings("default", category=DeprecationWarning)
+            warnings.warn(
+                DeprecationWarning(
+                    "As of version 0.6.0 the use of unwrapped arrays in the `PolynomialTensor` is "
+                    "deprecated. No sooner that 3 months after this release, arrays will "
+                    "automatically be wrapped into `Tensor` classes if not already done so by the "
+                    "user. You can switch to the wrapping immediately, by setting "
+                    "`qiskit_nature.settings.tensor_wrapping` to `True`."
+                ),
+                stacklevel=3,
+            )
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self._deprecation_shown.add("Tensor")
+
+        return self._tensor_wrapping
+
+    @tensor_wrapping.setter
+    def tensor_wrapping(self, tensor_wrapping: bool) -> None:
+        """Returns whether tensors in Nature should be wrapped.
+
+        More specifically, if this setting is enabled, tensors stored in a
+        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be wrapped into instances
+        of :class:`~qiskit_nature.second_q.operators.Tensor`.
+        """
+        if not tensor_wrapping and "Tensor" not in self._deprecation_shown:
+            warnings.filterwarnings("default", category=DeprecationWarning)
+            warnings.warn(
+                DeprecationWarning(
+                    "As of version 0.6.0 the use of unwrapped arrays in the `PolynomialTensor` is "
+                    "deprecated. No sooner that 3 months after this release, arrays will "
+                    "automatically be wrapped into `Tensor` classes if not already done so by the "
+                    "user. You can switch to the wrapping immediately, by setting "
+                    "`qiskit_nature.settings.tensor_wrapping` to `True`."
+                ),
+                stacklevel=3,
+            )
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self._deprecation_shown.add("Tensor")
+
+        self._tensor_wrapping = tensor_wrapping
 
 
 settings = QiskitNatureSettings()

--- a/qiskit_nature/settings.py
+++ b/qiskit_nature/settings.py
@@ -30,7 +30,7 @@ class QiskitNatureSettings:
         self._dict_aux_operators = True
         self._optimize_einsum = True
         self._deprecation_shown: set[str] = set()
-        self._tensor_wrapping = False
+        self._tensor_unwrapping = True
 
     @property
     def dict_aux_operators(self) -> bool:
@@ -89,54 +89,58 @@ class QiskitNatureSettings:
         self._optimize_einsum = optimize_einsum
 
     @property
-    def tensor_wrapping(self) -> bool:
-        """Returns whether tensors in Nature should be wrapped.
+    def tensor_unwrapping(self) -> bool:
+        """Returns whether tensors inside the :class:`~.PolynomialTensor` should be unwrapped.
 
-        More specifically, if this setting is enabled, tensors stored in a
-        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be wrapped into instances
-        of :class:`~qiskit_nature.second_q.operators.Tensor`.
+        More specifically, if this setting is disabled, the tensor objects stored in a
+        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be of type
+        :class:`~qiskit_nature.second_q.operators.Tensor` when accessed via ``__getitem__``.
+        Otherwise, they will appear as the nested array object which may be of type
+        ``numpy.ndarray``, ``sparse.SparseArray`` or a plain ``Number``.
         """
-        if not self._tensor_wrapping and "Tensor" not in self._deprecation_shown:
+        if self._tensor_unwrapping and "Tensor" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
-                    "As of version 0.6.0 the use of unwrapped arrays in the `PolynomialTensor` is "
-                    "deprecated. No sooner that 3 months after this release, arrays will "
-                    "automatically be wrapped into `Tensor` classes if not already done so by the "
-                    "user. You can switch to the wrapping immediately, by setting "
-                    "`qiskit_nature.settings.tensor_wrapping` to `True`."
+                    "As of version 0.6.0 the return of unwrapped tensors in the "
+                    "`PolynomialTensor.__getitem__` method is deprecated. No sooner that 3 months "
+                    "after this release, arrays will always be returned as `Tensor` objects. You "
+                    "can switch to the new objects immediately, by setting "
+                    "`qiskit_nature.settings.tensor_unwrapping` to `False`."
                 ),
                 stacklevel=3,
             )
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("Tensor")
 
-        return self._tensor_wrapping
+        return self._tensor_unwrapping
 
-    @tensor_wrapping.setter
-    def tensor_wrapping(self, tensor_wrapping: bool) -> None:
-        """Returns whether tensors in Nature should be wrapped.
+    @tensor_unwrapping.setter
+    def tensor_unwrapping(self, tensor_unwrapping: bool) -> None:
+        """Returns whether tensors inside the :class:`~.PolynomialTensor` should be unwrapped.
 
-        More specifically, if this setting is enabled, tensors stored in a
-        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be wrapped into instances
-        of :class:`~qiskit_nature.second_q.operators.Tensor`.
+        More specifically, if this setting is disabled, the tensor objects stored in a
+        :class:`~qiskit_nature.second_q.operators.PolynomialTensor` will be of type
+        :class:`~qiskit_nature.second_q.operators.Tensor` when accessed via ``__getitem__``.
+        Otherwise, they will appear as the nested array object which may be of type
+        ``numpy.ndarray``, ``sparse.SparseArray`` or a plain ``Number``.
         """
-        if not tensor_wrapping and "Tensor" not in self._deprecation_shown:
+        if tensor_unwrapping and "Tensor" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
-                    "As of version 0.6.0 the use of unwrapped arrays in the `PolynomialTensor` is "
-                    "deprecated. No sooner that 3 months after this release, arrays will "
-                    "automatically be wrapped into `Tensor` classes if not already done so by the "
-                    "user. You can switch to the wrapping immediately, by setting "
-                    "`qiskit_nature.settings.tensor_wrapping` to `True`."
+                    "As of version 0.6.0 the return of unwrapped tensors in the "
+                    "`PolynomialTensor.__getitem__` method is deprecated. No sooner that 3 months "
+                    "after this release, arrays will always be returned as `Tensor` objects. You "
+                    "can switch to the new objects immediately, by setting "
+                    "`qiskit_nature.settings.tensor_unwrapping` to `False`."
                 ),
                 stacklevel=3,
             )
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("Tensor")
 
-        self._tensor_wrapping = tensor_wrapping
+        self._tensor_unwrapping = tensor_unwrapping
 
 
 settings = QiskitNatureSettings()

--- a/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
+++ b/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
@@ -5,14 +5,14 @@ features:
     internally to consistently deal with n-dimensional tensors throughout the
     stack.
   - |
-    Adds the new :attr:`~qiskit_nature.settings.tensor_wrapping` setting which
-    may be set to ``True`` to enable automatic wrapping of any n-dimensional
-    tensor stored inside a
-    :class:`~qiskit_nature.second_q.operators.PolynomialTensor` into a
-    :class:`~qiskit_nature.second_q.operators.Tensor` instance.
+    Adds the new :attr:`~qiskit_nature.settings.tensor_unwrapping` setting which
+    may be set to ``False`` to disable the unwrapping of internally created
+    :class:`~qiskit_nature.second_q.operators.Tensor` objects stored inside of a
+    :class:`~qiskit_nature.second_q.operators.PolynomialTensor`. See also
+    :attr:`~qiskit_nature.settings.tensor_unwrapping` for more details.
 deprecations:
   - |
-    Deprecated the default value (``False``) of
-    :attr:`~qiskit_nature.settings.tensor_wrapping` meaning that in the future
+    Deprecated the default value (``True``) of
+    :attr:`~qiskit_nature.settings.tensor_unwrapping` meaning that in the future
     :meth:`~qiskit_nature.second_q.operators.PolynomialTensor.__getitem__` will
     return objects of type :class:`~qiskit_nature.second_q.operators.Tensor`.

--- a/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
+++ b/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Adds the new :class:`~qiskit_nature.second_q.operators.Tensor` class used
+    internally to consistently deal with n-dimensional tensors throughout the
+    stack.
+  - |
+    Adds the new :attr:`~qiskit_nature.settings.tensor_wrapping` setting which
+    may be set to ``True`` to enable automatic wrapping of any n-dimensional
+    tensor stored inside a
+    :class:`~qiskit_nature.second_q.operators.PolynomialTensor` into a
+    :class:`~qiskit_nature.second_q.operators.Tensor` instance.
+deprecations:
+  - |
+    Deprecated the default value (``False``) of
+    :attr:`~qiskit_nature.settings.tensor_wrapping` meaning that in the future
+    :meth:`~qiskit_nature.second_q.operators.PolynomialTensor.__getitem__` will
+    return objects of type :class:`~qiskit_nature.second_q.operators.Tensor`.

--- a/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
+++ b/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
@@ -21,6 +21,7 @@ from qiskit.quantum_info import random_hermitian
 from qiskit_nature.second_q.hamiltonians import QuadraticHamiltonian
 from qiskit_nature.second_q.mappers import JordanWignerMapper, QubitConverter
 from qiskit_nature.second_q.operators import FermionicOp
+from qiskit_nature.settings import settings
 from qiskit_nature.testing import random_antisymmetric_matrix
 
 
@@ -245,15 +246,31 @@ class TestQuadraticHamiltonian(QiskitNatureTestCase):
         )
         self.assertEqual(quad_ham_scaled, expected)
 
-    def test_repr(self):
+    @data(True, False)
+    def test_repr(self, tensor_wrapping):
         """Test repr"""
-        quad_ham = QuadraticHamiltonian(
-            np.array([[1, 2j], [-2j, 3]]), np.array([[0, 4.0], [-4.0, 0]]), 5.0
-        )
-        self.assertEqual(
-            repr(quad_ham),
-            "QuadraticHamiltonian("
-            "hermitian_part=array([[ 1.+0.j,  0.+2.j],\n       [-0.-2.j,  3.+0.j]]), "
-            "antisymmetric_part=array([[ 0.,  4.],\n       [-4.,  0.]]), "
-            "constant=array(5.), num_modes=2)",
-        )
+        aux = settings.tensor_wrapping
+        try:
+            settings.tensor_wrapping = tensor_wrapping
+            quad_ham = QuadraticHamiltonian(
+                np.array([[1, 2j], [-2j, 3]]), np.array([[0, 4.0], [-4.0, 0]]), 5.0
+            )
+
+            if tensor_wrapping:
+                self.assertEqual(
+                    repr(quad_ham),
+                    "QuadraticHamiltonian("
+                    "hermitian_part=array([[ 1.+0.j,  0.+2.j],\n       [-0.-2.j,  3.+0.j]]), "
+                    "antisymmetric_part=array([[ 0.,  4.],\n       [-4.,  0.]]), "
+                    "constant=array(5.), num_modes=2)",
+                )
+            else:
+                self.assertEqual(
+                    repr(quad_ham),
+                    "QuadraticHamiltonian("
+                    "hermitian_part=array([[ 1.+0.j,  0.+2.j],\n       [-0.-2.j,  3.+0.j]]), "
+                    "antisymmetric_part=array([[ 0.,  4.],\n       [-4.,  0.]]), "
+                    "constant=5.0, num_modes=2)",
+                )
+        finally:
+            settings.tensor_wrapping = aux

--- a/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
+++ b/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
@@ -247,16 +247,16 @@ class TestQuadraticHamiltonian(QiskitNatureTestCase):
         self.assertEqual(quad_ham_scaled, expected)
 
     @data(True, False)
-    def test_repr(self, tensor_wrapping):
+    def test_repr(self, tensor_unwrapping):
         """Test repr"""
-        aux = settings.tensor_wrapping
+        aux = settings.tensor_unwrapping
         try:
-            settings.tensor_wrapping = tensor_wrapping
+            settings.tensor_unwrapping = tensor_unwrapping
             quad_ham = QuadraticHamiltonian(
                 np.array([[1, 2j], [-2j, 3]]), np.array([[0, 4.0], [-4.0, 0]]), 5.0
             )
 
-            if tensor_wrapping:
+            if not tensor_unwrapping:
                 self.assertEqual(
                     repr(quad_ham),
                     "QuadraticHamiltonian("
@@ -273,4 +273,4 @@ class TestQuadraticHamiltonian(QiskitNatureTestCase):
                     "constant=5.0, num_modes=2)",
                 )
         finally:
-            settings.tensor_wrapping = aux
+            settings.tensor_unwrapping = aux

--- a/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
+++ b/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -255,5 +255,5 @@ class TestQuadraticHamiltonian(QiskitNatureTestCase):
             "QuadraticHamiltonian("
             "hermitian_part=array([[ 1.+0.j,  0.+2.j],\n       [-0.-2.j,  3.+0.j]]), "
             "antisymmetric_part=array([[ 0.,  4.],\n       [-4.,  0.]]), "
-            "constant=5.0, num_modes=2)",
+            "constant=array(5.), num_modes=2)",
         )

--- a/test/second_q/operators/tensor_test_cases.py
+++ b/test/second_q/operators/tensor_test_cases.py
@@ -14,11 +14,9 @@
 
 from __future__ import annotations
 
-import math
 import unittest
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from numbers import Complex, Number
 
 import numpy as np
 
@@ -30,7 +28,7 @@ class ScalarTensorTestCase(ABC):
     """Tests for Tensor class wrapping a single numeric value."""
 
     tensor: Tensor
-    expected: Number
+    expected: np.ndarray
 
     @abstractmethod
     def subTest(self, msg, **kwargs):
@@ -55,7 +53,7 @@ class ScalarTensorTestCase(ABC):
 
     def test_array(self):
         """Test array property."""
-        self.assertTrue(isinstance(self.tensor.array, Number))
+        self.assertTrue(isinstance(self.tensor.array, type(self.expected)))
 
     def test_shape(self):
         """Test shape property."""
@@ -64,40 +62,6 @@ class ScalarTensorTestCase(ABC):
     def test_ndim(self):
         """Test ndim property."""
         self.assertEqual(self.tensor.ndim, 0)
-
-    def test_int(self):
-        """Test conversion to int."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(int(self.tensor), int(self.expected))
-
-    def test_float(self):
-        """Test conversion to float."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(float(self.tensor), float(self.expected))
-
-    def test_complex(self):
-        """Test conversion to complex."""
-        self.assertEqual(complex(self.tensor), complex(self.expected))
-
-    def test_round(self):
-        """Test rounding."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(round(self.tensor), round(self.expected))
-
-    def test_trunc(self):
-        """Test truncating."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(math.trunc(self.tensor), math.trunc(self.expected))
-
-    def test_floor(self):
-        """Test flooring."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(math.floor(self.tensor), math.floor(self.expected))
-
-    def test_ceil(self):
-        """Test ceiling."""
-        if not isinstance(self.expected, Complex):
-            self.assertEqual(math.ceil(self.tensor), math.ceil(self.expected))
 
     def test_equality(self):
         """Test equality check."""

--- a/test/second_q/operators/tensor_test_cases.py
+++ b/test/second_q/operators/tensor_test_cases.py
@@ -1,0 +1,327 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for Tensor class"""
+
+from __future__ import annotations
+
+import math
+import unittest
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from numbers import Complex, Number
+
+import numpy as np
+
+import qiskit_nature.optionals as _optionals
+from qiskit_nature.second_q.operators.tensor import ARRAY_TYPE, Tensor
+
+
+class ScalarTensorTestCase(ABC):
+    """Tests for Tensor class wrapping a single numeric value."""
+
+    tensor: Tensor
+    expected: Number
+
+    @abstractmethod
+    def subTest(self, msg, **kwargs):
+        # pylint: disable=invalid-name
+        """subtest"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertEqual(self, first, second, msg=None):
+        """assert equal"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertTrue(self, condition, msg=None):
+        """assert true"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertFalse(self, condition, msg=None):
+        """assert false"""
+        raise Exception("Abstract method")
+
+    def test_array(self):
+        """Test array property."""
+        self.assertTrue(isinstance(self.tensor.array, Number))
+
+    def test_shape(self):
+        """Test shape property."""
+        self.assertEqual(self.tensor.shape, ())
+
+    def test_ndim(self):
+        """Test ndim property."""
+        self.assertEqual(self.tensor.ndim, 0)
+
+    def test_int(self):
+        """Test conversion to int."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(int(self.tensor), int(self.expected))
+
+    def test_float(self):
+        """Test conversion to float."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(float(self.tensor), float(self.expected))
+
+    def test_complex(self):
+        """Test conversion to complex."""
+        self.assertEqual(complex(self.tensor), complex(self.expected))
+
+    def test_round(self):
+        """Test rounding."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(round(self.tensor), round(self.expected))
+
+    def test_trunc(self):
+        """Test truncating."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(math.trunc(self.tensor), math.trunc(self.expected))
+
+    def test_floor(self):
+        """Test flooring."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(math.floor(self.tensor), math.floor(self.expected))
+
+    def test_ceil(self):
+        """Test ceiling."""
+        if not isinstance(self.expected, Complex):
+            self.assertEqual(math.ceil(self.tensor), math.ceil(self.expected))
+
+    def test_equality(self):
+        """Test equality check."""
+        self.assertEqual(self.tensor, Tensor(self.expected))
+
+    def test_equivalence(self):
+        """Test equivalence check."""
+        self.assertTrue(self.tensor.equiv(Tensor(self.expected + 1e-8)))
+
+        with self.subTest("changing tolerances"):
+            self.assertTrue(self.tensor.equiv(Tensor(self.expected + 1e-8)))
+            prev_atol = Tensor.atol
+            prev_rtol = Tensor.rtol
+            Tensor.atol = 1e-10
+            Tensor.rtol = 1e-10
+            self.assertFalse(self.tensor.equiv(Tensor(self.expected + 1e-8)))
+            Tensor.atol = prev_atol
+            Tensor.rtol = prev_rtol
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
+    def test_is_sparse(self):
+        """Test sparsity check."""
+        self.assertTrue(self.tensor.is_sparse())
+
+    def test_is_dense(self):
+        """Test density check."""
+        self.assertTrue(self.tensor.is_dense())
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
+    def test_to_sparse(self):
+        """Test to sparse conversion."""
+        self.assertEqual(self.tensor.to_sparse(), self.tensor)
+
+    def test_to_dense(self):
+        """Test to dense conversion."""
+        self.assertEqual(self.tensor.to_dense(), self.tensor)
+
+    def test_add(self):
+        """Test addition."""
+        self.assertEqual(2 + self.tensor, 2 + self.expected)
+
+    def test_mul(self):
+        """Test scalar multiplication."""
+        self.assertEqual(2 * self.tensor, 2 * self.expected)
+
+    def test_compose(self):
+        """Test composition."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        with self.subTest("front=False"):
+            self.assertEqual(a.compose(b), 6 * self.expected**2)
+
+        with self.subTest("front=True"):
+            self.assertEqual(a.compose(b, front=True), 6 * self.expected**2)
+
+    def test_tensor(self):
+        """Test tensoring."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        self.assertEqual(a.tensor(b), 6 * self.expected**2)
+
+    def test_expand(self):
+        """Test expanding."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        self.assertEqual(a.expand(b), 6 * self.expected**2)
+
+
+class MatrixTensorTestCase(ABC):
+    """Tests for Tensor class wrapping a dense or sparse array."""
+
+    tensor: Tensor
+    expected: ARRAY_TYPE
+
+    @abstractmethod
+    def subTest(self, msg, **kwargs):
+        # pylint: disable=invalid-name
+        """subtest"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertEqual(self, first, second, msg=None):
+        """assert equal"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertTrue(self, condition, msg=None):
+        """assert true"""
+        raise Exception("Abstract method")
+
+    @abstractmethod
+    def assertFalse(self, condition, msg=None):
+        """assert false"""
+        raise Exception("Abstract method")
+
+    def test_array(self):
+        """Test array property."""
+        self.assertTrue(isinstance(self.tensor.array, type(self.expected)))
+
+    def test_shape(self):
+        """Test shape property."""
+        self.assertEqual(self.tensor.shape, self.expected.shape)
+
+    def test_ndim(self):
+        """Test ndim property."""
+        self.assertEqual(self.tensor.ndim, self.expected.ndim)
+
+    def test_equality(self):
+        """Test equality check."""
+        self.assertEqual(self.tensor, Tensor(self.expected))
+
+    def test_equivalence(self):
+        """Test equivalence check."""
+        slightly_different = deepcopy(self.expected)
+        slightly_different[0, 0] += 1e-8
+        self.assertTrue(self.tensor.equiv(Tensor(slightly_different)))
+
+        with self.subTest("changing tolerances"):
+            self.assertTrue(self.tensor.equiv(Tensor(slightly_different)))
+            prev_atol = Tensor.atol
+            prev_rtol = Tensor.rtol
+            Tensor.atol = 1e-10
+            Tensor.rtol = 1e-10
+            self.assertFalse(self.tensor.equiv(Tensor(slightly_different)))
+            Tensor.atol = prev_atol
+            Tensor.rtol = prev_rtol
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
+    def test_is_sparse(self):
+        """Test sparsity check."""
+        if isinstance(self.expected, np.ndarray):
+            self.assertFalse(self.tensor.is_sparse())
+        else:
+            self.assertTrue(self.tensor.is_sparse())
+
+    def test_is_dense(self):
+        """Test density check."""
+        if isinstance(self.expected, np.ndarray):
+            self.assertTrue(self.tensor.is_dense())
+        else:
+            self.assertFalse(self.tensor.is_dense())
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
+    def test_to_sparse(self):
+        """Test to sparse conversion."""
+        if isinstance(self.expected, np.ndarray):
+            # pylint: disable=import-error
+            import sparse as sp
+
+            self.assertEqual(self.tensor.to_sparse(), Tensor(sp.as_coo(self.expected)))
+        else:
+            self.assertEqual(self.tensor.to_sparse(), self.tensor)
+
+    def test_to_dense(self):
+        """Test to dense conversion."""
+        if isinstance(self.expected, np.ndarray):
+            self.assertEqual(self.tensor.to_dense(), self.tensor)
+        else:
+            self.assertEqual(self.tensor.to_dense(), Tensor(self.expected.todense()))
+
+    def test_add(self):
+        """Test addition."""
+        self.assertTrue(Tensor(self.tensor + self.tensor).equiv(Tensor(2 * self.expected)))
+
+    def test_mul(self):
+        """Test scalar multiplication."""
+        self.assertTrue(Tensor(2 * self.tensor).equiv(Tensor(2 * self.expected)))
+
+    def test_compose(self):
+        """Test composition."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        with self.subTest("front=False"):
+            expected = np.outer(2 * self.expected, 3 * self.expected).reshape((4, 4, 4, 4))
+            self.assertTrue(a.compose(b).equiv(Tensor(expected)))
+
+        with self.subTest("front=True"):
+            expected = np.outer(3 * self.expected, 2 * self.expected).reshape((4, 4, 4, 4))
+            self.assertTrue(a.compose(b).equiv(Tensor(expected)))
+
+    def test_tensor(self):
+        """Test tensoring."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        azeros = np.zeros((2, 2))
+        azeros[0, 0] = 1
+        amat = np.kron(azeros, 2 * self.expected)
+
+        bzeros = np.zeros((2, 2))
+        bzeros[1, 1] = 1
+        bmat = np.kron(bzeros, 3 * self.expected)
+
+        if isinstance(self.expected, np.ndarray):
+            expected = np.einsum("ab,ij", amat, bmat)
+        else:
+            expected = np.einsum(
+                "ab,ij", amat.todense(), bmat.todense()  # pylint: disable=no-member
+            )
+
+        self.assertTrue(a.tensor(b).equiv(Tensor(expected)))
+
+    def test_expand(self):
+        """Test expanding."""
+        a = Tensor(2 * self.tensor)
+        b = Tensor(3 * self.tensor)
+
+        azeros = np.zeros((2, 2))
+        azeros[0, 0] = 1
+        amat = np.kron(azeros, 3 * self.expected)
+
+        bzeros = np.zeros((2, 2))
+        bzeros[1, 1] = 1
+        bmat = np.kron(bzeros, 2 * self.expected)
+
+        if isinstance(self.expected, np.ndarray):
+            expected = np.einsum("ab,ij", amat, bmat)
+        else:
+            expected = np.einsum(
+                "ab,ij", amat.todense(), bmat.todense()  # pylint: disable=no-member
+            )
+
+        self.assertTrue(a.tensor(b).equiv(Tensor(expected)))

--- a/test/second_q/operators/test_fermionic_op.py
+++ b/test/second_q/operators/test_fermionic_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -573,7 +573,9 @@ class TestFermionicOp(QiskitNatureTestCase):
             )
             op = FermionicOp.from_polynomial_tensor(p_t)
 
-            self.assertEqual(op @ op, FermionicOp.from_polynomial_tensor(p_t @ p_t))
+            a = op @ op
+            b = FermionicOp.from_polynomial_tensor(p_t @ p_t)
+            self.assertEqual(a, b)
 
         with self.subTest("tensor operation order"):
             r_l = 2

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -21,7 +21,7 @@ import numpy as np
 from ddt import ddt, idata
 
 import qiskit_nature.optionals as _optionals
-from qiskit_nature.second_q.operators import PolynomialTensor
+from qiskit_nature.second_q.operators import PolynomialTensor, Tensor
 
 
 @ddt
@@ -294,9 +294,10 @@ class TestPolynomialTensor(QiskitNatureTestCase):
             expected["++--"][0, 0, 0, 1] += 1
             expected["++--"][1, 0, 2, 1] += 2
             self.assertEqual(result, PolynomialTensor(expected))
-            self.assertIsInstance(result["+"].array, np.ndarray)
-            self.assertIsInstance(result["+-"].array, np.ndarray)
-            self.assertIsInstance(result["++--"].array, np.ndarray)
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+            self.assertIsInstance(Tensor(result["+"]).array, np.ndarray)
+            self.assertIsInstance(Tensor(result["+-"]).array, np.ndarray)
+            self.assertIsInstance(Tensor(result["++--"]).array, np.ndarray)
 
         with self.subTest("sparse + sparse"):
             result = PolynomialTensor(self.sparse_1) + PolynomialTensor(self.sparse_2)
@@ -307,9 +308,10 @@ class TestPolynomialTensor(QiskitNatureTestCase):
                 "++--": sp.as_coo({(0, 0, 0, 1): 1, (0, 1, 0, 1): 1}, shape=(4, 4, 4, 4)),
             }
             self.assertEqual(result, PolynomialTensor(expected))
-            self.assertIsInstance(result["+"].array, sp.COO)
-            self.assertIsInstance(result["+-"].array, sp.COO)
-            self.assertIsInstance(result["++--"].array, sp.COO)
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+            self.assertIsInstance(Tensor(result["+"]).array, sp.COO)
+            self.assertIsInstance(Tensor(result["+-"]).array, sp.COO)
+            self.assertIsInstance(Tensor(result["++--"]).array, sp.COO)
 
         with self.assertRaisesRegex(
             TypeError, "Incorrect argument type: other should be PolynomialTensor"

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -294,7 +294,7 @@ class TestPolynomialTensor(QiskitNatureTestCase):
             expected["++--"][0, 0, 0, 1] += 1
             expected["++--"][1, 0, 2, 1] += 2
             self.assertEqual(result, PolynomialTensor(expected))
-            # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
             self.assertIsInstance(Tensor(result["+"]).array, np.ndarray)
             self.assertIsInstance(Tensor(result["+-"]).array, np.ndarray)
             self.assertIsInstance(Tensor(result["++--"]).array, np.ndarray)
@@ -308,7 +308,7 @@ class TestPolynomialTensor(QiskitNatureTestCase):
                 "++--": sp.as_coo({(0, 0, 0, 1): 1, (0, 1, 0, 1): 1}, shape=(4, 4, 4, 4)),
             }
             self.assertEqual(result, PolynomialTensor(expected))
-            # TODO: remove extra-wrapping of Tensor once settings.tensor_wrapping is removed
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
             self.assertIsInstance(Tensor(result["+"]).array, sp.COO)
             self.assertIsInstance(Tensor(result["+-"]).array, sp.COO)
             self.assertIsInstance(Tensor(result["++--"]).array, sp.COO)

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,8 +20,8 @@ from test import QiskitNatureTestCase
 import numpy as np
 from ddt import ddt, idata
 
-from qiskit_nature.second_q.operators import PolynomialTensor
 import qiskit_nature.optionals as _optionals
+from qiskit_nature.second_q.operators import PolynomialTensor
 
 
 @ddt
@@ -185,7 +185,7 @@ class TestPolynomialTensor(QiskitNatureTestCase):
         """Test for getting value matrices corresponding to keys in PolynomialTensor"""
         og_poly_tensor = PolynomialTensor(self.og_poly)
         for key, value in self.og_poly.items():
-            np.testing.assert_array_equal(value, og_poly_tensor[key])
+            np.testing.assert_array_almost_equal(value - og_poly_tensor[key], np.zeros_like(value))
 
     def test_len(self):
         """Test for the length of PolynomialTensor"""
@@ -294,9 +294,9 @@ class TestPolynomialTensor(QiskitNatureTestCase):
             expected["++--"][0, 0, 0, 1] += 1
             expected["++--"][1, 0, 2, 1] += 2
             self.assertEqual(result, PolynomialTensor(expected))
-            self.assertIsInstance(result["+"], np.ndarray)
-            self.assertIsInstance(result["+-"], np.ndarray)
-            self.assertIsInstance(result["++--"], np.ndarray)
+            self.assertIsInstance(result["+"].array, np.ndarray)
+            self.assertIsInstance(result["+-"].array, np.ndarray)
+            self.assertIsInstance(result["++--"].array, np.ndarray)
 
         with self.subTest("sparse + sparse"):
             result = PolynomialTensor(self.sparse_1) + PolynomialTensor(self.sparse_2)
@@ -307,9 +307,9 @@ class TestPolynomialTensor(QiskitNatureTestCase):
                 "++--": sp.as_coo({(0, 0, 0, 1): 1, (0, 1, 0, 1): 1}, shape=(4, 4, 4, 4)),
             }
             self.assertEqual(result, PolynomialTensor(expected))
-            self.assertIsInstance(result["+"], sp.COO)
-            self.assertIsInstance(result["+-"], sp.COO)
-            self.assertIsInstance(result["++--"], sp.COO)
+            self.assertIsInstance(result["+"].array, sp.COO)
+            self.assertIsInstance(result["+-"].array, sp.COO)
+            self.assertIsInstance(result["++--"].array, sp.COO)
 
         with self.assertRaisesRegex(
             TypeError, "Incorrect argument type: other should be PolynomialTensor"

--- a/test/second_q/operators/test_tensor.py
+++ b/test/second_q/operators/test_tensor.py
@@ -1,0 +1,92 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for Tensor class"""
+
+from __future__ import annotations
+
+import unittest
+from test import QiskitNatureTestCase
+
+import numpy as np
+
+import qiskit_nature.optionals as _optionals
+from qiskit_nature.second_q.operators import Tensor
+
+from .tensor_test_cases import MatrixTensorTestCase, ScalarTensorTestCase
+
+
+class TestIntTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with integer value."""
+
+    tensor = Tensor(1)
+    expected = 1  # type: ignore
+
+
+class TestFloatTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with float value."""
+
+    tensor = Tensor(1.0)
+    expected = 1.0  # type: ignore
+
+
+class TestComplexTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with complex value."""
+
+    tensor = Tensor(1.0j)
+    expected = 1.0j  # type: ignore
+
+
+class TestNumpyIntTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with numpy integer value."""
+
+    tensor = Tensor(np.int64(1))
+    expected = np.int64(1)  # type: ignore
+
+
+class TestNumpyFloatTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with numpy float value."""
+
+    tensor = Tensor(np.float64(1.0))
+    expected = np.float64(1.0)  # type: ignore
+
+
+class TestNumpyComplexTensor(QiskitNatureTestCase, ScalarTensorTestCase):
+    """Test numeric Tensor with numpy complex value."""
+
+    tensor = Tensor(np.complex128(1.0j))
+    expected = np.complex128(1.0j)  # type: ignore
+
+
+class TestNumpyTensor(QiskitNatureTestCase, MatrixTensorTestCase):
+    """TODO."""
+
+    tensor = Tensor(np.arange(1, 17, dtype=float).reshape((4, 4)))
+    expected = np.arange(1, 17, dtype=float).reshape((4, 4))
+
+
+@unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
+class TestSparseTensor(QiskitNatureTestCase, MatrixTensorTestCase):
+    """TODO."""
+
+    def setUp(self) -> None:
+        """TODO."""
+        super().setUp()
+        # pylint: disable=import-error
+        import sparse as sp
+
+        self.expected = sp.DOK.from_numpy(np.arange(1, 17, dtype=float).reshape((4, 4)))
+        self.tensor = Tensor(self.expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/second_q/operators/test_tensor.py
+++ b/test/second_q/operators/test_tensor.py
@@ -29,42 +29,42 @@ class TestIntTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with integer value."""
 
     tensor = Tensor(1)
-    expected = 1  # type: ignore
+    expected = np.array(1)
 
 
 class TestFloatTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with float value."""
 
     tensor = Tensor(1.0)
-    expected = 1.0  # type: ignore
+    expected = np.array(1.0)
 
 
 class TestComplexTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with complex value."""
 
     tensor = Tensor(1.0j)
-    expected = 1.0j  # type: ignore
+    expected = np.array(1.0j)
 
 
 class TestNumpyIntTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with numpy integer value."""
 
     tensor = Tensor(np.int64(1))
-    expected = np.int64(1)  # type: ignore
+    expected = np.array(np.int64(1))
 
 
 class TestNumpyFloatTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with numpy float value."""
 
     tensor = Tensor(np.float64(1.0))
-    expected = np.float64(1.0)  # type: ignore
+    expected = np.array(np.float64(1.0))
 
 
 class TestNumpyComplexTensor(QiskitNatureTestCase, ScalarTensorTestCase):
     """Test numeric Tensor with numpy complex value."""
 
     tensor = Tensor(np.complex128(1.0j))
-    expected = np.complex128(1.0j)  # type: ignore
+    expected = np.array(np.complex128(1.0j))
 
 
 class TestNumpyTensor(QiskitNatureTestCase, MatrixTensorTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This class is designed to unify the usage of tensors throught the stack. It provides a central entry point for the handling of arrays enabling seamless interchange of dense and sparse arrays in any usecase. This is done by implementing this class as an `np.ndarray` container as described [here](https://numpy.org/doc/stable/user/basics.dispatch.html). At the same time this class can also wrap a `sparse.SparseArray` (which in turn implements the `np.ndarray` interface).


### Details and comments

I have two major motivators for this proposal:
1. one is explained in more detail in #1032
2. the other one is the implementation of AO-symmetry aware storage containers for 2-body integrals. I already have some prototypes prepared offline which will allow us to handle 1-, 4- and 8-fold symmetric 2-body terms while they can pretend to be fully functional 4-D matrices for the purposes of expanding them into our Hamiltonian terms (WIP code available [here](https://github.com/mrossinek/qiskit-nature/blob/e7fa3cf998b0da64dc0ba4a9c9605edf44fb17a1/qiskit_nature/second_q/operators/symmetric_two_body.py)). These classes will also allow us to greatly simplify the logic in our FCIDump parser, effectively dealing with #933.