### PR TITLE
Adds symmetry-reduced two-body electronic integral utilities

### DIFF
--- a/docs/apidocs/qiskit_nature.second_q.operators.symmetric_two_body.rst
+++ b/docs/apidocs/qiskit_nature.second_q.operators.symmetric_two_body.rst
@@ -1,0 +1,7 @@
+.. _qiskit_nature-second_q-operators-symmetric_two_body:
+
+
+.. automodule:: qiskit_nature.second_q.operators.symmetric_two_body
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_nature/second_q/hamiltonians/electronic_energy.py
+++ b/qiskit_nature/second_q/hamiltonians/electronic_energy.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,7 +20,12 @@ from typing import MutableMapping
 import numpy as np
 
 import qiskit_nature  # pylint: disable=unused-import
-from qiskit_nature.second_q.operators import ElectronicIntegrals, FermionicOp, PolynomialTensor
+from qiskit_nature.second_q.operators import (
+    ElectronicIntegrals,
+    FermionicOp,
+    PolynomialTensor,
+    Tensor,
+)
 
 from .hamiltonian import Hamiltonian
 
@@ -218,21 +223,32 @@ class ElectronicEnergy(Hamiltonian):
 
         Returns:
             The Coulomb operator coefficients.
+
+        Raises:
+            NotImplementedError: when encountering :class:`.SymmetricTwoBodyIntegrals` inside of
+                :attr:`.ElectronicEnergy.electronic_integrals`.
         """
+        two_body_aa = self.electronic_integrals.alpha.get("++--", None)
+        # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
+        if not isinstance(two_body_aa, Tensor):
+            two_body_aa = Tensor(two_body_aa)
+
+        einsum = f"{''.join(two_body_aa._reverse_label_template('pqrs'))},ps->qr"
         coulomb = ElectronicIntegrals.einsum(
-            {"pqrs,ps->qr": ("++--", "+-", "+-")}, self.electronic_integrals, density
+            {einsum: ("++--", "+-", "+-")}, self.electronic_integrals, density
         )
 
         if self.electronic_integrals.beta_alpha.is_empty():
             coulomb *= 2.0  # type: ignore
         else:
             coulomb.alpha += PolynomialTensor.einsum(
-                {"pqrs,ps->qr": ("++--", "+-", "+-")},
+                {einsum: ("++--", "+-", "+-")},
                 self.electronic_integrals.beta_alpha,
                 density.beta,
             )
+            einsum = einsum[2:4] + einsum[:2] + einsum[4:]
             coulomb.beta += PolynomialTensor.einsum(
-                {"rspq,ps->rq": ("++--", "+-", "+-")},
+                {einsum: ("++--", "+-", "+-")},
                 self.electronic_integrals.beta_alpha,
                 density.alpha,
             )
@@ -250,9 +266,19 @@ class ElectronicEnergy(Hamiltonian):
 
         Returns:
             The Exchange operator coefficients.
+
+        Raises:
+            NotImplementedError: when encountering :class:`.SymmetricTwoBodyIntegrals` inside of
+                :attr:`.ElectronicEnergy.electronic_integrals`.
         """
+        two_body_aa = self.electronic_integrals.alpha.get("++--", None)
+        # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
+        if not isinstance(two_body_aa, Tensor):
+            two_body_aa = Tensor(two_body_aa)
+
+        einsum = f"{''.join(two_body_aa._reverse_label_template('pqrs'))},qs->pr"
         exchange = ElectronicIntegrals.einsum(
-            {"pqrs,qs->pr": ("++--", "+-", "+-")}, self.electronic_integrals, density
+            {einsum: ("++--", "+-", "+-")}, self.electronic_integrals, density
         )
         return exchange
 

--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -37,6 +37,7 @@ Modules
    :toctree:
 
    tensor_ordering
+   symmetric_two_body
    commutators
 """
 

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from numbers import Number
-from typing import cast
+from typing import Tuple, cast
 
 import numpy as np
 
@@ -26,6 +26,7 @@ from qiskit_nature.exceptions import QiskitNatureError
 import qiskit_nature.optionals as _optionals
 
 from .polynomial_tensor import PolynomialTensor
+from .symmetric_two_body import SymmetricTwoBodyIntegrals
 from .tensor import Tensor
 from .tensor_ordering import (
     IndexType,
@@ -257,8 +258,18 @@ class ElectronicIntegrals(LinearMixin):
         if self.beta_alpha.is_empty():
             return self.beta_alpha
 
-        # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
-        alpha_beta = Tensor(np.moveaxis(Tensor(self.beta_alpha["++--"]), (0, 1), (2, 3)))
+        two_body_ba = self.beta_alpha["++--"]
+        if isinstance(two_body_ba, SymmetricTwoBodyIntegrals):
+            # NOTE: to ensure proper inter-operability with the symmetry-aware integral containers,
+            # we delegate the conjugation to the objects themselves
+            return PolynomialTensor({"++--": two_body_ba.conjugate()}, validate=False)
+
+        alpha_beta: Tensor | np.ndarray | SparseArray
+        if not isinstance(two_body_ba, Tensor):
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
+            alpha_beta = Tensor(np.moveaxis(Tensor(two_body_ba), (0, 1), (2, 3)))
+        else:
+            alpha_beta = np.moveaxis(two_body_ba, (0, 1), (2, 3))
         return PolynomialTensor({"++--": alpha_beta}, validate=False)
 
     @property
@@ -571,13 +582,29 @@ class ElectronicIntegrals(LinearMixin):
         kron_two_body = np.zeros((2, 2, 2, 2))
         kron_tensor = PolynomialTensor({"": 1.0, "+-": kron_one_body, "++--": kron_two_body})
 
+        ba_index = (1, 0, 0, 1)
+        ab_index = (0, 1, 1, 0)
+
         if beta_empty and beta_alpha_empty:
             kron_one_body[(0, 0)] = 1
             kron_one_body[(1, 1)] = 1
             kron_two_body[(0, 0, 0, 0)] = 0.5
-            kron_two_body[(0, 1, 1, 0)] = 0.5
-            kron_two_body[(1, 0, 0, 1)] = 0.5
             kron_two_body[(1, 1, 1, 1)] = 0.5
+
+            aa_tensor = self.alpha.get("++--", None)
+            if aa_tensor is not None:
+                if not isinstance(aa_tensor, Tensor):
+                    aa_tensor = Tensor(aa_tensor)
+
+                ba_index = cast(
+                    Tuple[int, int, int, int], tuple(aa_tensor._reverse_label_template(ba_index))
+                )
+                ab_index = cast(
+                    Tuple[int, int, int, int], tuple(aa_tensor._reverse_label_template(ab_index))
+                )
+
+            kron_two_body[ba_index] = 0.5
+            kron_two_body[ab_index] = 0.5
 
             tensor_blocked_spin_orbitals = PolynomialTensor.apply(np.kron, kron_tensor, self.alpha)
             return tensor_blocked_spin_orbitals
@@ -598,17 +625,29 @@ class ElectronicIntegrals(LinearMixin):
         # beta_alpha spin
         if not beta_alpha_empty:
             kron_tensor = PolynomialTensor({"++--": kron_two_body})
-            kron_two_body[(1, 0, 0, 1)] = 0.5
+
+            ba_tensor = self.beta_alpha["++--"]
+            if not isinstance(ba_tensor, Tensor):
+                ba_tensor = Tensor(ba_tensor)
+
+            ba_index = cast(
+                Tuple[int, int, int, int], tuple(ba_tensor._reverse_label_template(ba_index))
+            )
+            ab_index = cast(
+                Tuple[int, int, int, int], tuple(ba_tensor._reverse_label_template(ab_index))
+            )
+
+            kron_two_body[ba_index] = 0.5
             tensor_blocked_spin_orbitals += PolynomialTensor.apply(
                 np.kron, kron_tensor, self.beta_alpha
             )
-            kron_two_body[(1, 0, 0, 1)] = 0
+            kron_two_body[ba_index] = 0
             # extract transposed beta_alpha term
-            kron_two_body[(0, 1, 1, 0)] = 0.5
+            kron_two_body[ab_index] = 0.5
             tensor_blocked_spin_orbitals += PolynomialTensor.apply(
                 np.kron, kron_tensor, self.alpha_beta
             )
-            kron_two_body[(0, 1, 1, 0)] = 0
+            kron_two_body[ab_index] = 0
 
         return tensor_blocked_spin_orbitals
 
@@ -626,13 +665,10 @@ class ElectronicIntegrals(LinearMixin):
         if beta_empty and beta_alpha_empty:
             return cast(PolynomialTensor, 2.0 * self.alpha)
 
-        one_body = self.one_body
         two_body = self.two_body
         tensor_spin_traced = PolynomialTensor({})
-        tensor_spin_traced += one_body.alpha
-        tensor_spin_traced += one_body.beta
-        tensor_spin_traced += two_body.alpha
-        tensor_spin_traced += two_body.beta
+        tensor_spin_traced += self.alpha
+        tensor_spin_traced += self.beta
         if beta_alpha_empty:
             tensor_spin_traced += two_body.alpha
             tensor_spin_traced += two_body.beta

--- a/qiskit_nature/second_q/operators/symmetric_two_body.py
+++ b/qiskit_nature/second_q/operators/symmetric_two_body.py
@@ -299,7 +299,7 @@ class S8Integrals(SymmetricTwoBodyIntegrals):
     This class is a utility subclass of the central :class:`.Tensor` used for storing n-dimensional
     arrays. This particular one holds 2-body electronic integrals when contracted to 8-fold
     symmetry. This means, that the full 4-dimensional integrals are contracted to a 1-dimensional
-    representation of length :math:`M * (M + 1) / 2` where math:`M` is the number of orbital pairs
+    representation of length :math:`M * (M + 1) / 2` where :math:`M` is the number of orbital pairs
     given by :math:`M = N * (N + 1) / 2` where :math:`N` is the number of orbitals.
     """
 

