### PR TITLE
fix: enforce zero absolute tolerance in commutator routines

### DIFF
--- a/qiskit_nature/second_q/operators/commutators.py
+++ b/qiskit_nature/second_q/operators/commutators.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -45,7 +45,7 @@ def commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
     Returns:
         The computed commutator.
     """
-    return (op_a @ op_b - op_b @ op_a).simplify()
+    return (op_a @ op_b - op_b @ op_a).simplify(atol=0)
 
 
 def anti_commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
@@ -61,7 +61,7 @@ def anti_commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
     Returns:
         The computed anti-commutator.
     """
-    return (op_a @ op_b + op_b @ op_a).simplify()
+    return (op_a @ op_b + op_b @ op_a).simplify(atol=0)
 
 
 def double_commutator(
@@ -120,4 +120,4 @@ def double_commutator(
         + 0.5 * (-op_bac + sign_num * op_cab - op_acb + sign_num * op_bca)
     )
 
-    return res.simplify()
+    return res.simplify(atol=0)

--- a/releasenotes/notes/fix-commutator-simplification-tolerance-09c72ce1adc0bbf0.yaml
+++ b/releasenotes/notes/fix-commutator-simplification-tolerance-09c72ce1adc0bbf0.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The commutator methods like :meth:`~qiskit_nature.second_q.operators.commutators.commutator`,
+    :meth:`~qiskit_nature.second_q.operators.commutators.anti_commutator`, and
+    :meth:`~qiskit_nature.second_q.operators.commutators.double_commutator` no longer faultily
+    simplify the returned operator (i.e. the absolute tolerance during simplification is set to zero
+    instead of defaulting to ``SparseLabelOp.atol``).

--- a/releasenotes/notes/fix-commutator-simplification-tolerance-09c72ce1adc0bbf0.yaml
+++ b/releasenotes/notes/fix-commutator-simplification-tolerance-09c72ce1adc0bbf0.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    The commutator methods like :meth:`~qiskit_nature.second_q.operators.commutators.commutator`,
+    The commutator methods :meth:`~qiskit_nature.second_q.operators.commutators.commutator`,
     :meth:`~qiskit_nature.second_q.operators.commutators.anti_commutator`, and
     :meth:`~qiskit_nature.second_q.operators.commutators.double_commutator` no longer faultily
     simplify the returned operator (i.e. the absolute tolerance during simplification is set to zero

--- a/test/second_q/operators/test_commutators.py
+++ b/test/second_q/operators/test_commutators.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 import unittest
 from test import QiskitNatureTestCase
-from ddt import ddt, data, unpack
+
+from ddt import data, ddt, unpack
 
 from qiskit_nature.second_q.operators import FermionicOp
 from qiskit_nature.second_q.operators.commutators import (
-    commutator,
     anti_commutator,
+    commutator,
     double_commutator,
 )
 
@@ -45,6 +46,12 @@ class TestCommutators(QiskitNatureTestCase):
         """Test commutator method"""
         self.assertEqual(commutator(op_a, op_b), FermionicOp(expected, num_spin_orbitals=1))
 
+        with self.subTest("test simplfication tolerance"):
+            modified_op = op_a + FermionicOp({"+_0": 1e-10}, num_spin_orbitals=1)
+            self.assertNotEqual(
+                commutator(modified_op, op_b), FermionicOp(expected, num_spin_orbitals=1)
+            )
+
     @unpack
     @data(
         (op1, op2, {}),
@@ -53,6 +60,12 @@ class TestCommutators(QiskitNatureTestCase):
     def test_anti_commutator(self, op_a: FermionicOp, op_b: FermionicOp, expected: dict):
         """Test anti commutator method"""
         self.assertEqual(anti_commutator(op_a, op_b), FermionicOp(expected, num_spin_orbitals=1))
+
+        with self.subTest("test simplfication tolerance"):
+            modified_op = op_a + FermionicOp({"-_0": 1e-10}, num_spin_orbitals=1)
+            self.assertNotEqual(
+                anti_commutator(modified_op, op_b), FermionicOp(expected, num_spin_orbitals=1)
+            )
 
     @unpack
     @data(
@@ -72,6 +85,13 @@ class TestCommutators(QiskitNatureTestCase):
         self.assertEqual(
             double_commutator(op_a, op_b, op_c, sign), FermionicOp(expected, num_spin_orbitals=1)
         )
+
+        with self.subTest("test simplfication tolerance"):
+            modified_op = op_a + FermionicOp({"-_0": 1e-10}, num_spin_orbitals=1)
+            self.assertNotEqual(
+                double_commutator(modified_op, op_b, op_c, sign),
+                FermionicOp(expected, num_spin_orbitals=1),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Thanks to @ikkoham for spotting this [here](https://github.com/Qiskit/qiskit-nature/pull/1031#discussion_r1088531480)!

### Details and comments


