### PR TITLE
Add constraint.txt to deploy translatable script

### DIFF
--- a/tools/deploy_translatable_strings.sh
+++ b/tools/deploy_translatable_strings.sh
@@ -75,6 +75,7 @@ cp -r $SOURCE_DIR/$DOC_DIR_PO/ nature/docs
 cp $SOURCE_DIR/setup.py nature/.
 cp $SOURCE_DIR/requirements-dev.txt nature/.
 cp $SOURCE_DIR/requirements.txt nature/.
+cp $SOURCE_DIR/constraints.txt nature/.
 cp $SOURCE_DIR/README.md nature/.
 cp $SOURCE_DIR/qiskit_nature/VERSION.txt nature/qiskit_nature/.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The nature docs pushing translatable files to qiskit-translations repo is failing. Added right dependencies when runs pip install constraints.txt which is why I'm adding this to the script.

### Details and comments

Requesting to run the docs deploy script and backport the changes.
