### PR TITLE
feat: adds the `Tensor.label_template` property

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -256,6 +256,7 @@ isospectral
 iswap
 isym
 iten
+iter
 iterable
 iteratively
 itertools

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -23,11 +23,11 @@ import numpy as np
 from scipy.sparse import csc_matrix
 
 from qiskit_nature.exceptions import QiskitNatureError
-import qiskit_nature.optionals as _optionals
 
 from ._bits_container import _BitsContainer
 from .polynomial_tensor import PolynomialTensor
 from .sparse_label_op import _TCoeff, SparseLabelOp, _to_number
+from .tensor import Tensor
 
 
 class FermionicOp(SparseLabelOp):
@@ -258,24 +258,17 @@ class FermionicOp(SparseLabelOp):
                 data[""] = cast(float, tensor[key])
                 continue
 
-            # TODO: extract label_template into Tensor class
-            label_template = " ".join(f"{op}_{{}}" for op in key)
-
-            # PERF: the following matrix unpacking is a performance bottleneck!
-            # We could consider using Rust in the future to improve upon this.
-
             mat = tensor[key]
-            if isinstance(mat, np.ndarray):
-                for index in np.ndindex(*mat.shape):
-                    data[label_template.format(*index)] = mat[index]
-            else:
-                _optionals.HAS_SPARSE.require_now("SparseArray")
-                import sparse as sp  # pylint: disable=import-error
 
-                if isinstance(mat, sp.SparseArray):
-                    coo = sp.as_coo(mat)
-                    for value, *index in zip(coo.data, *coo.coords):
-                        data[label_template.format(*index)] = value
+            if not isinstance(mat, Tensor):
+                # TODO: this case is to be removed once qiskit_nature.settings.tensor_unwrapping is
+                # deprecated and the PolynomialTensor item is guaranteed to be of type Tensor
+                mat = Tensor(mat)
+
+            label_template = mat.label_template.format(*key)
+
+            for value, index in mat.coord_iter():
+                data[label_template.format(*index)] = value
 
         return cls(data, copy=False, num_spin_orbitals=tensor.register_length).chop()
 

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -30,10 +30,10 @@ from functools import partial, reduce
 import numpy as np
 
 from qiskit_nature import QiskitNatureError
-import qiskit_nature.optionals as _optionals
 
 from .polynomial_tensor import PolynomialTensor
 from .sparse_label_op import _TCoeff, SparseLabelOp, _to_number
+from .tensor import Tensor
 
 
 class SpinOp(SparseLabelOp):
@@ -304,24 +304,17 @@ class SpinOp(SparseLabelOp):
                 data[""] = cast(float, tensor[key])
                 continue
 
-            # TODO: extract label_template into Tensor class
-            label_template = " ".join(f"{op}_{{}}" for op in key)
-
-            # PERF: the following matrix unpacking is a performance bottleneck!
-            # We could consider using Rust in the future to improve upon this.
-
             mat = tensor[key]
-            if isinstance(mat, np.ndarray):
-                for index in np.ndindex(*mat.shape):
-                    data[label_template.format(*index)] = mat[index]
-            else:
-                _optionals.HAS_SPARSE.require_now("SparseArray")
-                import sparse as sp  # pylint: disable=import-error
 
-                if isinstance(mat, sp.SparseArray):
-                    coo = sp.as_coo(mat)
-                    for value, *index in zip(coo.data, *coo.coords):
-                        data[label_template.format(*index)] = value
+            if not isinstance(mat, Tensor):
+                # TODO: this case is to be removed once qiskit_nature.settings.tensor_unwrapping is
+                # deprecated and the PolynomialTensor item is guaranteed to be of type Tensor
+                mat = Tensor(mat)
+
+            label_template = mat.label_template.format(*key)
+
+            for value, index in mat.coord_iter():
+                data[label_template.format(*index)] = value
 
         return cls(data, copy=False, num_spins=tensor.register_length).chop()
 

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -269,7 +269,7 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
 
            eri_chem = ...  # chemistry-ordered 2-body integrals (a 4-dimensional array)
            tensor = Tensor(eri_chem)
