### PR TITLE
Deprecate `FermionicOp.to_matrix`

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -157,6 +157,7 @@ einsum
 electronicintegrals
 electronicstructureproblem
 endian
+endianness
 endif
 enum
 eom

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -22,6 +22,7 @@ from typing import cast, Iterator
 import numpy as np
 from scipy.sparse import csc_matrix
 
+from qiskit_nature.deprecation import deprecate_method
 from qiskit_nature.exceptions import QiskitNatureError
 
 from ._bits_container import _BitsContainer
@@ -342,10 +343,20 @@ class FermionicOp(SparseLabelOp):
             new_op.num_spin_orbitals = a.num_spin_orbitals + b.num_spin_orbitals
         return new_op
 
-    # TODO: do we want to change the returned type to be non-scipy sparse matrix?
+    # pylint: disable=bad-docstring-quotes
+    @deprecate_method(
+        "0.6.0",
+        additional_msg=(
+            ". This method has no direct replacement. Instead, use the "
+            "`qiskit_nature.second_q.mappers.JordanWignerMapper` to create a qubit operator and "
+            "subsequently use its `to_matrix()` method. Be advised, that the basis state ordering "
+            "of that output will differ due to the bitstring endianness. For more information "
+            "refer to https://github.com/Qiskit/qiskit-nature/issues/875."
+        ),
+    )
     def to_matrix(self, sparse: bool | None = True) -> csc_matrix | np.ndarray:
-        """Convert to a matrix representation over the full fermionic Fock space in the occupation
-        number basis.
+        """DEPRECATED Convert to a matrix representation over the full fermionic Fock space in the
+        occupation number basis.
 
         The basis states are ordered in increasing bitstring order as 0000, 0001, ..., 1111.
 

--- a/releasenotes/notes/deprecate-fermionic-op-to-matrix-74b182129fbb0171.yaml
+++ b/releasenotes/notes/deprecate-fermionic-op-to-matrix-74b182129fbb0171.yaml
@@ -1,0 +1,28 @@
+---
+deprecations:
+  - |
+    Deprecated the :meth:`~qiskit_nature.second_q.operators.FermionicOp.to_matrix` method.
+    The same functionality can be achieved via the qubit-operator after applying the
+    :class:`~qiskit_nature.second_q.mappers.JordanWignerMapper` (one only needs to
+    adapt to the different basis state ordering due to the reversed bitstring endianness).
+
+    .. code-block:: python
+
+       import numpy as np
+       from qiskit_nature.second_q.mappers import JordanWignerMapper
+       from qiskit_nature.second_q.operators import FermionicOp
+       from qiskit_nature.settings import settings
+
+       settings.use_pauli_sum_op = False
+
+       op = FermionicOp({"+_0": 1, "-_1": 1})
+       mat = op.to_matrix().todense()
+       jw = JordanWignerMapper().map(op)
+
+       print(np.allclose(mat, jw.to_matrix(), atol=1e-8))  # prints False
+
+       for pauli in jw.paulis:
+           pauli.x = pauli.x[::-1]
+           pauli.z = pauli.z[::-1]
+
+       print(np.allclose(mat, jw.to_matrix(), atol=1e-8))  # prints True

--- a/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
+++ b/test/second_q/hamiltonians/test_quadratic_hamiltonian.py
@@ -178,16 +178,16 @@ class TestQuadraticHamiltonian(QiskitNatureTestCase):
         expected_terms = {
             "": 5.0,
             "+_0 -_0": 1.0,
-            "+_1 -_1": 3.0,
             "+_0 -_1": 2j,
-            "-_0 +_1": 2j,
-            "+_0 +_1": 4j,
-            "-_0 -_1": 4j,
+            "+_1 -_0": -2j,
+            "+_1 -_1": 3.0,
+            "+_0 +_1": 2j,
+            "+_1 +_0": -2j,
+            "-_0 -_1": 2j,
+            "-_1 -_0": -2j,
         }
         expected_op = FermionicOp(expected_terms, num_spin_orbitals=2)
-        matrix = fermionic_op.to_matrix(sparse=False)
-        expected_matrix = expected_op.to_matrix(sparse=False)
-        np.testing.assert_allclose(matrix, expected_matrix)
+        self.assertTrue(expected_op.equiv(fermionic_op))
 
     def test_validate(self):
         """Test input validation."""

