### PR TITLE
fix: printing debye-dipole-moment

### DIFF
--- a/qiskit_nature/second_q/problems/electronic_structure_result.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_result.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/problems/electronic_structure_result.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_result.py
@@ -164,11 +164,7 @@ class ElectronicStructureResult(EigenstateResult):
         tdm = self.total_dipole_moment
         if tdm is None:
             return None
-        tdmd = []
-        for dip in tdm:
-            dipmd = dip / DEBYE
-            tdmd.append(dipmd)
-        return tdmd
+        return [dip / DEBYE if dip is not None else None for dip in tdm]
 
     @property
     def dipole_moment(self) -> Optional[List[DipoleTuple]]:

--- a/qiskit_nature/second_q/problems/electronic_structure_result.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_result.py
@@ -162,7 +162,13 @@ class ElectronicStructureResult(EigenstateResult):
     def total_dipole_moment_in_debye(self) -> Optional[List[float]]:
         """Returns total dipole of moment in Debye"""
         tdm = self.total_dipole_moment
-        return [dip / DEBYE if dip is not None else None for dip in tdm]
+        if tdm is None:
+            return None
+        tdmd = []
+        for dip in tdm:
+            dipmd = dip / DEBYE
+            tdmd.append(dipmd)
+        return tdmd
 
     @property
     def dipole_moment(self) -> Optional[List[DipoleTuple]]:

--- a/releasenotes/notes/fix-debye-dipole-0154e964da22910d.yaml
+++ b/releasenotes/notes/fix-debye-dipole-0154e964da22910d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug when printing the :attr:`~qiskit_nature.second_q.problems.ElectronicStructureResult.total_dipole_moment_in_debye` 

--- a/test/second_q/problems/test_electronic_structure_result.py
+++ b/test/second_q/problems/test_electronic_structure_result.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/problems/test_electronic_structure_result.py
+++ b/test/second_q/problems/test_electronic_structure_result.py
@@ -12,9 +12,9 @@
 
 """Tests for the ElectronicStructureResult."""
 
-import unittest
 import contextlib
 import io
+import unittest
 from itertools import zip_longest
 from test import QiskitNatureTestCase
 
@@ -79,6 +79,12 @@ class TestElectronicStructureResult(QiskitNatureTestCase):
                              (debye): [0.0  0.0  2.54174623+2.54174623j]  Total: 2.54174623+2.54174623j
         """
         self._assert_printed_result(res)
+
+    def test_print_debye_dipole(self):
+        """Test printing debye dipoles."""
+        res = ElectronicStructureResult()
+        res.computed_dipole_moment = None
+        self.assertIsNone(res.total_dipole_moment_in_debye)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I found a bug when printing the debye-dipole-moment. This fix has been discussed with @mrossinek. 


### Details and comments