-           tensor.label_template = "+_{{0}}} +_{{2}} -_{{3}} -_{{1}}"
+           tensor.label_template = "+_{{0}} +_{{2}} -_{{3}} -_{{1}}"
            poly = PolynomialTensor({"++--": tensor})
            ferm_op_chem = FermionicOp.from_polynomial_tensor(poly)
 

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -307,6 +307,19 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
            ``sparse_label_template`` only unpacks one set of curly braces but does not actually
            inject anything into the template)
 
+        .. note::
+
+           You could have also used the following template: ``{}_{{0}} {}_{{2}} {}_{{3}} {}_{{1}}``.
+           This will work in the same way if the key under which your ``Tensor`` is stored inside of
+           the ``PolynomialTensor`` is ``++--``. We did not do this in the example above to show
+           that the number of replacement fields can be smaller than the number of arguments
+           provided during the formatting step, and to simplify the example a little bit.
+
+           However, if you were to try to use ``+_{0} +_{2} -_{3} -_{1}`` instead, this will **not**
+           work as intended because the both string formatting steps are applied unconditionally!
+           Thus, this wrong use case would in fact get expanded to ``+_+ +_- -_- -_+`` in the first
+           step of the processing leaving no replacement fields to be processed in the second step.
+
         .. _[1]: https://docs.python.org/3/library/string.html#formatstrings
         """
         if self._label_template is None:

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -107,7 +107,8 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
                 :`Tensor`: another Tensor whose ``array`` attribute will be extracted
             label_template: the template string used during the translation procedure implemented in
                 :meth:`.SparseLabelOp.from_polynomial_tensor`. When ``None``, this will fall back to
-                the default template string documented separately for the :attr:`label_template`.
+                the default template string - see the :attr:`label_template` property for more
+                information.
         """
         if isinstance(array, Tensor):
             array = array._array
@@ -206,14 +207,18 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         r"""The template string used during the translation implemented in
         :meth:`.SparseLabelOp.from_polynomial_tensor`.
 
-        If no custom template is provided, all instances of ``Tensor`` will resort to the default
-        template. This template depends on the dimension of the wrapped matrix. It will repeat
-        ``{}_{{}}`` for every dimension. This is explained best with an example:
+        If the ``label_template`` is set to ``None`` (the default value) during initialization of a
+        ``Tensor`` instance, this value will be substituted by the internal default template. Its
+        value depends on the dimension of the wrapped matrix: it will repeat ``{}_{{}}`` for every
+        dimension (independent of its size). This is explained best with an example:
 
         .. code-block:: python
 
-            print(Tensor(np.eye(2)).label_template)
+            print(Tensor(np.eye(4)).label_template)
             # "{}_{{}} {}_{{}}"
+
+            print(Tensor(np.ones((3, 1, 2)).label_template)
+            # "{}_{{}} {}_{{}} {}_{{}}"
 
             print(Tensor(np.ones((2, 2, 2, 2)).label_template)
             # "{}_{{}} {}_{{}} {}_{{}} {}_{{}}"
@@ -472,9 +477,9 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         """
         if self._label_template is not None or other._label_template is not None:
             raise NotImplementedError(
-                "Composing Tensor objects with label_template attributes other than None is not "
-                "implemented. Instead, construct the desired matrix manually and wrap it into a "
-                "new Tensor instance with the desired label_template."
+                "Composing Tensor objects with label_template attributes other than the default "
+                "value of None is not implemented. Instead, construct the desired matrix manually "
+                "and wrap it into a new Tensor instance with the desired label_template."
             )
 
         a = self if front else other
