### PR TITLE
fix the inverted logic of settings.use_pauli_sum_op deprecation warning

### DIFF
--- a/qiskit_nature/settings.py
+++ b/qiskit_nature/settings.py
@@ -42,7 +42,7 @@ class QiskitNatureSettings:
     @property
     def use_pauli_sum_op(self) -> bool:
         """Return whether ``PauliSumOp`` or ``SparsePauliOp`` should be returned on methods."""
-        if not self._use_pauli_sum_op and "PauliSumOp" not in self._deprecation_shown:
+        if self._use_pauli_sum_op and "PauliSumOp" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=PauliSumOpDeprecationWarning)
             warnings.warn(
                 PauliSumOpDeprecationWarning(
@@ -61,7 +61,7 @@ class QiskitNatureSettings:
     @use_pauli_sum_op.setter
     def use_pauli_sum_op(self, pauli_sum_op: bool) -> None:
         """Set whether ``PauliSumOp`` or ``SparsePauliOp`` should be returned on methods."""
-        if not pauli_sum_op and "PauliSumOp" not in self._deprecation_shown:
+        if pauli_sum_op and "PauliSumOp" not in self._deprecation_shown:
             warnings.filterwarnings("default", category=PauliSumOpDeprecationWarning)
             warnings.warn(
                 PauliSumOpDeprecationWarning(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The logic when to show the deprecation warning on `settings.use_pauli_sum_op` was inverted. This PR fixes that.

### Details and comments