--- a/qiskit_nature/second_q/operators/symmetric_two_body.py
+++ b/qiskit_nature/second_q/operators/symmetric_two_body.py
@@ -1,0 +1,768 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
+"""
+Symmetric 2-body electronic integrals (:mod:`qiskit_nature.second_q.operators.symmetric_two_body`)
+==================================================================================================
+
+.. currentmodule:: qiskit_nature.second_q.operators.symmetric_two_body
+
+This module provides utilities to deal with symmetry-reduced 2-body electronic integrals.
+
+Container classes
+-----------------
+
+The classes provided here extend the ``numpy.ndarray`` interface and, thus, may be used as such
+interchangeably.
+
+.. note::
+
+   Some operations may not be available on the symmetry-reduced space in which case the instance
+   will automatically be unfolded to the full 4-dimensional array. After a successful operation, the
+   original symmetry will be attempted to be restored.
+
+.. autosummary::
+   :toctree: ../stubs/
+   :template: autosummary/class_with_inherited_members.rst
+   :nosignatures:
+
+   SymmetricTwoBodyIntegrals
+   S1Integrals
+   S4Integrals
+   S8Integrals
+
+Unfolding methods
+-----------------
+
+These methods can be used to unfold higher symmetries to lower ones.
+
+.. note::
+
+   This implies that the memory consumption **increases**.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   unfold
+   unfold_s4_to_s1
+   unfold_s8_to_s1
+   unfold_s8_to_s4
+
+Folding methods
+---------------
+
+These methods can be used to fold lower symmetries to higher ones.
+
+.. note::
+
+   This implies that the memory consumption **decreases**.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   fold
+   fold_s1_to_s4
+   fold_s1_to_s8
+   fold_s4_to_s8
+
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from itertools import takewhile
+from numbers import Number
+from typing import Any, Generator, Tuple, cast
+
+import numpy as np
+
+import qiskit_nature.optionals as _optionals
+
+from .tensor import ARRAY_TYPE, Tensor
+from .tensor_ordering import IndexType, find_index_order
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _contracted_indices(maximum: int) -> Generator[int, None, None]:
+    for idx in range(maximum):
+        yield (idx + 1) * (idx + 2) // 2
+
+
+def _inflate_index(index: int, maximum: int) -> tuple[int, int]:
+    p, q = 0, 0
+    for _ in takewhile(lambda pq: pq <= index, _contracted_indices(maximum)):
+        p += 1
+    q = index - p * (p + 1) // 2
+    return p, q
+
+
+class SymmetricTwoBodyIntegrals(Tensor, ABC):
+    """An abstract base class providing the interface for symmetry-reduced two-body electronic
+    integral container classes.
+    """
+
+    _HANDLED_FUNCTIONS = {np.kron, np.transpose, np.tensordot, np.einsum}
+
+    def __init__(self, eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> None:
+        # pylint: disable=unused-argument
+        """
+        Args:
+            eri: the actual two-body tensor.
+            validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+        .. note::
+
+           Actual implementations of this abstract base class may raise a ``ValueError`` if ``eri``
+           does not fulfill the requirements imposed by that subclass.
+        """
+        super().__init__(eri, label_template="+_{{0}} +_{{2}} -_{{3}} -_{{1}}")
+
+    def __array_wrap__(self, array: ARRAY_TYPE, context=None) -> SymmetricTwoBodyIntegrals:
+        try:
+            return self.__class__(array)
+        except ValueError:
+            # upon construction failure of the SymmetricTwoBodyIntegrals instance we fall back to
+            # using a plain Tensor
+            return Tensor(array)
+
+    def __array_function__(self, func, types, args, kwargs):
+        if func in self._HANDLED_FUNCTIONS:
+            return self._numpy_function_via_s1(func, types, args, kwargs)
+        try:
+            return super().__array_function__(func, types, args, kwargs)
+        except np.AxisError:
+            return fold(self._numpy_function_via_s1(func, types, args, kwargs))
+
+    def _numpy_function_via_s1(self, func, types, args, kwargs):
+        uses_sparse = True
+        if func is np.einsum:
+            # TODO: figure out why not even opt_einsum can handle this case consistently
+            uses_sparse = False
+        new_args = []
+        for a in args:
+            if isinstance(a, SymmetricTwoBodyIntegrals):
+                s1 = unfold(a)
+                if not uses_sparse:
+                    s1 = s1.to_dense()
+                new_args.append(s1)
+            else:
+                new_args.append(a)
+        new_types = []
+        for t in types:
+            if issubclass(t, SymmetricTwoBodyIntegrals):
+                new_types.append(S1Integrals)
+            else:
+                new_types.append(t)
+        return super().__array_function__(func, tuple(new_types), tuple(new_args), kwargs)
+
+    def conjugate(self) -> SymmetricTwoBodyIntegrals:
+        """Returns the complex conjugate of itself."""
+        return self.__class__(self.array.transpose().conjugate())
+
+
+class S1Integrals(SymmetricTwoBodyIntegrals):
+    """A container for 1-fold symmetric 2-body electronic integrals in chemist ordering.
+
+    This class is a utility subclass of the central :class:`.Tensor` used for storing n-dimensional
+    arrays. This particular one holds 2-body electronic integrals when unfolded to 1-fold symmetry
+    (or in other words the full 4-dimensional array). Even though this provides no reduced memory
+    consumption over using a plain array, the benefit of this class is two-fold:
+
+    1. it simplifies the usage of chemist-ordered 2-body electronic integrals in the stack
+    2. it can interact with the sibling :class:`.S4Integrals` and :class:`.S8Integrals` classes
+    """
+
+    def __init__(self, eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> None:
+        """
+        Args:
+            eri: the 4-dimensional array of the 2-body electronic integrals stored in chemist order.
+            validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+        Raises:
+            ValueError: If ``eri`` is not 4-dimensional.
+        """
+        if validate and len(eri.shape) != 4:
+            raise ValueError(
+                "Expected a 4-dimensional array but obtained one with shape: ", eri.shape
+            )
+        super().__init__(eri)
+
+
+class S4Integrals(SymmetricTwoBodyIntegrals):
+    """A container for 4-fold symmetric 2-body electronic integrals in chemist ordering.
+
+    This class is a utility subclass of the central :class:`.Tensor` used for storing n-dimensional
+    arrays. This particular one holds 2-body electronic integrals when contracted to 4-fold
+    symmetry. This means, that the full 4-dimensional integrals are contracted to a 2-dimensional
+    representation of shape :math:`M x M` where :math:`M` is the number of orbital pairs given by
+    :math:`M = N * (N + 1) / 2` where :math:`N` is the number of orbitals.
+    """
+
+    def __init__(self, eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> None:
+        """
+        Args:
+            eri: the 2-dimensional array of the 4-fold symmetric 2-body electronic integrals stored
+                 in chemist order. The shape of this matrix must be :math:`M x M` where
+                 :math:`M = N * (N + 1) / 2` and :math:`N` is the number of orbitals.
+            validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+        Raises:
+            ValueError: If ``eri`` is not 2-dimensional.
+        """
+        if validate and len(eri.shape) != 2:
+            raise ValueError(
+                "Expected a 2-dimensional array but obtained one with shape: ", eri.shape
+            )
+        super().__init__(eri)
+        self._npair = eri.shape[0]
+        self._norb = int(-0.5 + np.sqrt(0.25 + 2 * eri.shape[0]))
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (self._norb,) * 4
+
+    def __array_wrap__(self, array: ARRAY_TYPE, context=None) -> SymmetricTwoBodyIntegrals:
+        if len(array.shape) == 4:
+            # NOTE: some operations may require implicit unfolding to S1Integrals
+            return S1Integrals(array)
+        try:
+            return self.__class__(array)
+        except ValueError:
+            # upon construction failure of the SymmetricTwoBodyIntegrals instance we fall back to
+            # using a plain Tensor
+            return Tensor(array)
+
+    def _reduced_dim_index(self, idx: tuple[int, int, int, int]) -> tuple[int, int]:
+        i, j, k, l = idx
+        if i < j:
+            i, j = j, i
+        if k < l:
+            k, l = l, k
+        ij = i * (i + 1) // 2 + j
+        kl = k * (k + 1) // 2 + l
+        return (ij, kl)
+
+    def __getitem__(self, key: Any) -> Any:
+        if isinstance(key, tuple) and len(key) == 4:
+            key = cast(Tuple[int, int, int, int], key)
+            return self.__array__().__getitem__(self._reduced_dim_index(key))
+        return super().__getitem__(key)
+
+    def _full_index(self, idx: tuple[int, int]) -> Generator[tuple[int, int, int, int], None, None]:
+        i, j = _inflate_index(idx[0], self._norb)
+        k, l = _inflate_index(idx[1], self._norb)
+        yield i, j, k, l
+        if i > j:
+            yield j, i, k, l
+        if k > l:
+            yield i, j, l, k
+        if i > j and k > l:
+            yield j, i, l, k
+
+    def coord_iter(self) -> Generator[tuple[Number, tuple[int, ...]], None, None]:
+        # PERF: the following matrix unpacking is a performance bottleneck!
+        # We could consider using Rust in the future to improve upon this.
+        if isinstance(self._array, np.ndarray):
+            for index in np.ndindex(*self._array.shape):
+                index = cast(Tuple[int, int], index)
+                value = self._array[index]
+                for full_idx in self._full_index(index):
+                    yield value, full_idx
+        else:
+            _optionals.HAS_SPARSE.require_now("SparseArray")
+            import sparse as sp  # pylint: disable=import-error
+
+            if isinstance(self._array, sp.SparseArray):
+                coo = sp.as_coo(self._array)
+                for value, *index in zip(coo.data, *coo.coords):
+                    index = cast(Tuple[int, int], index)
+                    for full_idx in self._full_index(index):
+                        yield value, tuple(full_idx)
+
+
+class S8Integrals(SymmetricTwoBodyIntegrals):
+    """A container for 8-fold symmetric 2-body electronic integrals in chemist ordering.
+
+    This class is a utility subclass of the central :class:`.Tensor` used for storing n-dimensional
+    arrays. This particular one holds 2-body electronic integrals when contracted to 8-fold
+    symmetry. This means, that the full 4-dimensional integrals are contracted to a 1-dimensional
+    representation of length :math:`M * (M + 1) / 2` where math:`M` is the number of orbital pairs
+    given by :math:`M = N * (N + 1) / 2` where :math:`N` is the number of orbitals.
+    """
+
+    def __init__(self, eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> None:
+        """
+        Args:
+            eri: the 1-dimensional array of the 8-fold symmetric 2-body electronic integrals stored
+                 in chemist order. The length of this 1D matrix must be :math:`M * (M + 1) / 2`
+                 where :math:`M = N * (N + 1) / 2` and :math:`N` is the number of orbitals.
+            validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+        Raises:
+            ValueError: If ``eri`` is not 1-dimensional.
+        """
+        if validate and len(eri.shape) != 1:
+            raise ValueError(
+                "Expected a 1-dimensional array but obtained one with shape: ", eri.shape
+            )
+        super().__init__(eri)
+        self._npair = int(-0.5 + np.sqrt(0.25 + 2 * eri.shape[0]))
+        self._norb = int(-0.5 + np.sqrt(0.25 + 2 * self._npair))
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (self._norb,) * 4
+
+    def __array_wrap__(self, array: ARRAY_TYPE, context=None) -> SymmetricTwoBodyIntegrals:
+        if len(array.shape) == 4:
+            # NOTE: some operations may require implicit unfolding to S1Integrals
+            return S1Integrals(array)
+        try:
+            return self.__class__(array)
+        except ValueError:
+            # upon construction failure of the SymmetricTwoBodyIntegrals instance we fall back to
+            # using a plain Tensor
+            return Tensor(array)
+
+    def _reduced_dim_index(self, idx: tuple[int, int, int, int]) -> int:
+        i, j, k, l = idx
+        if i < j:
+            i, j = j, i
+        if k < l:
+            k, l = l, k
+        ij = i * (i + 1) // 2 + j
+        kl = k * (k + 1) // 2 + l
+        if ij < kl:
+            ij, kl = kl, ij
+        ijkl = ij * (ij + 1) // 2 + kl
+        return ijkl
+
+    def __getitem__(self, key: Any) -> Any:
+        if isinstance(key, tuple) and len(key) == 4:
+            key = cast(Tuple[int, int, int, int], key)
+            return self.__array__().__getitem__(self._reduced_dim_index(key))
+        return super().__getitem__(key)
+
+    def _full_index(self, idx: int) -> Generator[tuple[int, int, int, int], None, None]:
+        ij, kl = _inflate_index(idx, self._npair)
+        i, j = _inflate_index(ij, self._norb)
+        k, l = _inflate_index(kl, self._norb)
+        yield i, j, k, l
+        if i > j:
+            yield j, i, k, l
+        if k > l:
+            yield i, j, l, k
+        if i > j and k > l:
+            yield j, i, l, k
+        if ij > kl:
+            i, j, k, l = k, l, i, j
+            yield i, j, k, l
+            if i > j:
+                yield j, i, k, l
+            if k > l:
+                yield i, j, l, k
+            if i > j and k > l:
+                yield j, i, l, k
+
+    def coord_iter(self) -> Generator[tuple[Number, tuple[int, ...]], None, None]:
+        # PERF: the following matrix unpacking is a performance bottleneck!
+        # We could consider using Rust in the future to improve upon this.
+        if isinstance(self._array, np.ndarray):
+            for index in np.ndindex(*self._array.shape):
+                value = self._array[index]
+                for full_idx in self._full_index(index[0]):
+                    yield value, full_idx
+        else:
+            _optionals.HAS_SPARSE.require_now("SparseArray")
+            import sparse as sp  # pylint: disable=import-error
+
+            if isinstance(self._array, sp.SparseArray):
+                coo = sp.as_coo(self._array)
+                for value, *index in zip(coo.data, *coo.coords):
+                    for full_idx in self._full_index(index[0]):
+                        yield value, tuple(full_idx)
+
+
+def unfold(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S1Integrals:
+    """Unfolds an electronic integrals tensor to 1-fold symmetries (4-dimensional).
+
+    This utility method combines :meth:`.unfold_s4_to_s1` and :meth:`.unfold_s8_to_s1`.
+
+    Args:
+        eri: a 4-, 2- or 1-dimensional array storing electronic integrals.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        A 1-fold symmetric tensor.
+
+    Raises:
+        NotImplementedError: if ``eri`` is of an unsupported dimension.
+    """
+    if isinstance(eri, S1Integrals):
+        return eri
+
+    if isinstance(eri, Tensor):
+        eri = eri.array
+
+    if len(eri.shape) == 2:
+        return unfold_s4_to_s1(eri, validate=validate)
+
+    if len(eri.shape) == 1:
+        return unfold_s8_to_s1(eri, validate=validate)
+
+    raise NotImplementedError(
+        "Expected either a 4-, 2- or 1-dimensional array. Instead, an array of the following shape "
+        f"was encountered: {eri.shape}"
+    )
+
+
+def fold(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> SymmetricTwoBodyIntegrals:
+    """Folds an electronic integrals tensor.
+
+    This utility method combines :meth:`.fold_s4_to_s8`, :meth:`.fold_s1_to_s8` and
+    :meth:`.fold_s1_to_s4` and attempts to fold the provided tensor as much as possible given
+    these folding methods.
+    Any ``ValueError`` raised by the methods above is caught. When this happens, this utility will
+    try the next folding method.
+
+    Args:
+        eri: a 4-, 2- or 1-dimensional array storing electronic integrals.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        Either an instance of :class:`.S8Integrals`, :class:`.S4Integrals` or :class:`.S1Integrals`
+        (in this order) depending on the first successful folding method.
+
+    Raises:
+        NotImplementedError: if ``eri`` is of an unsupported dimension.
+    """
+    if isinstance(eri, S8Integrals):
+        return eri
+
+    if isinstance(eri, Tensor):
+        eri = eri.array
+
+    if len(eri.shape) == 2:
+        try:
+            return fold_s4_to_s8(eri, validate=validate)
+        except ValueError as err:
+            LOGGER.warning(
+                "The following error was encountered during the attempted conversion of the 4-fold "
+                "to 8-fold symmetric integrals: %s",
+                err,
+            )
+            LOGGER.info("Returning 4-fold symmetric integrals as the lowest achievable folding.")
+            return S4Integrals(eri, validate=validate)
+
+    if len(eri.shape) == 4:
+        try:
+            return fold_s1_to_s8(eri, validate=validate)
+        except ValueError as err:
+            LOGGER.warning(
+                "The following error was encountered during the attempted conversion of the 1-fold "
+                "to 8-fold symmetric integrals: %s",
+                err,
+            )
+            try:
+                return fold_s1_to_s4(eri, validate=validate)
+            except ValueError:
+                LOGGER.warning(
+                    "The following error was encountered during the attempted conversion of the "
+                    "1-fold to 4-fold symmetric integrals: %s",
+                    err,
+                )
+                LOGGER.info("No folding was possible. Returing 1-fold symmetric integrals.")
+                return S1Integrals(eri, validate=validate)
+
+    raise NotImplementedError(
+        "Expected either a 1-, 2- or 4-dimensional array. Instead, an array of the following shape "
+        f"was encountered: {eri.shape}"
+    )
+
+
+def _get_norb_and_npair(eri: Tensor | ARRAY_TYPE) -> tuple[int, int]:
+    if isinstance(eri, Tensor):
+        eri = eri.array
+
+    if len(eri.shape) == 4:
+        norb = eri.shape[0]
+        npair = norb * (norb + 1) // 2
+
+    elif len(eri.shape) == 2:
+        npair = eri.shape[0]
+        norb = int(-0.5 + np.sqrt(0.25 + 2 * npair))
+
+    elif len(eri.shape) == 1:
+        npair = int(-0.5 + np.sqrt(0.25 + 2 * eri.shape[0]))
+        norb = int(-0.5 + np.sqrt(0.25 + 2 * npair))
+
+    return norb, npair
+
+
+def fold_s1_to_s4(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S4Integrals:
+    """Folds a 4-dimensional tensor to 4-fold symmetries (2-dimensional).
+
+    Args:
+        eri: the 4-dimensional tensor to fold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        A 4-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 4-dimensional.
+        ValueError: if ``eri`` does not satisfy the permutational symmetries dictated by the
+            chemist' convention for the ordering of two-body electronic integrals.
+    """
+    LOGGER.info("Attempting 1-fold to 4-fold symmetric folding.")
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 4:
+        raise ValueError(
+            "Expected a 4-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    index_order = find_index_order(eri)
+    if validate and index_order != IndexType.CHEMIST:
+        # TODO: relax this to allow complex integrals which only satisfy a subset of the
+        # permutations tested in the `find_index_order` method
+        raise ValueError(
+            "Expected a tensor satisfying the permutational symmetries dictated by the chemist' "
+            "convention for two-body electronic integral storage. Instead, the following index "
+            f"ordering was determined: {index_order}"
+        )
+    norb, npair = _get_norb_and_npair(eri)
+    new_eri = np.zeros((npair, npair))
+    for ij, (i, j) in enumerate(zip(*np.tril_indices(norb))):
+        for kl, (k, l) in enumerate(zip(*np.tril_indices(norb))):
+            new_eri[ij, kl] = eri[i, j, k, l]
+    return S4Integrals(new_eri)
+
+
+def fold_s1_to_s8(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S8Integrals:
+    """Folds a 4-dimensional tensor to 8-fold symmetries (1-dimensional).
+
+    Args:
+        eri: the 4-dimensional tensor to fold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        An 8-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 4-dimensional.
+        ValueError: if ``eri`` does not satisfy the permutational symmetries dictated by the
+            chemist' convention for the ordering of two-body electronic integrals.
+    """
+    LOGGER.info("Attempting 1-fold to 8-fold symmetric folding.")
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 4:
+        raise ValueError(
+            "Expected a 4-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    index_order = find_index_order(eri)
+    if validate and index_order != IndexType.CHEMIST:
+        # TODO: relax this to allow complex integrals which only satisfy a subset of the
+        # permutations tested in the `find_index_order` method
+        raise ValueError(
+            "Expected a tensor satisfying the permutational symmetries dictated by the chemist' "
+            "convention for two-body electronic integral storage. Instead, the following index "
+            f"ordering was determined: {index_order}"
+        )
+    norb, npair = _get_norb_and_npair(eri)
+    new_eri = np.zeros(npair * (npair + 1) // 2)
+    ijkl = 0
+    for ij, (i, j) in enumerate(zip(*np.tril_indices(norb))):
+        for kl, (k, l) in enumerate(zip(*np.tril_indices(i + 1))):
+            if ij >= kl:
+                new_eri[ijkl] = eri[i, j, k, l]
+                ijkl += 1
+    return S8Integrals(new_eri)
+
+
+def fold_s4_to_s8(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S8Integrals:
+    """Folds a 2-dimensional tensor to 8-fold symmetries (1-dimensional).
+
+    Args:
+        eri: the 2-dimensional tensor to fold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        An 8-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 2-dimensional.
+        ValueError: if ``eri`` is not a symmetric tensor.
+    """
+    LOGGER.info("Attempting 4-fold to 8-fold symmetric conversion.")
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 2:
+        raise ValueError(
+            "Expected a 2-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    if validate and not np.allclose(eri, eri.T):
+        raise ValueError("Expected a symmetric tensor.")
+    return S8Integrals(eri[np.tril_indices_from(eri)])
+
+
+def unfold_s8_to_s4(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S4Integrals:
+    """Unfolds an 8-fold symmetric tensor to 4-fold symmetries (2-dimensional).
+
+    Args:
+        eri: the 1-dimensional tensor to unfold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        A 4-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 1-dimensional.
+    """
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 1:
+        raise ValueError(
+            "Expected a 1-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    _, npair = _get_norb_and_npair(eri)
+    new_eri = np.zeros((npair, npair))
+    new_eri[np.tril_indices(npair)] = eri
+    new_eri[np.triu_indices(npair, k=1)] = new_eri.T[np.triu_indices(npair, k=1)]
+    return S4Integrals(new_eri)
+
+
+def unfold_s4_to_s1(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S1Integrals:
+    """Unfolds an 4-fold symmetric tensor to 1-fold symmetries (4-dimensional).
+
+    Args:
+        eri: the 2-dimensional tensor to unfold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        A 1-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 2-dimensional.
+    """
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 2:
+        raise ValueError(
+            "Expected a 2-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    norb, _ = _get_norb_and_npair(eri)
+
+    new_eri: ARRAY_TYPE
+    is_sparse = False
+    if _optionals.HAS_SPARSE:
+        _optionals.HAS_SPARSE.require_now("DOK")
+        import sparse as sp  # pylint: disable=import-error
+
+        new_eri = sp.DOK((norb, norb, norb, norb))
+        is_sparse = True
+    else:
+        new_eri = np.zeros((norb, norb, norb, norb))
+
+    for ij, (i, j) in enumerate(zip(*np.tril_indices(norb))):
+        for kl, (k, l) in enumerate(zip(*np.tril_indices(norb))):
+            new_eri[i, j, k, l] = eri[ij, kl]
+            new_eri[i, j, l, k] = eri[ij, kl]
+
+            if is_sparse and i > j:
+                # NOTE: we cannot slice a sparse array so we need to write the symmetric values here
+                new_eri[j, i, k, l] = eri[ij, kl]
+                new_eri[j, i, l, k] = eri[ij, kl]
+
+        if not is_sparse and i > j:
+            # NOTE: when our array is dense, we avoid a lot of individual writes above and instead
+            # exploit the slicing operation here
+            new_eri[j, i, :, :] = new_eri[i, j, :, :]
+
+    if is_sparse:
+        new_eri = new_eri.to_coo()
+
+    return S1Integrals(new_eri)
+
+
+def unfold_s8_to_s1(eri: Tensor | ARRAY_TYPE, *, validate: bool = True) -> S1Integrals:
+    """Unfolds an 8-fold symmetric tensor to 1-fold symmetries (4-dimensional).
+
+    Args:
+        eri: the 1-dimensional tensor to unfold.
+        validate: when set to ``False``, the requirements of ``eri`` are not validated.
+
+    Returns:
+        A 1-fold symmetric tensor.
+
+    Raises:
+        ValueError: if ``eri`` is not 1-dimensional.
+    """
+    if isinstance(eri, Tensor):
+        eri = eri.array
+    if validate and len(eri.shape) != 1:
+        raise ValueError(
+            "Expected a 1-dimensional array. Instead, an array of the following shape was "
+            f"encountered: {eri.shape}"
+        )
+    norb, npair = _get_norb_and_npair(eri)
+
+    new_eri: ARRAY_TYPE
+    is_sparse = False
+    if _optionals.HAS_SPARSE:
+        _optionals.HAS_SPARSE.require_now("DOK")
+        import sparse as sp  # pylint: disable=import-error
+
+        new_eri = sp.DOK((norb, norb, norb, norb))
+        is_sparse = True
+    else:
+        new_eri = np.zeros((norb, norb, norb, norb))
+
+    for ij, (i, j) in enumerate(zip(*np.tril_indices(norb))):
+        row = np.zeros(npair)
+        idx = ij * (ij + 1) // 2
+        row[:ij] = eri[idx : idx + ij]
+        for k in range(ij, npair):
+            idx += k
+            row[k] = eri[idx]
+        idx = ij * (ij + 1) // 2
+        for kl, (k, l) in enumerate(zip(*np.tril_indices(norb))):
+            if ij <= kl:
+                idx += kl
+            elif kl > 0:
+                idx += 1
+            new_eri[i, j, k, l] = row[kl]
+            new_eri[i, j, l, k] = row[kl]
+
+            if is_sparse and i > j:
+                # NOTE: we cannot slice a sparse array so we need to write the symmetric values here
+                new_eri[j, i, k, l] = row[kl]
+                new_eri[j, i, l, k] = row[kl]
+
+        if not is_sparse and i > j:
+            # NOTE: when our array is dense, we avoid a lot of individual writes above and instead
+            # exploit the slicing operation here
+            new_eri[j, i, :, :] = new_eri[i, j, :, :]
+
+    if is_sparse:
+        new_eri = new_eri.to_coo()
+
+    return S1Integrals(new_eri)

--- a/qiskit_nature/second_q/transformers/basis_transformer.py
+++ b/qiskit_nature/second_q/transformers/basis_transformer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,7 @@ import numpy as np
 
 from qiskit_nature.exceptions import QiskitNatureError
 from qiskit_nature.second_q.hamiltonians import ElectronicEnergy, Hamiltonian
-from qiskit_nature.second_q.operators import ElectronicIntegrals, PolynomialTensor
+from qiskit_nature.second_q.operators import ElectronicIntegrals, PolynomialTensor, Tensor
 from qiskit_nature.second_q.problems import BaseProblem, ElectronicBasis, ElectronicStructureProblem
 from qiskit_nature.second_q.properties import (
     AngularMomentum,
@@ -176,9 +176,21 @@ class BasisTransformer(BaseTransformer):
                 f"coefficients of type, {type(self.coefficients)}, rather than ElectronicIntegrals."
             )
 
+        prsq = "prsq"
+        iklj = "iklj"
+
+        two_body_aa = integrals.alpha.get("++--", None)
+        if two_body_aa is not None:
+            # TODO: remove extra-wrapping of Tensor once settings.tensor_unwrapping is removed
+            if not isinstance(two_body_aa, Tensor):
+                two_body_aa = Tensor(two_body_aa)
+
+            prsq = "".join(two_body_aa._reverse_label_template(prsq))
+            iklj = "".join(two_body_aa._reverse_label_template(iklj))
+
         einsum_map = {
             "jk,ji,kl->il": ("+-",) * 4,
-            "prsq,pi,qj,rk,sl->iklj": ("++--", *("+-",) * 4, "++--"),
+            f"{prsq},pi,qj,rk,sl->{iklj}": ("++--", *("+-",) * 4, "++--"),
         }
 
         transformed_integrals = ElectronicIntegrals.einsum(
@@ -187,7 +199,7 @@ class BasisTransformer(BaseTransformer):
 
         if not self.coefficients.beta.is_empty() and transformed_integrals.beta_alpha.is_empty():
             transformed_integrals.beta_alpha = PolynomialTensor.einsum(
-                {"prsq,pi,qj,rk,sl->iklj": ("++--", *("+-",) * 4, "++--")},
+                {f"{prsq},pi,qj,rk,sl->{iklj}": ("++--", *("+-",) * 4, "++--")},
                 integrals.alpha if integrals.beta_alpha.is_empty() else integrals.beta_alpha,
                 *(self.coefficients.beta,) * 2,
                 *(self.coefficients.alpha,) * 2,

--- a/releasenotes/notes/feat-symmetric-electronic-integrals-7791b8fba0ebd75f.yaml
+++ b/releasenotes/notes/feat-symmetric-electronic-integrals-7791b8fba0ebd75f.yaml
@@ -1,0 +1,39 @@
+---
+features:
+  - |
+    Adds the :mod:`~qiskit_nature.second_q.operators.symmetric_two_body` module.
+    This module provides utilities to exploit the inherent symmetries of
+    chemistry-ordered two-body electronic integrals. You may use these to reduce
+    memory consumption of your code, for example like so:
+
+    .. code-block:: python
+
+       from pyscf import gto
+       from qiskit_nature.second_q.hamiltonians import ElectronicEnergy
+       from qiskit_nature.second_q.operators import (
+            ElectronicIntegrals,
+            PolynomialTensor,
+       )
+       from qiskit_nature.second_q.operators.symmetric_two_body import S8Integrals
+
+       mol = gto.M(atom="H 0 0 0; H 0 0 0.735", basis="631g*")
+
+       hamiltonian = ElectronicEnergy(
+           ElectronicIntegrals(
+               PolynomialTensor(
+                   {
+                       "+-": mol.get_hcore(),
+                       "++--": S8Integrals(mol.intor("int2e", aosym=8)),
+                   },
+                   validate=False,
+               )
+           )
+       )
+
+       print(hamiltonian.second_q_op())
+
+    Since these integral containers are integrated into the stack, you can
+    continue to use existing tools such as the
+    :class:`~qiskit_nature.second_q.transformers.BasisTransformer` or even the
+    :class:`~qiskit_nature.second_q.transformers.ActiveSpaceTransformer` as if
+    you had stored your integrals in standard arrays.

--- a/test/second_q/operators/test_symmetric_two_body.py
+++ b/test/second_q/operators/test_symmetric_two_body.py
@@ -1,0 +1,492 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the symmetric 2-body electronic integral utilities."""
+
+from __future__ import annotations
+
+import unittest
+from test import QiskitNatureTestCase
+
+import numpy as np
+from ddt import data, ddt
+from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
+
+import qiskit_nature.optionals as _optionals
+from qiskit_nature.second_q.algorithms import GroundStateEigensolver
+from qiskit_nature.second_q.drivers import MethodType, PySCFDriver
+from qiskit_nature.second_q.formats.qcschema_translator import (
+    get_ao_to_mo_from_qcschema,
+    qcschema_to_problem,
+)
+from qiskit_nature.second_q.hamiltonians import ElectronicEnergy
+from qiskit_nature.second_q.mappers import JordanWignerMapper
+from qiskit_nature.second_q.operators import ElectronicIntegrals, FermionicOp, PolynomialTensor
+from qiskit_nature.second_q.operators.symmetric_two_body import (
+    S1Integrals,
+    S4Integrals,
+    S8Integrals,
+    unfold,
+    unfold_s4_to_s1,
+    unfold_s8_to_s1,
+    unfold_s8_to_s4,
+    fold,
+    fold_s1_to_s4,
+    fold_s1_to_s8,
+    fold_s4_to_s8,
+)
+from qiskit_nature.second_q.operators.tensor_ordering import (
+    IndexType,
+    to_physicist_ordering,
+    to_chemist_ordering,
+)
+from qiskit_nature.second_q.problems import ElectronicBasis, ElectronicStructureProblem
+from qiskit_nature.second_q.transformers import ActiveSpaceTransformer
+
+
+@ddt
+class TestSymmetricIntegrals(QiskitNatureTestCase):
+    """Tests the symmetric 2-body electronic integral utility classes."""
+
+    @unittest.skipIf(not _optionals.HAS_PYSCF, "PySCF not available.")
+    def setUp(self):
+        super().setUp()
+
+        # pylint: disable=import-error
+        from pyscf import gto
+
+        self.mol = gto.M(atom="H 0 0 0; H 0 0 0.735", basis="sto3g")
+
+        self.eri1 = self.mol.intor("int2e", aosym=1)
+        self.eri4 = self.mol.intor("int2e", aosym=4)
+        self.eri8 = self.mol.intor("int2e", aosym=8)
+
+        self.ints1 = S1Integrals(self.eri1)
+        self.ints4 = S4Integrals(self.eri4)
+        self.ints8 = S8Integrals(self.eri8)
+
+        self.reference = FermionicOp.from_polynomial_tensor(
+            PolynomialTensor({"++--": to_physicist_ordering(self.eri1)})
+        )
+
+    @data("ints1", "ints4", "ints8")
+    def test_unfold(self, ints_name: str):
+        """Test the ``unfold`` method."""
+        ints = getattr(self, ints_name)
+        unfolded = unfold(ints)
+        if unfolded.is_sparse():
+            unfolded = unfolded.to_dense()
+        np.testing.assert_allclose(self.eri1, unfolded)
+
+    def test_unfold_s4_to_s1(self):
+        """Test the ``unfold_s4_to_s1`` method."""
+        unfolded = unfold_s4_to_s1(self.ints4)
+        if unfolded.is_sparse():
+            unfolded = unfolded.to_dense()
+        np.testing.assert_allclose(self.eri1, unfolded)
+
+    def test_unfold_s8_to_s1(self):
+        """Test the ``unfold_s8_to_s1`` method."""
+        unfolded = unfold_s8_to_s1(self.ints8)
+        if unfolded.is_sparse():
+            unfolded = unfolded.to_dense()
+        np.testing.assert_allclose(self.eri1, unfolded)
+
+    def test_unfold_s8_to_s4(self):
+        """Test the ``unfold_s8_to_s4`` method."""
+        np.testing.assert_allclose(self.eri4, unfold_s8_to_s4(self.ints8))
+
+    @data("ints1", "ints4", "ints8")
+    def test_fold(self, ints_name: str):
+        """Test the ``fold`` method."""
+        ints = getattr(self, ints_name)
+        np.testing.assert_allclose(self.eri8, fold(ints))
+
+    def test_fold_s1_to_s4(self):
+        """Test the ``fold_s1_to_s4`` method."""
+        np.testing.assert_allclose(self.eri4, fold_s1_to_s4(self.ints1))
+
+    def test_fold_s1_to_s4_failure(self):
+        """Test the ``fold_s1_to_s4`` method failure."""
+        with self.assertRaises(ValueError):
+            fold_s1_to_s4(S1Integrals(np.arange(16).reshape((2, 2, 2, 2))))
+
+    def test_fold_s1_to_s8(self):
+        """Test the ``fold_s1_to_s8`` method."""
+        np.testing.assert_allclose(self.eri8, fold_s1_to_s8(self.ints1))
+
+    def test_fold_s1_to_s8_failure(self):
+        """Test the ``fold_s1_to_s8`` method failure."""
+        with self.assertRaises(ValueError):
+            fold_s1_to_s8(S1Integrals(np.arange(16).reshape((2, 2, 2, 2))))
+
+    def test_fold_s4_to_s8(self):
+        """Test the ``fold_s4_to_s8`` method."""
+        np.testing.assert_allclose(self.eri8, fold_s4_to_s8(self.ints4))
+
+    def test_fold_s4_to_s8_failure(self):
+        """Test the ``fold_s4_to_s8`` method failure."""
+        with self.assertRaises(ValueError):
+            fold_s4_to_s8(S4Integrals(np.arange(9).reshape((3, 3))))
+
+    def test_s4_getitem(self):
+        """Test item access in the ``S4Integrals``."""
+        for index in np.ndindex(*self.ints1.shape):
+            self.assertAlmostEqual(self.ints1[index], self.ints4[index])
+
+    def test_s8_getitem(self):
+        """Test item access in the ``S8Integrals``."""
+        for index in np.ndindex(*self.ints1.shape):
+            self.assertAlmostEqual(self.ints1[index], self.ints8[index])
+
+    def test_s1_fermionic_op(self):
+        """Test the FermionicOp generated from a S1Integrals instance."""
+        self.assertTrue(
+            self.reference.equiv(
+                FermionicOp.from_polynomial_tensor(PolynomialTensor({"++--": self.ints1}))
+            )
+        )
+
+    def test_s4_fermionic_op(self):
+        """Test the FermionicOp generated from a S4Integrals instance."""
+        self.assertTrue(
+            self.reference.equiv(
+                FermionicOp.from_polynomial_tensor(PolynomialTensor({"++--": self.ints4}))
+            )
+        )
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "sparse library not available.")
+    def test_s4_fermionic_op_sparse(self):
+        """Test the FermionicOp generated from a sparse S4Integrals instance."""
+        self.assertTrue(
+            self.reference.equiv(
+                FermionicOp.from_polynomial_tensor(
+                    PolynomialTensor({"++--": self.ints4.to_sparse()})
+                )
+            )
+        )
+
+    def test_s8_fermionic_op(self):
+        """Test the FermionicOp generated from a S8Integrals instance."""
+        self.assertTrue(
+            self.reference.equiv(
+                FermionicOp.from_polynomial_tensor(PolynomialTensor({"++--": self.ints8}))
+            )
+        )
+
+    @unittest.skipIf(not _optionals.HAS_SPARSE, "sparse library not available.")
+    def test_s8_fermionic_op_sparse(self):
+        """Test the FermionicOp generated from a sparse S8Integrals instance."""
+        self.assertTrue(
+            self.reference.equiv(
+                FermionicOp.from_polynomial_tensor(
+                    PolynomialTensor({"++--": self.ints8.to_sparse()})
+                )
+            )
+        )
+
+    def test_s4_integration(self):
+        """Test integration of the S4Integrals."""
+        # pylint: disable=import-error
+        from pyscf import ao2mo
+
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver()
+        problem = driver.run()
+        expected = algo.solve(problem).computed_energies[0]
+
+        s4_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": np.dot(
+                            np.dot(driver._calc.mo_coeff.T, driver._calc.get_hcore()),
+                            driver._calc.mo_coeff,
+                        ),
+                        "++--": S4Integrals(
+                            ao2mo.full(driver._mol, driver._calc.mo_coeff, aosym=4)
+                        ),
+                    },
+                    validate=False,
+                )
+            )
+        )
+        s4_problem = ElectronicStructureProblem(s4_hamil)
+        result = algo.solve(s4_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                problem.hamiltonian.second_q_op().equiv(s4_problem.hamiltonian.second_q_op())
+            )
+
+    def test_s4_integration_uhf(self):
+        """Test integration of the S4Integrals with UHF."""
+        # pylint: disable=import-error
+        from pyscf import ao2mo
+
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver(method=MethodType.UHF)
+        problem = driver.run()
+        expected = algo.solve(problem).computed_energies[0]
+
+        s4_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": np.dot(
+                            np.dot(driver._calc.mo_coeff[0].T, driver._calc.get_hcore()),
+                            driver._calc.mo_coeff[0],
+                        ),
+                        "++--": S4Integrals(
+                            ao2mo.full(driver._mol, driver._calc.mo_coeff[0], aosym=4)
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "+-": np.dot(
+                            np.dot(driver._calc.mo_coeff[1].T, driver._calc.get_hcore()),
+                            driver._calc.mo_coeff[1],
+                        ),
+                        "++--": S4Integrals(
+                            ao2mo.full(driver._mol, driver._calc.mo_coeff[1], aosym=4)
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "++--": S4Integrals(
+                            ao2mo.general(
+                                driver._mol,
+                                [
+                                    driver._calc.mo_coeff[1],
+                                    driver._calc.mo_coeff[1],
+                                    driver._calc.mo_coeff[0],
+                                    driver._calc.mo_coeff[0],
+                                ],
+                                aosym=4,
+                            )
+                        ),
+                    },
+                    validate=False,
+                ),
+            )
+        )
+        s4_problem = ElectronicStructureProblem(s4_hamil)
+        result = algo.solve(s4_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                problem.hamiltonian.second_q_op().equiv(s4_problem.hamiltonian.second_q_op())
+            )
+
+    def test_s8_integration(self):
+        """Test integration of the S8Integrals."""
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver()
+        driver.run_pyscf()
+        qcschema = driver.to_qcschema()
+        trafo = get_ao_to_mo_from_qcschema(qcschema)
+        problem = qcschema_to_problem(qcschema, basis=ElectronicBasis.MO)
+        expected = algo.solve(problem).computed_energies[0]
+
+        s8_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": driver._calc.get_hcore(),
+                        "++--": S8Integrals(driver._mol.intor("int2e", aosym=8)),
+                    },
+                    validate=False,
+                )
+            )
+        )
+        ao_problem = ElectronicStructureProblem(s8_hamil)
+        ao_problem.basis = ElectronicBasis.AO
+        s8_mo_problem = trafo.transform(ao_problem)
+        result = algo.solve(s8_mo_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                problem.hamiltonian.second_q_op().equiv(s8_mo_problem.hamiltonian.second_q_op())
+            )
+
+    def test_s8_integration_uhf(self):
+        """Test integration of the S8Integrals with UHF."""
+        # pylint: disable=import-error
+        from pyscf import ao2mo
+
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver(method=MethodType.UHF)
+        problem = driver.run()
+        expected = algo.solve(problem).computed_energies[0]
+
+        s8_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": np.dot(
+                            np.dot(driver._calc.mo_coeff[0].T, driver._calc.get_hcore()),
+                            driver._calc.mo_coeff[0],
+                        ),
+                        "++--": fold_s4_to_s8(
+                            ao2mo.full(driver._mol, driver._calc.mo_coeff[0], aosym=4)
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "+-": np.dot(
+                            np.dot(driver._calc.mo_coeff[1].T, driver._calc.get_hcore()),
+                            driver._calc.mo_coeff[1],
+                        ),
+                        "++--": fold_s4_to_s8(
+                            ao2mo.full(driver._mol, driver._calc.mo_coeff[1], aosym=4)
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "++--": fold_s4_to_s8(
+                            ao2mo.general(
+                                driver._mol,
+                                [
+                                    driver._calc.mo_coeff[1],
+                                    driver._calc.mo_coeff[1],
+                                    driver._calc.mo_coeff[0],
+                                    driver._calc.mo_coeff[0],
+                                ],
+                                aosym=4,
+                            )
+                        ),
+                    },
+                    validate=False,
+                ),
+            )
+        )
+        s8_problem = ElectronicStructureProblem(s8_hamil)
+        result = algo.solve(s8_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                problem.hamiltonian.second_q_op().equiv(s8_problem.hamiltonian.second_q_op())
+            )
+
+    def test_active(self):
+        """Test integration with ActiveSpaceTransformer."""
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver(atom="Li 0 0 0; H 0 0 1.1")
+        problem = driver.run()
+        trafo = ActiveSpaceTransformer(2, 2)
+        as_problem = trafo.transform(problem)
+        expected = algo.solve(as_problem).computed_energies[0]
+
+        red_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": problem.hamiltonian.electronic_integrals.alpha["+-"],
+                        "++--": fold_s1_to_s8(
+                            to_chemist_ordering(
+                                problem.hamiltonian.electronic_integrals.alpha["++--"]
+                            ),
+                        ),
+                    },
+                    validate=False,
+                )
+            )
+        )
+
+        red_problem = ElectronicStructureProblem(red_hamil)
+        red_problem.basis = ElectronicBasis.MO
+        red_problem.num_particles = problem.num_particles
+        trafo = ActiveSpaceTransformer(2, 2)
+        red_as_problem = trafo.transform(red_problem)
+        as_result = algo.solve(red_as_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, as_result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                as_problem.hamiltonian.second_q_op().equiv(red_as_problem.hamiltonian.second_q_op())
+            )
+
+    def test_active_uhf(self):
+        """Test integration with ActiveSpaceTransformer with UHF."""
+        algo = GroundStateEigensolver(JordanWignerMapper(), NumPyMinimumEigensolver())
+        driver = PySCFDriver(atom="Li 0 0 0; H 0 0 1.1", method=MethodType.UHF)
+        problem = driver.run()
+        trafo = ActiveSpaceTransformer(2, 2)
+        as_problem = trafo.transform(problem)
+        expected = algo.solve(as_problem).computed_energies[0]
+
+        red_hamil = ElectronicEnergy(
+            ElectronicIntegrals(
+                PolynomialTensor(
+                    {
+                        "+-": problem.hamiltonian.electronic_integrals.alpha["+-"],
+                        "++--": fold_s1_to_s8(
+                            to_chemist_ordering(
+                                problem.hamiltonian.electronic_integrals.alpha["++--"]
+                            ),
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "+-": problem.hamiltonian.electronic_integrals.beta["+-"],
+                        "++--": fold_s1_to_s8(
+                            to_chemist_ordering(
+                                problem.hamiltonian.electronic_integrals.beta["++--"]
+                            ),
+                        ),
+                    },
+                    validate=False,
+                ),
+                PolynomialTensor(
+                    {
+                        "++--": S1Integrals(
+                            to_chemist_ordering(
+                                problem.hamiltonian.electronic_integrals.beta_alpha["++--"],
+                                index_order=IndexType.PHYSICIST,
+                            ),
+                        ),
+                    },
+                    validate=False,
+                ),
+            )
+        )
+
+        red_problem = ElectronicStructureProblem(red_hamil)
+        red_problem.basis = ElectronicBasis.MO
+        red_problem.num_particles = problem.num_particles
+        trafo = ActiveSpaceTransformer(2, 2)
+        red_as_problem = trafo.transform(red_problem)
+        as_result = algo.solve(red_as_problem)
+        with self.subTest("computed energy"):
+            self.assertAlmostEqual(expected, as_result.computed_energies[0])
+        with self.subTest("generated FermionicOp"):
+            self.assertTrue(
+                as_problem.hamiltonian.second_q_op().equiv(red_as_problem.hamiltonian.second_q_op())
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds utility classes to automatically handle symmetry-reduced two-body electronic integrals.
This will enable calculations with lower memory footprints and will in the future also allow to solve #933 fairly elegantly.

~For now, this is a WIP which still needs to be battle-tested. The classes themselves are fully functional but the integration into the stack still poses some questions here and there. If we need to proceed with this PR faster, we may need to fallback to expanding to the fully expanded integrals when running into errors.~

### Details and comments

- [x] the actual symmetry classes:
  - [x] `S1Integrals`: the fully expanded case but stored in chemistry notation and useful for conversions
  - [x] `S4Integrals`: for 4-fold symmetric integrals
  - [x] `S8Integrals`: for 8-fold symmetric integrals (cannot be used for beta-alpha integrals in the general case)
- [x] integration with `ElectronicEnergy` in the MO basis (mostly working; more unittests needed)
- [x] integration with `transformers` module
  - [x] `BasisTransformer`: planned as part of this PR
  - [x] `ActiveSpaceTransformer`: not planned for now, needs to be caught
  - [x] `FreezeCoreTransformer`: not planned for now, needs to be caught
- [x] reno