@@ -501,9 +506,9 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         """
         if self._label_template is not None or other._label_template is not None:
             raise NotImplementedError(
-                "Tensoring Tensor objects with label_template attributes other than None is not "
-                "implemented. Instead, construct the desired matrix manually and wrap it into a "
-                "new Tensor instance with the desired label_template."
+                "Tensoring Tensor objects with label_template attributes other than the default "
+                "value of None is not implemented. Instead, construct the desired matrix manually "
+                "and wrap it into a new Tensor instance with the desired label_template."
             )
 
         return self._tensor(self, other)
@@ -527,9 +532,9 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         """
         if self._label_template is not None or other._label_template is not None:
             raise NotImplementedError(
-                "Expanding Tensor objects with label_template attributes other than None is not "
-                "implemented. Instead, construct the desired matrix manually and wrap it into a "
-                "new Tensor instance with the desired label_template."
+                "Expanding Tensor objects with label_template attributes other than the default "
+                "value of None is not implemented. Instead, construct the desired matrix manually "
+                "and wrap it into a new Tensor instance with the desired label_template."
             )
 
         return self._tensor(other, self)

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -203,12 +203,12 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
 
     @property
     def label_template(self) -> str:
-        """The template string used during the translation implemented in
+        r"""The template string used during the translation implemented in
         :meth:`.SparseLabelOp.from_polynomial_tensor`.
 
-        If no custom template is provided, all instances of``Tensor``will resort to the default template. This template
-        depends on the dimension of the wrapped matrix. It will repeat ``{}_{{}}`` for every
-        dimension. This is explained best with an example:
+        If no custom template is provided, all instances of ``Tensor`` will resort to the default
+        template. This template depends on the dimension of the wrapped matrix. It will repeat
+        ``{}_{{}}`` for every dimension. This is explained best with an example:
 
         .. code-block:: python
 
