### PR TITLE
Fixing Typo on Line 73

### DIFF
--- a/docs/migration/00a_Solving_problems_with_v0.5.ipynb
+++ b/docs/migration/00a_Solving_problems_with_v0.5.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "We have been consistently describing the number of orbitals via `num_spin_orbitals` throughout the package. However, what this oftentimes implied (without rigorous checks) was that an **even** number was supplied, since the number of spin orbitals was assumed to equal twice the number of **spatial** orbitals.\n",
     "\n",
-    "To be more rigorous and avoid the ill-defined behavior when providing _odd_ numbers for `num_spin_orbitals`, we have switch the entire stack to use `num_spatial_orbitals` instead. This is well defined for any positive integer value (and negative values are guarded against).\n",
+    "To be more rigorous and avoid the ill-defined behavior when providing _odd_ numbers for `num_spin_orbitals`, we have switched the entire stack to use `num_spatial_orbitals` instead. This is well defined for any positive integer value (and negative values are guarded against).\n",
     "\n",
     "What this means for you in practice, is that whenever you supply the `num_spin_orbitals` manually in the past, you now need to supply **half the value** to represent the `num_spatial_orbitals`."
    ]


### PR DESCRIPTION
I am part of the Qiskit German translation team and noticed the typo here: "we have switch the entire stack to use `num_spatial_orbitals` instead." This needs to be changed as follows "we have switched the entire stack to use `num_spatial_orbitals` instead.".

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


