### PR TITLE
Fix prior release note formatting

### DIFF
--- a/releasenotes/notes/implements-two-qubit-reduction-in-paritymapper-f88ef199f0a954b6.yaml
+++ b/releasenotes/notes/implements-two-qubit-reduction-in-paritymapper-f88ef199f0a954b6.yaml
@@ -3,7 +3,7 @@ features:
   - |
     Adds the new argument ``num_particles`` to the
     :class:`~qiskit_nature.second_q.mappers.ParityMapper` which will implement the two qubit reduction
-    without requiring an instance of:class:`~qiskit_nature.second_q.mappers.QubitConverter`.
+    without requiring an instance of :class:`~qiskit_nature.second_q.mappers.QubitConverter`.
 
     .. code-block:: python
 


### PR DESCRIPTION
### Summary
Fixes formatting of a prior release note. Adds a space so `:class:` is parsed correctly