@@ -218,10 +218,10 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
             print(Tensor(np.ones((2, 2, 2, 2)).label_template)
             # "{}_{{}} {}_{{}} {}_{{}} {}_{{}}"
 
-        The format of this template allows to construct a :class:`.SparseLabelOp` from the``Tensor``\s stored  
-        in a :class:`.PolynomialTensor`. This operation is performed when calling
-        :meth:`.SparseLabelOp.from_polynomial_tensor`. There, the template is processed in two
-        steps:
+        The format of this template allows to construct a :class:`.SparseLabelOp` from the
+        ``Tensor``\s stored in a :class:`.PolynomialTensor`. This operation is performed when
+        calling :meth:`.SparseLabelOp.from_polynomial_tensor`. There, the template is processed in
+        two steps:
 
         1. First, the template is formatted using the key under which the ``Tensor`` object was
            stored inside of the :class:`.PolynomialTensor` object. For example:
@@ -263,18 +263,6 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         allows you to modify how the ``Tensor`` objects stored inside a :class:`.PolynomialTensor`
         are processed when they are being translated into a :class:`.SparseLabelOp`.
 
-        .. note::
-
-           The string formatting in Python is a very powerful tool `[1]`_. Note, that in the use
-           case here, we only ever supply positional arguments in the ``.format(...)`` calls which
-           means that you cannot use names to identify replacement fields in your label templates.
-           However, you can modify their replacement order using numeric values (like shown below).
-
-           Another detail to keep in mind, is that the number of replacement fields may _not_ exceed
-           the number of arguments provided to the ``.format(...)`` call. However, the number of
-           arguments _can_ exceed the number of replacement fields in your template (this will not
-           cause any errors).
-
         Here is a concrete example which enables you to use chemistry-ordered two-body terms:
 
         .. code-block:: python
@@ -294,7 +282,19 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
 
            print(ferm_op_chem.equiv(ferm_op_phys))  # True
 
-        Note, that in the example above we made use of both previously noted features:
+        .. note::
+
+           The string formatting in Python is a very powerful tool `[1]`_. Note, that in the use
+           case here, we only ever supply positional arguments in the ``.format(...)`` calls which
+           means that you cannot use names to identify replacement fields in your label templates.
+           However, you can modify their replacement order using numeric values (like shown below).
+
+           Another detail to keep in mind, is that the number of replacement fields may _not_ exceed
+           the number of arguments provided to the ``.format(...)`` call. However, the number of
+           arguments _can_ exceed the number of replacement fields in your template (this will not
+           cause any errors).
+
+        Both of those noted features were actually used in the example provided above:
 
         1. a custom ordering of the replacement fields in our template string
         2. a smaller number of replacement fields than arguments (because we already hard-coded the

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -206,7 +206,7 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
         """The template string used during the translation implemented in
         :meth:`.SparseLabelOp.from_polynomial_tensor`.
 
-        By default, any ``Tensor`` instance will return the same string here. This returned template
+        If no custom template is provided, all instances of``Tensor``will resort to the default template. This template
         depends on the dimension of the wrapped matrix. It will repeat ``{}_{{}}`` for every
         dimension. This is explained best with an example:
 
@@ -218,7 +218,8 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
             print(Tensor(np.ones((2, 2, 2, 2)).label_template)
             # "{}_{{}} {}_{{}} {}_{{}} {}_{{}}"
 
-        The format of this template only makes sense in the context of what is done inside of
+        The format of this template allows to construct a :class:`.SparseLabelOp` from the``Tensor``\s stored  
+        in a :class:`.PolynomialTensor`. This operation is performed when calling
         :meth:`.SparseLabelOp.from_polynomial_tensor`. There, the template is processed in two
         steps:
 

--- a/qiskit_nature/second_q/operators/tensor.py
+++ b/qiskit_nature/second_q/operators/tensor.py
@@ -225,8 +225,8 @@ class Tensor(np.lib.mixins.NDArrayOperatorsMixin, TolerancesMixin):
 
         The format of this template allows to construct a :class:`.SparseLabelOp` from the
         ``Tensor``\s stored in a :class:`.PolynomialTensor`. This operation is performed when
-        calling :meth:`.SparseLabelOp.from_polynomial_tensor`. There, the template is processed in
-        two steps:
+        calling :meth:`.SparseLabelOp.from_polynomial_tensor`. There, the template is processed
+        using the Python string formatter in two steps:
 
         1. First, the template is formatted using the key under which the ``Tensor`` object was
            stored inside of the :class:`.PolynomialTensor` object. For example:

--- a/qiskit_nature/second_q/operators/vibrational_integrals.py
+++ b/qiskit_nature/second_q/operators/vibrational_integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,6 +19,7 @@ from typing import Mapping
 import qiskit_nature.optionals as _optionals
 
 from .polynomial_tensor import PolynomialTensor
+from .tensor import Tensor
 
 if _optionals.HAS_SPARSE:
     # pylint: disable=import-error
@@ -64,8 +65,9 @@ class VibrationalIntegrals(PolynomialTensor):
         max_n_body = max(len(key) for key in integrals) // 3
         ret = cls(
             {
-                ("_+-" * n_body): as_coo(
-                    {k: v for k, v in integrals.items() if len(k) == 3 * n_body}
+                ("_+-" * n_body): Tensor(
+                    as_coo({k: v for k, v in integrals.items() if len(k) == 3 * n_body}),
+                    label_template=" ".join(["{}_{{}}_{{}}"] * n_body * 2),
                 )
                 for n_body in range(1, max_n_body + 1)
             },

--- a/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
+++ b/releasenotes/notes/feat-tensor-class-2ad38ba7246ccbd5.yaml
@@ -3,7 +3,10 @@ features:
   - |
     Adds the new :class:`~qiskit_nature.second_q.operators.Tensor` class used
     internally to consistently deal with n-dimensional tensors throughout the
-    stack.
+    stack. This class also exposes the
+    :attr:`~qiskit_nature.second_q.operators.Tensor.label_template` which allows
+    an end-user to influence the translation procedure implemented in
+    :meth:`~qiskit_nature.second_q.operators.SparseLabelOp.from_polynomial_tensor`.
   - |
     Adds the new :attr:`~qiskit_nature.settings.tensor_unwrapping` setting which
     may be set to ``False`` to disable the unwrapping of internally created

--- a/test/second_q/operators/tensor_test_cases.py
+++ b/test/second_q/operators/tensor_test_cases.py
@@ -132,6 +132,10 @@ class ScalarTensorTestCase(ABC):
 
         self.assertEqual(a.expand(b), 6 * self.expected**2)
 
+    def test_coord_iter(self):
+        """Test iterating."""
+        self.assertEqual(list(self.tensor.coord_iter()), [(self.expected.item(), tuple())])
+
 
 class MatrixTensorTestCase(ABC):
     """Tests for Tensor class wrapping a dense or sparse array."""
@@ -289,3 +293,8 @@ class MatrixTensorTestCase(ABC):
             )
 
         self.assertTrue(a.tensor(b).equiv(Tensor(expected)))
+
+    def test_coord_iter(self):
+        """Test iterating."""
+        for value, index in self.tensor.coord_iter():
+            self.assertEqual(value, self.expected[index])

--- a/test/second_q/operators/test_tensor.py
+++ b/test/second_q/operators/test_tensor.py
@@ -20,7 +20,12 @@ from test import QiskitNatureTestCase
 import numpy as np
 
 import qiskit_nature.optionals as _optionals
-from qiskit_nature.second_q.operators import Tensor
+from qiskit_nature.second_q.operators import FermionicOp, PolynomialTensor, Tensor
+from qiskit_nature.second_q.operators.tensor_ordering import (
+    IndexType,
+    find_index_order,
+    to_physicist_ordering,
+)
 
 from .tensor_test_cases import MatrixTensorTestCase, ScalarTensorTestCase
 
@@ -68,7 +73,7 @@ class TestNumpyComplexTensor(QiskitNatureTestCase, ScalarTensorTestCase):
 
 
 class TestNumpyTensor(QiskitNatureTestCase, MatrixTensorTestCase):
-    """TODO."""
+    """Test a dense Tensor."""
 
     tensor = Tensor(np.arange(1, 17, dtype=float).reshape((4, 4)))
     expected = np.arange(1, 17, dtype=float).reshape((4, 4))
@@ -76,16 +81,48 @@ class TestNumpyTensor(QiskitNatureTestCase, MatrixTensorTestCase):
 
 @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
 class TestSparseTensor(QiskitNatureTestCase, MatrixTensorTestCase):
-    """TODO."""
+    """Test a sparse Tensor."""
 
     def setUp(self) -> None:
-        """TODO."""
         super().setUp()
         # pylint: disable=import-error
         import sparse as sp
 
         self.expected = sp.DOK.from_numpy(np.arange(1, 17, dtype=float).reshape((4, 4)))
         self.tensor = Tensor(self.expected)
+
+
+class TestChemOrdered2Body(QiskitNatureTestCase):
+    """Tests the ``Tensor.label_template`` mechanics."""
+
+    def test_chem_eri(self):
+        """This test mirrors the example from the docstring of that attribute and, thus, ensures
+        that chemistry-ordered 2-body electronic integrals do in fact work as advertised.
+        """
+        chem_eri = np.asarray(
+            [
+                [
+                    [[0.77460594, 0.44744572], [0.44744572, 0.57187698]],
+                    [[0.44744572, 0.3009177], [0.3009177, 0.44744572]],
+                ],
+                [
+                    [[0.44744572, 0.3009177], [0.3009177, 0.44744572]],
+                    [[0.57187698, 0.44744572], [0.44744572, 0.77460594]],
+                ],
+            ]
+        )
+        self.assertEqual(find_index_order(chem_eri), IndexType.CHEMIST)
+
+        chem_tensor = Tensor(chem_eri)
+        chem_tensor.label_template = "+_{{0}} +_{{2}} -_{{3}} -_{{1}}"
+
+        chem_op = FermionicOp.from_polynomial_tensor(PolynomialTensor({"++--": chem_tensor}))
+
+        phys_eri = to_physicist_ordering(chem_eri)
+
+        phys_op = FermionicOp.from_polynomial_tensor(PolynomialTensor({"++--": phys_eri}))
+
+        self.assertTrue(chem_op.equiv(phys_op))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR implements #1032. The idea is that the `label_template` which was previously hard-coded into the various `SparseLabelOp.from_polynomial_tensor` implementations gets exposes as part of the `Tensor` API. This allows an advanced user to take more influence on the mapping procedure as it enables the use of chemistry-ordered 2-body terms (see example in the docstring) and it will also enable the integration of symmetry-reduced or low-rank integral containers (see also #1032).

### Details and comments

- this PR also fixes #1059 
- this PR does _not_ come with a separate release note, because the `Tensor` class has not been released yet and is already covered in a previous release note more generally. That release note has been updated to note this additional label template capability.
