### PR TITLE
feat: implement the `InterleavedQubitMapper`

### DIFF
--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -38,6 +38,15 @@ FermionicOp Mappers
    JordanWignerMapper
    ParityMapper
 
+**Interleaved Qubit-Ordering:** If you want to generate qubit operators where the alpha-spin and
+beta-spin components are mapped to the qubit register in an interleaved (rather than the default
+blocked) order, you can use the following wrapper:
+
+.. autosummary::
+   :toctree: ../stubs/
+   :nosignatures:
+
+   InterleavedQubitMapper
 
 VibrationalOp Mappers
 +++++++++++++++++++++
@@ -83,6 +92,7 @@ from .qubit_converter import QubitConverter
 from .fermionic_mapper import FermionicMapper
 from .spin_mapper import SpinMapper
 from .vibrational_mapper import VibrationalMapper
+from .interleaved_qubit_mapper import InterleavedQubitMapper
 
 __all__ = [
     "BravyiKitaevMapper",
@@ -94,4 +104,5 @@ __all__ = [
     "LogarithmicMapper",
     "QubitConverter",
     "QubitMapper",
+    "InterleavedQubitMapper",
 ]

--- a/qiskit_nature/second_q/mappers/interleaved_qubit_mapper.py
+++ b/qiskit_nature/second_q/mappers/interleaved_qubit_mapper.py
@@ -1,0 +1,106 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A QubitMapper wrapper to transform from block-ordered to interleaved qubits."""
+
+from __future__ import annotations
+
+from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_nature.second_q.operators import FermionicOp
+
+from .fermionic_mapper import FermionicMapper
+
+
+class InterleavedQubitMapper(FermionicMapper):
+    """A ``FermionicMapper`` wrapper returning interleaved-ordered operators.
+
+    This class is intended to be used with fermionic systems. Furthermore, it is designed to work
+    with ``FermionicMapper`` classes which map fermionic operators to the qubit space by site
+    (unlike for example the :class:`~qiskit_nature.second_q.mappers.BravyiKitaevSuperFastMapper`
+    which maps by interactions).
+
+    .. warning::
+
+       The mapper will _not_ perform any assertions on the wrapped ``FermionicMapper``. Thus,
+       wrapping a :class:`~qiskit_nature.second_q.mappers.BravyiKitaevSuperFastMapper` is valid code
+       which will indeed produce qubit operators for you. You will just not be able to interpret the
+       order of the qubits in the same way.
+
+    For site-based mappers, Qiskit Nature always arranges the qubits corresponding to the alpha-spin
+    and beta-spin components in a blocked fashion. I.e. the first half of the qubit register
+    corresponds to the alpha-spin components, and the second half to the beta-spin one, like so:
+
+    .. code-block::
+
+       a1, a2, ..., aN, b1, b2, ..., bN
+
+    This class allows you to wrap such a ``FermionicMapper`` to produce qubit operators which have
+    an interleaved order of qubits, instead. Taking the example from before, the outcome will be the
+    following:
+
+    .. code-block::
+
+       a1, b1, a2, b2, ..., aN, bN
+
+    .. note::
+
+       This reordering is intended for an even total number of spin orbitals (i.e. the alpha-spin
+       and beta-spin components should be identical in length; which they usually are). However,
+       this is not asserted, so reordering a qubit operator label of odd length will still happen.
+
+    Here is a very simple usage example:
+
+    .. code-block:: python
+
+       from qiskit_nature.second_q.mappers import JordanWignerMapper, InterleavedQubitMapper
+       from qiskit_nature.second_q.operators import FermionicOp
+
+       blocked_mapper = JordanWignerMapper()
+       interleaved_mapper = InterleavedQubitMapper(blocked_mapper)
+
+       ferm_op = FermionicOp({"+_0 -_1": 1}, num_spin_orbitals=4)
+
+       blocked_op = blocked_mapper.map(ferm_op)
+       # SparsePauliOp(['IIXY', 'IIYY', 'IIXX', 'IIYX'], coeffs=[-0.25j, 0.25, 0.25, 0.25j])
+
+       print(interleaved_mapper.map(ferm_op))
+       # SparsePauliOp(['IXIY', 'IYIY', 'IXIX', 'IYIX'], coeffs=[-0.25j, 0.25, 0.25, 0.25j])
+
+    The following attributes can be set via the initializer but can also be read and updated once
+    the ``InterleavedQubitMapper`` object has been constructed.
+
+    Attributes:
+        mapper (FermionicMapper): the actual mapper for mapping from :class:`.FermionicOp` to qubit
+            operators.
+    """
+
+    def __init__(self, mapper: FermionicMapper):
+        """
+        Args:
+            mapper: the actual ``FermionicMapper`` mapping :class:`.FermionicOp` to qubit operators.
+        """
+        super().__init__(allows_two_qubit_reduction=mapper.allows_two_qubit_reduction)
+        self.mapper = mapper
+
+    def _map_single(self, second_q_op: FermionicOp) -> PauliSumOp:
+        blocked_op = self.mapper._map_single(second_q_op).primitive
+
+        def blocked_to_interleaved(label: str) -> str:
+            return label[::2] + label[1::2]
+
+        interleaved_op = SparsePauliOp.from_list(
+            [(blocked_to_interleaved(label), coeff) for label, coeff in blocked_op.to_list()]
+        )
+
+        return PauliSumOp(interleaved_op)

--- a/releasenotes/notes/feat-interleaved-qubit-mapper-1f04e5b12383386e.yaml
+++ b/releasenotes/notes/feat-interleaved-qubit-mapper-1f04e5b12383386e.yaml
@@ -1,0 +1,28 @@
+---
+features:
+  - |
+    Added the :class:`~qiskit_nature.second_q.mappers.InterleavedQubitMapper`
+    which allows wrapping of another ``FermionicMapper`` to produce qubit operators
+    where the alpha- and beta-spin components are arranged in the qubit register
+    in an interleaved rather than blocked order.
+
+    .. code-block:: python
+
+       from qiskit_nature.second_q.mappers import JordanWignerMapper, InterleavedQubitMapper
+       from qiskit_nature.second_q.operators import FermionicOp
+
+       blocked_mapper = JordanWignerMapper()
+       interleaved_mapper = InterleavedQubitMapper(blocked_mapper)
+
+       ferm_op = FermionicOp({"+_0 -_1": 1}, num_spin_orbitals=4)
+
+       blocked_op = blocked_mapper.map(ferm_op)
+       # SparsePauliOp(['IIXY', 'IIYY', 'IIXX', 'IIYX'], coeffs=[-0.25j, 0.25, 0.25, 0.25j])
+
+       print(interleaved_mapper.map(ferm_op))
+       # SparsePauliOp(['IXIY', 'IYIY', 'IXIX', 'IYIX'], coeffs=[-0.25j, 0.25, 0.25, 0.25j])
+
+    The example above extends naturally to work with any scenario in which a
+    ``FermionicMapper`` may be used like the construction of a
+    :class:`~qiskit_nature.second_q.circuit.library.HartreeFock` initial state
+    or :class:`~qiskit_nature.second_q.circuit.library.UCC` ansatz, for example.

--- a/test/second_q/mappers/test_interleaved_qubit_mapper.py
+++ b/test/second_q/mappers/test_interleaved_qubit_mapper.py
@@ -1,0 +1,44 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test InterleavedQubitMapper """
+
+import unittest
+from test import QiskitNatureTestCase
+
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_nature.second_q.mappers import InterleavedQubitMapper, JordanWignerMapper
+from qiskit_nature.second_q.operators import FermionicOp
+
+
+class TestInterleavedQubitMapper(QiskitNatureTestCase):
+    """Test InterleavedQubitMapper"""
+
+    def test_mapping(self) -> None:
+        """Test the actual mapping procedure."""
+        ferm_op = FermionicOp({"+_0 -_1": 1}, num_spin_orbitals=4)
+
+        interleaved_mapper = InterleavedQubitMapper(JordanWignerMapper())
+
+        qubit_op = interleaved_mapper.map(ferm_op).primitive
+
+        self.assertEqual(
+            qubit_op,
+            SparsePauliOp.from_list(
+                [("IXIY", -0.25j), ("IYIY", 0.25), ("IXIX", 0.25), ("IYIX", 0.25j)]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This implements an `InterleavedQubitMapper` which enables the generation of interleaved-ordered qubit operators.
It being a wrapper to another `QubitMapper`, means it can be straight forwardly used across the stack.

### Details and comments

Closes #918