--- a/test/second_q/operators/test_fermionic_op.py
+++ b/test/second_q/operators/test_fermionic_op.py
@@ -13,6 +13,7 @@
 """Test for FermionicOp"""
 
 import unittest
+import warnings
 from test import QiskitNatureTestCase
 
 import numpy as np
@@ -306,70 +307,73 @@ class TestFermionicOp(QiskitNatureTestCase):
 
     def test_to_matrix(self):
         """Test to_matrix"""
-        with self.subTest("identity operator matrix"):
-            op = FermionicOp.one()
-            op.num_spin_orbitals = 2
-            mat = op.to_matrix(sparse=False)
-            targ = np.eye(4)
-            self.assertTrue(np.allclose(mat, targ))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
 
-        with self.subTest("number operator matrix"):
-            mat = FermionicOp({"+_1 -_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
-            targ = np.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1]])
-            self.assertTrue(np.allclose(mat, targ))
+            with self.subTest("identity operator matrix"):
+                op = FermionicOp.one()
+                op.num_spin_orbitals = 2
+                mat = op.to_matrix(sparse=False)
+                targ = np.eye(4)
+                self.assertTrue(np.allclose(mat, targ))
 
-        with self.subTest("emptiness operator matrix"):
-            mat = FermionicOp({"-_1 +_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
-            targ = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]])
-            self.assertTrue(np.allclose(mat, targ))
+            with self.subTest("number operator matrix"):
+                mat = FermionicOp({"+_1 -_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
+                targ = np.array([[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1]])
+                self.assertTrue(np.allclose(mat, targ))
 
-        with self.subTest("raising operator matrix"):
-            mat = FermionicOp({"+_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
-            targ = np.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 0, -1, 0]])
-            self.assertTrue(np.allclose(mat, targ))
+            with self.subTest("emptiness operator matrix"):
+                mat = FermionicOp({"-_1 +_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
+                targ = np.array([[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]])
+                self.assertTrue(np.allclose(mat, targ))
 
-        with self.subTest("lowering operator matrix"):
-            mat = FermionicOp({"-_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
-            targ = np.array([[0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1], [0, 0, 0, 0]])
-            self.assertTrue(np.allclose(mat, targ))
+            with self.subTest("raising operator matrix"):
+                mat = FermionicOp({"+_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
+                targ = np.array([[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 0, -1, 0]])
+                self.assertTrue(np.allclose(mat, targ))
 
-        with self.subTest("nontrivial sparse matrix"):
-            mat = FermionicOp(
-                {"-_0 +_0 +_1 -_1 +_3": 3j, "-_0 +_1 -_1 +_2 -_3": -2}, num_spin_orbitals=4
-            ).to_matrix()
-            targ = csc_matrix(([-3j, 3j, -2], ([5, 7, 6], [4, 6, 13])), shape=(16, 16))
-            self.assertTrue((mat != targ).nnz == 0)
+            with self.subTest("lowering operator matrix"):
+                mat = FermionicOp({"-_1": 1}, num_spin_orbitals=2).to_matrix(sparse=False)
+                targ = np.array([[0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1], [0, 0, 0, 0]])
+                self.assertTrue(np.allclose(mat, targ))
 
-        with self.subTest("Test Hydrogen spectrum"):
-            h2_labels = {
-                "+_0 -_1 +_2 -_3": 0.18093120148374142,
-                "+_0 -_1 -_2 +_3": -0.18093120148374134,
-                "-_0 +_1 +_2 -_3": -0.18093120148374134,
-                "-_0 +_1 -_2 +_3": 0.18093120148374128,
-                "+_3 -_3": -0.4718960038869427,
-                "+_2 -_2": -1.2563391028292563,
-                "+_2 -_2 +_3 -_3": 0.48365053378098793,
-                "+_1 -_1": -0.4718960038869427,
-                "+_1 -_1 +_3 -_3": 0.6985737398458793,
-                "+_1 -_1 +_2 -_2": 0.6645817352647293,
-                "+_0 -_0": -1.2563391028292563,
-                "+_0 -_0 +_3 -_3": 0.6645817352647293,
-                "+_0 -_0 +_2 -_2": 0.6757101625347564,
-                "+_0 -_0 +_1 -_1": 0.48365053378098793,
-            }
-            h2_matrix = FermionicOp(h2_labels, num_spin_orbitals=4).to_matrix()
-            evals, evecs = eigs(h2_matrix)
-            self.assertTrue(np.isclose(np.min(evals), -1.8572750))
-            # make sure the ground state has support only in the 2-particle subspace
-            groundstate = evecs[:, np.argmin(evals)]
-            for idx in np.where(~np.isclose(groundstate, 0))[0]:
-                binary = f"{idx:0{4}b}"
-                self.assertEqual(binary.count("1"), 2)
+            with self.subTest("nontrivial sparse matrix"):
+                mat = FermionicOp(
+                    {"-_0 +_0 +_1 -_1 +_3": 3j, "-_0 +_1 -_1 +_2 -_3": -2}, num_spin_orbitals=4
+                ).to_matrix()
+                targ = csc_matrix(([-3j, 3j, -2], ([5, 7, 6], [4, 6, 13])), shape=(16, 16))
+                self.assertTrue((mat != targ).nnz == 0)
 
-        with self.subTest("parameters"):
-            fer_op = FermionicOp({"+_0": self.a})
-            with self.assertRaisesRegex(ValueError, "parameter"):
-                _ = fer_op.to_matrix()
+            with self.subTest("Test Hydrogen spectrum"):
+                h2_labels = {
+                    "+_0 -_1 +_2 -_3": 0.18093120148374142,
+                    "+_0 -_1 -_2 +_3": -0.18093120148374134,
+                    "-_0 +_1 +_2 -_3": -0.18093120148374134,
+                    "-_0 +_1 -_2 +_3": 0.18093120148374128,
+                    "+_3 -_3": -0.4718960038869427,
+                    "+_2 -_2": -1.2563391028292563,
+                    "+_2 -_2 +_3 -_3": 0.48365053378098793,
+                    "+_1 -_1": -0.4718960038869427,
+                    "+_1 -_1 +_3 -_3": 0.6985737398458793,
+                    "+_1 -_1 +_2 -_2": 0.6645817352647293,
+                    "+_0 -_0": -1.2563391028292563,
+                    "+_0 -_0 +_3 -_3": 0.6645817352647293,
+                    "+_0 -_0 +_2 -_2": 0.6757101625347564,
+                    "+_0 -_0 +_1 -_1": 0.48365053378098793,
+                }
+                h2_matrix = FermionicOp(h2_labels, num_spin_orbitals=4).to_matrix()
+                evals, evecs = eigs(h2_matrix)
+                self.assertTrue(np.isclose(np.min(evals), -1.8572750))
+                # make sure the ground state has support only in the 2-particle subspace
+                groundstate = evecs[:, np.argmin(evals)]
+                for idx in np.where(~np.isclose(groundstate, 0))[0]:
+                    binary = f"{idx:0{4}b}"
+                    self.assertEqual(binary.count("1"), 2)
+
+            with self.subTest("parameters"):
+                fer_op = FermionicOp({"+_0": self.a})
+                with self.assertRaisesRegex(ValueError, "parameter"):
+                    _ = fer_op.to_matrix()
 
     def test_normal_order(self):
         """test normal_order method"""
@@ -613,13 +617,16 @@ class TestFermionicOp(QiskitNatureTestCase):
             self.assertTrue(op1.equiv(1.000001 * op3))
 
         with self.subTest("to_matrix"):
-            ref = np.array([[0, 0], [0, 1]])
-            np.testing.assert_array_almost_equal(op1.to_matrix(False), ref)
-            op1.num_spin_orbitals = 2
-            np.testing.assert_array_almost_equal(op1.to_matrix(False), np.kron(ref, np.eye(2)))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
 
-            ref = np.array([[1]])
-            np.testing.assert_array_almost_equal(op0.to_matrix(False), ref)
+                ref = np.array([[0, 0], [0, 1]])
+                np.testing.assert_array_almost_equal(op1.to_matrix(False), ref)
+                op1.num_spin_orbitals = 2
+                np.testing.assert_array_almost_equal(op1.to_matrix(False), np.kron(ref, np.eye(2)))
+
+                ref = np.array([[1]])
+                np.testing.assert_array_almost_equal(op0.to_matrix(False), ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #875

### Details and comments


