### PR TITLE
ci: fix requirement specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.23.*
+qiskit-terra>=0.23
 scipy>=1.4
 numpy>=1.17
 psutil>=5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Over the last weekend the CI started to fail what I can only describe as out of the blue...
The following error started to occur during the installation step of Qiskit Nature:
```
% pip install -e .
Obtaining file:///home/oss/Files/Dev/Qiskit/qiskit-nature/main
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in qiskit-nature setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          qiskit-terra>=0.23.*
                      ~~~~~~^
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip
```

I was able to reproduce this locally _withOUT_ any modifications to my environment. This is what astounds me the most...
It could be, that I updated some package last week without triggering a re-install (since I have editable installs) such that the upgrade at fault went by unnoticed though.

That said, changing the requirements to remove the `.*` suffix fixes the build for now.
We should investigate what exactly causes the issue though in order to avoid running into this again in the future.

### Details and comments


