### PR TITLE
Deprecate the `(Minimum)EigensolverFactory` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,16 @@ estimator = Estimator()
 # setup the ansatz for VQE
 from qiskit_nature.second_q.circuit.library import HartreeFock, UCCSD
 
-ansatz = UCCSD()
-ansatz.num_particles = problem.num_particles
-ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
-ansatz.qubit_mapper = mapper
-initial_state = HartreeFock()
-initial_state.num_particles = problem.num_particles
-initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
-initial_state.qubit_mapper = mapper
-ansatz.initial_state = initial_state
+ansatz = UCCSD(
+    problem.num_spatial_orbitals,
+    problem.num_particles,
+    mapper,
+    initial_state=HartreeFock(
+        problem.num_spatial_orbitals,
+        problem.num_particles,
+        mapper,
+    ),
+)
 
 # set up our actual VQE instance
 from qiskit.algorithms.minimum_eigensolvers import VQE

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ ansatz.initial_state = initial_state
 from qiskit.algorithms.minimum_eigensolvers import VQE
 
 vqe = VQE(estimator, ansatz, optimizer)
+# ensure that the optimizer starts in the all-zero state which corresponds to
+# the Hartree-Fock starting point
+vqe.initial_point = [0] * ansatz.num_parameters
 
 # prepare the ground-state solver and run it
 from qiskit_nature.second_q.algorithms import GroundStateEigensolver
@@ -113,18 +116,17 @@ H<sub>2</sub>, where the two atoms are configured to be at a distance of 0.735 a
 input specification is processed by the PySCF driver. This driver produces an `ElectronicStructureProblem`
 which gathers all the problem information required by Qiskit Nature.
 The second-quantized operators contained in that problem can be mapped to qubit operators with a
-`QubitConverter`. Here, we chose the parity mapping in combination with a 2-qubit reduction, which
-is a precision-preserving optimization removing two qubits; a reduction in complexity that is particularly
+`QubitMapper`. Here, we chose the `ParityMapper` which automatically removes 2 qubits due to inherit
+symmetries when the `num_particles` are provided to it; a reduction in complexity that is particularly
 advantageous for NISQ computers.
 
 For actually finding the ground state solution, the Variational Quantum Eigensolver (VQE) algorithm is used.
-Its main three components, the estimator primitive, wavefunciton ansatz (`UCCSD`), and optimizer, are passed
-to the `VQEUCCFactory`, a utility of Qiskit Nature simplifying the setup of the `VQE` algorithm and its
-components. This factory also ensures consistent settings for the ansatzes initial state and the optimizers
-initial point.
+Its main three components are the estimator primitive, wavefunciton ansatz (`UCCSD`), and optimizer.
+The `UCCSD` component is the only one provided directly by Qiskit Nature and it is usually paired with the
+`HartreeFock` initial state and an all-zero initial point for the optimizer.
 
-The entire problem is then solved using a `GroundStateEigensolver` which wraps both, the `QubitConverter`
-and `VQEUCCFactory`. Since an `ElectronicStructureProblem` is provided to it (which was the output of the
+The entire problem is then solved using a `GroundStateEigensolver` which wraps both, the `ParityMapper`
+and `VQE`. Since an `ElectronicStructureProblem` is provided to it (which was the output of the
 `PySCFDriver`) it also returns an `ElectronicStructureResult`.
 
 ### Further examples

--- a/docs/howtos/adapt_vqe.rst
+++ b/docs/howtos/adapt_vqe.rst
@@ -27,15 +27,16 @@ This tutorial outlines how the algorithm can be used.
 .. testcode::
 
     from qiskit_nature.second_q.circuit.library import UCCSD, HartreeFock
-    ansatz = UCCSD()
-    ansatz.num_particles = problem.num_particles
-    ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
-    ansatz.qubit_mapper = mapper
-    initial_state = HartreeFock()
-    initial_state.num_particles = problem.num_particles
-    initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
-    initial_state.qubit_mapper = mapper
-    ansatz.initial_state = initial_state
+    ansatz = UCCSD(
+        problem.num_spatial_orbitals,
+        problem.num_particles,
+        mapper,
+        initial_state=HartreeFock(
+            problem.num_spatial_orbitals,
+            problem.num_particles,
+            mapper,
+        ),
+    )
 
 4. We setup a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`:
 

--- a/docs/howtos/adapt_vqe.rst
+++ b/docs/howtos/adapt_vqe.rst
@@ -8,48 +8,62 @@ This tutorial outlines how the algorithm can be used.
 
 1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
 
->>> from qiskit_nature.second_q.drivers import PySCFDriver
->>> driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
->>> problem = driver.run()
+.. testcode::
 
-2. We setup our ``QubitConverter``:
+    from qiskit_nature.second_q.drivers import PySCFDriver
+    driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
+    problem = driver.run()
 
->>> from qiskit_nature.second_q.mappers import JordanWignerMapper, QubitConverter
->>> converter = QubitConverter(JordanWignerMapper())
+2. We setup our ``QubitMapper``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.mappers import JordanWignerMapper
+    mapper = JordanWignerMapper()
 
 3. We setup our ansatz:
 
->>> from qiskit_nature.second_q.circuit.library import UCCSD, HartreeFock
->>> ansatz = UCCSD()
->>> ansatz.num_particles = problem.num_particles
->>> ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
->>> ansatz.qubit_converter = converter
->>> initial_state = HartreeFock()
->>> initial_state.num_particles = problem.num_particles
->>> initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
->>> initial_state.qubit_converter = converter
->>> ansatz.initial_state = initial_state
+.. testcode::
+
+    from qiskit_nature.second_q.circuit.library import UCCSD, HartreeFock
+    ansatz = UCCSD()
+    ansatz.num_particles = problem.num_particles
+    ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
+    ansatz.qubit_mapper = mapper
+    initial_state = HartreeFock()
+    initial_state.num_particles = problem.num_particles
+    initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
+    initial_state.qubit_mapper = mapper
+    ansatz.initial_state = initial_state
 
 4. We setup a ``VQE``:
 
->>> import numpy as np
->>> from qiskit.algorithms.optimizers import SLSQP
->>> from qiskit.algorithms.minimum_eigensolvers import VQE
->>> from qiskit.primitives import Estimator
->>> vqe = VQE(Estimator(), ansatz, SLSQP())
->>> vqe.initial_point = np.zeros(ansatz.num_parameters)
+.. testcode::
+
+    import numpy as np
+    from qiskit.algorithms.optimizers import SLSQP
+    from qiskit.algorithms.minimum_eigensolvers import VQE
+    from qiskit.primitives import Estimator
+    vqe = VQE(Estimator(), ansatz, SLSQP())
+    vqe.initial_point = np.zeros(ansatz.num_parameters)
 
 5. We setup the ``AdaptVQE``:
 
->>> from qiskit.algorithms.minimum_eigensolvers import AdaptVQE
->>> adapt_vqe = AdaptVQE(vqe)
->>> adapt_vqe.supports_aux_operators = lambda: True  # temporary fix
+.. testcode::
+
+    from qiskit.algorithms.minimum_eigensolvers import AdaptVQE
+    adapt_vqe = AdaptVQE(vqe)
+    adapt_vqe.supports_aux_operators = lambda: True  # temporary fix
 
 6. We wrap everything in a ``GroundStateEigensolver``:
 
->>> from qiskit_nature.second_q.algorithms import GroundStateEigensolver
->>> solver = GroundStateEigensolver(converter, adapt_vqe)
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms import GroundStateEigensolver
+    solver = GroundStateEigensolver(mapper, adapt_vqe)
 
 7. We solve the problem:
 
->>> result = solver.solve(problem)
+.. testcode::
+
+    result = solver.solve(problem)

--- a/docs/howtos/adapt_vqe.rst
+++ b/docs/howtos/adapt_vqe.rst
@@ -69,3 +69,9 @@ This tutorial outlines how the algorithm can be used.
 .. testcode::
 
     result = solver.solve(problem)
+
+    print(f"Total ground state energy = {result.total_energies[0]:.4f}")
+
+.. testoutput::
+
+    Total ground state energy = -1.1373

--- a/docs/howtos/adapt_vqe.rst
+++ b/docs/howtos/adapt_vqe.rst
@@ -1,12 +1,13 @@
 How to use the ``AdaptVQE``
 ===========================
 
-As of Qiskit Nature v0.5, the ``AdaptVQE`` algorithm has been migrated to Qiskit
-Terra (released in v0.22).
+As of Qiskit Nature v0.5, the :class:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE`
+algorithm has been migrated to Qiskit Terra (released in v0.22).
 
 This tutorial outlines how the algorithm can be used.
 
-1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+1. We obtain an :class:`~qiskit_nature.second_q.problems.ElectronicStructureProblem`
+   which we want to solve:
 
 .. testcode::
 
@@ -14,7 +15,7 @@ This tutorial outlines how the algorithm can be used.
     driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
     problem = driver.run()
 
-2. We setup our ``QubitMapper``:
+2. We setup our :class:`~qiskit_nature.second_q.mappers.QubitMapper`:
 
 .. testcode::
 
@@ -36,7 +37,7 @@ This tutorial outlines how the algorithm can be used.
     initial_state.qubit_mapper = mapper
     ansatz.initial_state = initial_state
 
-4. We setup a ``VQE``:
+4. We setup a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`:
 
 .. testcode::
 
@@ -47,7 +48,7 @@ This tutorial outlines how the algorithm can be used.
     vqe = VQE(Estimator(), ansatz, SLSQP())
     vqe.initial_point = np.zeros(ansatz.num_parameters)
 
-5. We setup the ``AdaptVQE``:
+5. We setup the :class:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE`:
 
 .. testcode::
 
@@ -55,7 +56,7 @@ This tutorial outlines how the algorithm can be used.
     adapt_vqe = AdaptVQE(vqe)
     adapt_vqe.supports_aux_operators = lambda: True  # temporary fix
 
-6. We wrap everything in a ``GroundStateEigensolver``:
+6. We wrap everything in a :class:`~qiskit_nature.second_q.algorithms.GroundStateEigensolver`:
 
 .. testcode::
 

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -52,7 +52,11 @@ Below we show how you can use this setting.
     result = solver.solve(problem)
 
     print(f"Total ground state energy = {result.total_energies[0]:.4f}")
+    print(f"Total first excited state energy = {result.total_energies[1]:.3f}")
+    print(f"Total second excited state energy = {result.total_energies[2]:.3f}")
 
 .. testoutput::
 
     Total ground state energy = -1.1373
+    Total first excited state energy = -0.163
+    Total second excited state energy = 0.495

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -4,8 +4,8 @@ How to use the ``NumPyEigensolver``
 ===================================
 
 In order to ensure a physically meaningful excited states of a hamiltonian are found when using the
-:class:`~qiskit.algorithms.minimum_eigensolvers.NumPyEigensolver` one needs to set the
-:attr:`~qiskit.algorithms.minimum_eigensolvers.NumPyEigensolver.filter_criterion` attribute
+:class:`~qiskit.algorithms.eigensolvers.NumPyEigensolver` one needs to set the
+:attr:`~qiskit.algorithms.eigensolvers.NumPyEigensolver.filter_criterion` attribute
 of the solver.
 
 Subclasses of :class:`~qiskit_nature.second_q.problems.BaseProblem` in Qiskit Nature provide the

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -1,0 +1,49 @@
+How to use the ``NumPyEigensolver``
+===================================
+
+In order to ensure a physically meaningful excited states of a hamiltonian are found when using the
+:class:`~qiskit.algorithms.minimum_eigensolvers.NumPyEigensolver` one needs to set the
+:attr:`~qiskit.algorithms.minimum_eigensolvers.NumPyEigensolver.filter_criterion` attribute
+of the solver.
+
+Subclasses of :class:`~qiskit_nature.second_q.problems.BaseProblem` in Qiskit Nature provide the
+:meth:`~qiskit_nature.second_q.problems.BaseProblem.get_default_filter_criterion` method which
+provides a default implementation of such a filter criterion for commonly encountered cases.
+
+Below we show how you can use this setting.
+
+1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+
+.. testcode::
+
+   from qiskit_nature.second_q.drivers import PySCFDriver
+   driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
+   problem = driver.run()
+
+2. We setup our ``QubitMapper``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.mappers import JordanWignerMapper
+    mapper = JordanWignerMapper()
+
+3. We setup our ``NumPyEigensolver``:
+
+.. testcode::
+
+    from qiskit.algorithms.eigensolvers import NumPyEigensolver
+    algo = NumPyEigensolver(k=100)
+    algo.filter_criterion = problem.get_default_filter_criterion()
+
+4. We wrap everything in a ``ExcitedStatesEigensolver``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms import ExcitedStatesEigensolver
+    solver = ExcitedStatesEigensolver(mapper, algo)
+
+5. We solve the problem:
+
+.. testcode::
+
+    result = solver.solve(problem)

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -1,3 +1,5 @@
+.. _how-to-numpy:
+
 How to use the ``NumPyEigensolver``
 ===================================
 

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -50,3 +50,9 @@ Below we show how you can use this setting.
 .. testcode::
 
     result = solver.solve(problem)
+
+    print(f"Total ground state energy = {result.total_energies[0]:.4f}")
+
+.. testoutput::
+
+    Total ground state energy = -1.1373

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -14,7 +14,8 @@ provides a default implementation of such a filter criterion for commonly encoun
 
 Below we show how you can use this setting.
 
-1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+1. We obtain an :class:`~qiskit_nature.second_q.problems.ElectronicStructureProblem`
+   which we want to solve:
 
 .. testcode::
 
@@ -22,14 +23,14 @@ Below we show how you can use this setting.
    driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
    problem = driver.run()
 
-2. We setup our ``QubitMapper``:
+2. We setup our :class:`~qiskit_nature.second_q.mappers.QubitMapper`:
 
 .. testcode::
 
     from qiskit_nature.second_q.mappers import JordanWignerMapper
     mapper = JordanWignerMapper()
 
-3. We setup our ``NumPyEigensolver``:
+3. We setup our :class:`~qiskit.algorithms.eigensolvers.NumPyEigensolver`:
 
 .. testcode::
 
@@ -37,7 +38,7 @@ Below we show how you can use this setting.
     algo = NumPyEigensolver(k=100)
     algo.filter_criterion = problem.get_default_filter_criterion()
 
-4. We wrap everything in a ``ExcitedStatesEigensolver``:
+4. We wrap everything in a :class:`~qiskit_nature.second_q.algorithms.ExcitedStatesEigensolver`:
 
 .. testcode::
 

--- a/docs/howtos/numpy_minimum_eigensolver.rst
+++ b/docs/howtos/numpy_minimum_eigensolver.rst
@@ -14,7 +14,8 @@ provides a default implementation of such a filter criterion for commonly encoun
 
 Below we show how you can use this setting.
 
-1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+1. We obtain an :class:`~qiskit_nature.second_q.problems.ElectronicStructureProblem`
+   which we want to solve:
 
 .. testcode::
 
@@ -22,14 +23,14 @@ Below we show how you can use this setting.
     driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
     problem = driver.run()
 
-2. We setup our ``QubitMapper``:
+2. We setup our :class:`~qiskit_nature.second_q.mappers.QubitMapper`:
 
 .. testcode::
 
     from qiskit_nature.second_q.mappers import JordanWignerMapper
     mapper = JordanWignerMapper()
 
-3. We setup our ``NumPyMinimumEigensolver``:
+3. We setup our :class:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver`:
 
 .. testcode::
 
@@ -37,7 +38,7 @@ Below we show how you can use this setting.
     algo = NumPyMinimumEigensolver()
     algo.filter_criterion = problem.get_default_filter_criterion()
 
-4. We wrap everything in a ``GroundStateEigensolver``:
+4. We wrap everything in a :class:`~qiskit_nature.second_q.algorithms.GroundStateEigensolver`:
 
 .. testcode::
 

--- a/docs/howtos/numpy_minimum_eigensolver.rst
+++ b/docs/howtos/numpy_minimum_eigensolver.rst
@@ -1,3 +1,5 @@
+.. _how-to-numpy-min:
+
 How to use the ``NumPyMinimumEigensolver``
 ==========================================
 

--- a/docs/howtos/numpy_minimum_eigensolver.rst
+++ b/docs/howtos/numpy_minimum_eigensolver.rst
@@ -1,0 +1,49 @@
+How to use the ``NumPyMinimumEigensolver``
+==========================================
+
+In order to ensure a physically meaningful ground state of a hamiltonian is found when using the
+:class:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver` one needs to set the
+:attr:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver.filter_criterion` attribute
+of the solver.
+
+Subclasses of :class:`~qiskit_nature.second_q.problems.BaseProblem` in Qiskit Nature provide the
+:meth:`~qiskit_nature.second_q.problems.BaseProblem.get_default_filter_criterion` method which
+provides a default implementation of such a filter criterion for commonly encountered cases.
+
+Below we show how you can use this setting.
+
+1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+
+.. testcode::
+
+    from qiskit_nature.second_q.drivers import PySCFDriver
+    driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
+    problem = driver.run()
+
+2. We setup our ``QubitMapper``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.mappers import JordanWignerMapper
+    mapper = JordanWignerMapper()
+
+3. We setup our ``NumPyMinimumEigensolver``:
+
+.. testcode::
+
+    from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
+    algo = NumPyMinimumEigensolver()
+    algo.filter_criterion = problem.get_default_filter_criterion()
+
+4. We wrap everything in a ``GroundStateEigensolver``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms import GroundStateEigensolver
+    solver = GroundStateEigensolver(mapper, algo)
+
+5. We solve the problem:
+
+.. testcode::
+
+    result = solver.solve(problem)

--- a/docs/howtos/numpy_minimum_eigensolver.rst
+++ b/docs/howtos/numpy_minimum_eigensolver.rst
@@ -50,3 +50,9 @@ Below we show how you can use this setting.
 .. testcode::
 
     result = solver.solve(problem)
+
+    print(f"Total ground state energy = {result.total_energies[0]:.4f}")
+
+.. testoutput::
+
+    Total ground state energy = -1.1373

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -1,3 +1,5 @@
+.. _how-to-vqe-ucc:
+
 How to use a UCC-like ansatz with a ``VQE``
 ===========================================
 

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -31,15 +31,16 @@ Hartree-Fock state).
 .. testcode::
 
     from qiskit_nature.second_q.circuit.library import UCCSD, HartreeFock
-    ansatz = UCCSD()
-    ansatz.num_particles = problem.num_particles
-    ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
-    ansatz.qubit_mapper = mapper
-    initial_state = HartreeFock()
-    initial_state.num_particles = problem.num_particles
-    initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
-    initial_state.qubit_mapper = mapper
-    ansatz.initial_state = initial_state
+    ansatz = UCCSD(
+        problem.num_spatial_orbitals,
+        problem.num_particles,
+        mapper,
+        initial_state=HartreeFock(
+            problem.num_spatial_orbitals,
+            problem.num_particles,
+            mapper,
+        ),
+    )
 
 4. We setup a ``VQE``:
 

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -1,0 +1,91 @@
+How to use a UCC-like ansatz with a ``VQE``
+===========================================
+
+When using a :class:`~qiskit_nature.second_q.circuit.library.UCC`-style ansatz with a
+:class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the
+:attr:`~qiskit.algorithms.minimum_eigensolvers.VQE.initial_point` attribute which indicates from
+which set of initial parameters the optimization routine should start.
+By default, the algorithm will start from a *random* initial point. In this how to we show how one
+can set a custom initial point instead (for example to guarantee that one starts from the
+Hartree-Fock state).
+
+1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+
+.. testcode::
+
+    from qiskit_nature.second_q.drivers import PySCFDriver
+    driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
+    problem = driver.run()
+
+2. We setup our ``QubitMapper``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.mappers import JordanWignerMapper
+    mapper = JordanWignerMapper()
+
+3. We setup our ansatz:
+
+.. testcode::
+
+    from qiskit_nature.second_q.circuit.library import UCCSD, HartreeFock
+    ansatz = UCCSD()
+    ansatz.num_particles = problem.num_particles
+    ansatz.num_spatial_orbitals = problem.num_spatial_orbitals
+    ansatz.qubit_mapper = mapper
+    initial_state = HartreeFock()
+    initial_state.num_particles = problem.num_particles
+    initial_state.num_spatial_orbitals = problem.num_spatial_orbitals
+    initial_state.qubit_mapper = mapper
+    ansatz.initial_state = initial_state
+
+4. We setup a ``VQE``:
+
+.. testcode::
+
+    import numpy as np
+    from qiskit.algorithms.optimizers import SLSQP
+    from qiskit.algorithms.minimum_eigensolvers import VQE
+    from qiskit.primitives import Estimator
+    vqe = VQE(Estimator(), ansatz, SLSQP())
+
+5. Now comes the key step: choosing the initial point. Since we picked the ``HartreeFock`` initial
+   state before, in order to ensure we start from that, we need to initialize our ``initial_point``
+   with all-zero parameters. One way to do that is like so:
+
+.. testcode::
+
+    vqe.initial_point = np.zeros(ansatz.num_parameters)
+
+Alternatively, one can also use
+:class:`~qiskit_nature.second_q.algorithms.initial_points.HFInitialPoint` like so:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms.initial_points import HFInitialPoint
+    initial_point = HFInitialPoint()
+    initial_point.ansatz = ansatz
+    initial_point.problem = problem
+    vqe.initial_point = initial_point.to_numpy_array()
+
+This may seem like it is not adding a lot of benefit, but the key aspect here is that you can build
+your code on top of the :class:`~qiskit_nature.second_q.algorithms.initial_points.InitialPoint`
+interface based on which we also have the
+:class:`~qiskit_nature.second_q.algorithms.initial_points.MP2InitialPoint` which allows you to start
+from an MP2 starting point like so:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms.initial_points import MP2InitialPoint
+    initial_point = MP2InitialPoint()
+    initial_point.ansatz = ansatz
+    initial_point.problem = problem
+    vqe.initial_point = initial_point.to_numpy_array()
+
+6. Finally, we can now actually solve our problem:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms import GroundStateEigensolver
+    solver = GroundStateEigensolver(mapper, vqe)
+    result = solver.solve(problem)

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -11,7 +11,8 @@ By default, the algorithm will start from a *random* initial point. In this how 
 can set a custom initial point instead (for example to guarantee that one starts from the
 Hartree-Fock state).
 
-1. We obtain an ``ElectronicStructureProblem`` which we want to solve:
+1. We obtain an :class:`~qiskit_nature.second_q.problems.ElectronicStructureProblem`
+   which we want to solve:
 
 .. testcode::
 
@@ -19,7 +20,7 @@ Hartree-Fock state).
     driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", basis="sto-3g")
     problem = driver.run()
 
-2. We setup our ``QubitMapper``:
+2. We setup our :class:`~qiskit_nature.second_q.mappers.QubitMapper`:
 
 .. testcode::
 
@@ -42,7 +43,7 @@ Hartree-Fock state).
         ),
     )
 
-4. We setup a ``VQE``:
+4. We setup a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`:
 
 .. testcode::
 
@@ -52,9 +53,10 @@ Hartree-Fock state).
     from qiskit.primitives import Estimator
     vqe = VQE(Estimator(), ansatz, SLSQP())
 
-5. Now comes the key step: choosing the initial point. Since we picked the ``HartreeFock`` initial
-   state before, in order to ensure we start from that, we need to initialize our ``initial_point``
-   with all-zero parameters. One way to do that is like so:
+5. Now comes the key step: choosing the initial point. Since we picked the
+   :class:`~qiskit_nature.second_q.circuit.library.HartreeFock` initial
+   state before, in order to ensure we start from that, we need to initialize our
+   ``initial_point`` with all-zero parameters. One way to do that is like so:
 
 .. testcode::
 

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -94,3 +94,9 @@ from an MP2 starting point like so:
     from qiskit_nature.second_q.algorithms import GroundStateEigensolver
     solver = GroundStateEigensolver(mapper, vqe)
     result = solver.solve(problem)
+
+    print(f"Total ground state energy = {result.total_energies[0]:.4f}")
+
+.. testoutput::
+
+    Total ground state energy = -1.1373

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -7,7 +7,7 @@ When using a :class:`~qiskit_nature.second_q.circuit.library.UCC`-style ansatz w
 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the
 :attr:`~qiskit.algorithms.minimum_eigensolvers.VQE.initial_point` attribute which indicates from
 which set of initial parameters the optimization routine should start.
-By default, the algorithm will start from a *random* initial point. In this how to we show how one
+By default, VQE will start from a *random* initial point. In this how to we show how one
 can set a custom initial point instead (for example to guarantee that one starts from the
 Hartree-Fock state).
 

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -7,7 +7,7 @@ When using a :class:`~qiskit_nature.second_q.circuit.library.UVCC`-style ansatz 
 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the
 :attr:`~qiskit.algorithms.minimum_eigensolvers.VQE.initial_point` attribute which indicates from
 which set of initial parameters the optimization routine should start.
-By default, the algorithm will start from a *random* initial point. In this how to we show how one
+By default, VQE will start from a *random* initial point. In this how to we show how one
 can set a custom initial point instead (for example to guarantee that one starts from the
 VSCF state).
 

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -15,7 +15,8 @@ The basics of this how-to are identical to the UCC-like ansatz how-to (TODO: add
 we will simply show how to use the
 :class:`~qiskit_nature.second_q.algorithms.initial_points.VSCFInitialPoint` like so:
 
-1. Assuming we already have our ``VibrationalStructureProblem`` and ``QubitMapper``:
+1. Assuming we already have our :class:`~qiskit_nature.second_q.problems.VibrationalStructureProblem`
+   and :class:`~qiskit_nature.second_q.mappers.QubitMapper`:
 
 .. testcode::
 
@@ -39,7 +40,7 @@ we will simply show how to use the
         ),
     )
 
-3. We setup a ``VQE``:
+3. We setup a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`:
 
 .. testcode::
 
@@ -49,8 +50,9 @@ we will simply show how to use the
     from qiskit.primitives import Estimator
     vqe = VQE(Estimator(), ansatz, SLSQP())
 
-4. Now comes the key step: choosing the initial point. Since we picked the ``VSCF`` initial
-   state before, in order to ensure we start from that, we need to initialize our ``initial_point``
+4. Now comes the key step: choosing the initial point. Since we picked the
+   :class:`~qiskit_nature.second_q.circuit.library.VSCF` initial state before,
+   in order to ensure we start from that, we need to initialize our ``initial_point``
    with all-zero parameters. One way to do that is like so:
 
 .. testcode::

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -30,13 +30,14 @@ we will simply show how to use the
 .. testcode::
 
     from qiskit_nature.second_q.circuit.library import UVCCSD, VSCF
-    ansatz = UVCCSD()
-    ansatz.num_modals = num_modals
-    ansatz.qubit_mapper = mapper
-    initial_state = VSCF()
-    initial_state.num_modals = num_modals
-    initial_state.qubit_mapper = mapper
-    ansatz.initial_state = initial_state
+    ansatz = UVCCSD(
+        num_modals,
+        mapper,
+        initial_state=VSCF(
+            num_modals,
+            mapper,
+        ),
+    )
 
 3. We setup a ``VQE``:
 

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -1,0 +1,69 @@
+How to use a UVCC-like ansatz with a ``VQE``
+============================================
+
+When using a :class:`~qiskit_nature.second_q.circuit.library.UVCC`-style ansatz with a
+:class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the
+:attr:`~qiskit.algorithms.minimum_eigensolvers.VQE.initial_point` attribute which indicates from
+which set of initial parameters the optimization routine should start.
+By default, the algorithm will start from a *random* initial point. In this how to we show how one
+can set a custom initial point instead (for example to guarantee that one starts from the
+VSCF state).
+
+The basics of this how-to are identical to the UCC-like ansatz how-to (TODO: add link). Thus, here
+we will simply show how to use the
+:class:`~qiskit_nature.second_q.algorithms.initial_points.VSCFInitialPoint` like so:
+
+1. Assuming we already have our ``VibrationalStructureProblem`` and ``QubitMapper``:
+
+.. testcode::
+
+    from qiskit_nature.second_q.mappers import DirectMapper
+    from qiskit_nature.second_q.problems import VibrationalStructureProblem
+    problem: VibrationalStructureProblem = ...
+    num_modals = [2, 2, 2]  # some example of what problem.num_modals might yield
+    mapper = DirectMapper()
+
+2. We setup our ansatz:
+
+.. testcode::
+
+    from qiskit_nature.second_q.circuit.library import UVCCSD, VSCF
+    ansatz = UVCCSD()
+    ansatz.num_modals = num_modals
+    ansatz.qubit_mapper = mapper
+    initial_state = VSCF()
+    initial_state.num_modals = num_modals
+    initial_state.qubit_mapper = mapper
+    ansatz.initial_state = initial_state
+
+3. We setup a ``VQE``:
+
+.. testcode::
+
+    import numpy as np
+    from qiskit.algorithms.optimizers import SLSQP
+    from qiskit.algorithms.minimum_eigensolvers import VQE
+    from qiskit.primitives import Estimator
+    vqe = VQE(Estimator(), ansatz, SLSQP())
+
+4. Now comes the key step: choosing the initial point. Since we picked the ``VSCF`` initial
+   state before, in order to ensure we start from that, we need to initialize our ``initial_point``
+   with all-zero parameters. One way to do that is like so:
+
+.. testcode::
+
+    vqe.initial_point = np.zeros(ansatz.num_parameters)
+
+Alternatively, one can also use
+:class:`~qiskit_nature.second_q.algorithms.initial_points.VSCFInitialPoint` like so:
+
+.. testcode::
+
+    from qiskit_nature.second_q.algorithms.initial_points import VSCFInitialPoint
+    initial_point = VSCFInitialPoint()
+    initial_point.ansatz = ansatz
+    initial_point.problem = problem
+    vqe.initial_point = initial_point.to_numpy_array()
+
+Just like in the UCC-ansatz case, this is mostly useful when building more code on top of the
+:class:`~qiskit_nature.second_q.algorithms.initial_points.InitialPoint` interface.

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -1,3 +1,5 @@
+.. _how-to-vqe-uvcc:
+
 How to use a UVCC-like ansatz with a ``VQE``
 ============================================
 

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -70,5 +70,5 @@ Alternatively, one can also use
     initial_point.problem = problem
     vqe.initial_point = initial_point.to_numpy_array()
 
-Just like in the UCC-ansatz case, this is mostly useful when building more code on top of the
-:class:`~qiskit_nature.second_q.algorithms.initial_points.InitialPoint` interface.
+Just like in the :ref:`UCC-ansatz case <how-to-vqe-ucc>`, this is mostly useful when building more
+code on top of the :class:`~qiskit_nature.second_q.algorithms.initial_points.InitialPoint` interface.

--- a/docs/tutorials/01_electronic_structure.ipynb
+++ b/docs/tutorials/01_electronic_structure.ipynb
@@ -123,7 +123,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<qiskit_nature.second_q.problems.electronic_structure_problem.ElectronicStructureProblem object at 0x15287045b700>\n"
+      "<qiskit_nature.second_q.problems.electronic_structure_problem.ElectronicStructureProblem object at 0x7f3647c732b0>\n"
      ]
     }
    ],
@@ -409,7 +409,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit_nature.second_q.problems.electronic_properties_container.ElectronicPropertiesContainer at 0x152870462310>"
+       "<qiskit_nature.second_q.problems.electronic_properties_container.ElectronicPropertiesContainer at 0x7f3647c733a0>"
       ]
      },
      "execution_count": 11,
@@ -429,7 +429,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit_nature.second_q.properties.particle_number.ParticleNumber at 0x1528704623a0>"
+       "<qiskit_nature.second_q.properties.particle_number.ParticleNumber at 0x7f3647c73430>"
       ]
      },
      "execution_count": 12,
@@ -449,7 +449,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit_nature.second_q.properties.angular_momentum.AngularMomentum at 0x1528704621f0>"
+       "<qiskit_nature.second_q.properties.angular_momentum.AngularMomentum at 0x7f3647c73310>"
       ]
      },
      "execution_count": 13,
@@ -469,7 +469,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit_nature.second_q.properties.magnetization.Magnetization at 0x1528704622e0>"
+       "<qiskit_nature.second_q.properties.magnetization.Magnetization at 0x7f3647c73370>"
       ]
      },
      "execution_count": 14,
@@ -489,7 +489,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit_nature.second_q.properties.dipole_moment.ElectronicDipoleMoment at 0x152870462790>"
+       "<qiskit_nature.second_q.properties.dipole_moment.ElectronicDipoleMoment at 0x7f3647c73490>"
       ]
      },
      "execution_count": 15,
@@ -523,12 +523,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver, NumPyMinimumEigensolverFactory\n",
+    "from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver\n",
+    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver\n",
     "from qiskit_nature.second_q.mappers import JordanWignerMapper, QubitConverter\n",
     "\n",
     "solver = GroundStateEigensolver(\n",
     "    QubitConverter(JordanWignerMapper()),\n",
-    "    NumPyMinimumEigensolverFactory(),\n",
+    "    NumPyMinimumEigensolver(),\n",
     ")"
    ]
   },
@@ -582,7 +583,7 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.23.0.dev0+fca8db6</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.14</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20220819 (Red Hat 12.2.1-1)</td></tr><tr><td>Python build</td><td>main, Sep  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.501182556152344</td></tr><tr><td colspan='2'>Fri Oct 21 11:22:40 2022 CEST</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0.dev0+3005806</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.2</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.16</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20221121 (Red Hat 12.2.1-4)</td></tr><tr><td>Python build</td><td>main, Dec  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.50002670288086</td></tr><tr><td colspan='2'>Tue Mar 14 18:16:39 2023 CET</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -594,7 +595,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2022.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
+       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2023.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -628,7 +629,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/02_vibrational_structure.ipynb
+++ b/docs/tutorials/02_vibrational_structure.ipynb
@@ -656,17 +656,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver, NumPyMinimumEigensolverFactory\n",
-    "\n",
-    "solver = GroundStateEigensolver(\n",
-    "    qubit_converter,\n",
-    "    NumPyMinimumEigensolverFactory(use_default_filter_criterion=True),\n",
-    ")"
+    "# for simplicity, we will use the smaller basis again\n",
+    "vibrational_problem = driver.run(basis=HarmonicBasis([2, 2, 2, 2]))\n",
+    "vibrational_problem.hamiltonian.truncation_order = 2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver\n",
+    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver\n",
+    "\n",
+    "solver = GroundStateEigensolver(\n",
+    "    qubit_converter,\n",
+    "    NumPyMinimumEigensolver(filter_criterion=vibrational_problem.get_default_filter_criterion()),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -685,23 +697,19 @@
     }
    ],
    "source": [
-    "# for simplicity, we will use the smaller basis again\n",
-    "vibrational_problem = driver.run(basis=HarmonicBasis([2, 2, 2, 2]))\n",
-    "vibrational_problem.hamiltonian.truncation_order = 2\n",
-    "\n",
     "result = solver.solve(vibrational_problem)\n",
     "print(result)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.23.0.dev0+3095955</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.0</td></tr><tr><td><code>qiskit-nature</code></td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.15</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20220819 (Red Hat 12.2.1-2)</td></tr><tr><td>Python build</td><td>main, Oct 12 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.501182556152344</td></tr><tr><td colspan='2'>Fri Nov 04 08:57:18 2022 CET</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0.dev0+3005806</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.2</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.16</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20221121 (Red Hat 12.2.1-4)</td></tr><tr><td>Python build</td><td>main, Dec  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.50002670288086</td></tr><tr><td colspan='2'>Tue Mar 14 18:17:50 2023 CET</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -713,7 +721,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2022.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
+       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2023.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -747,7 +755,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/03_ground_state_solvers.ipynb
+++ b/docs/tutorials/03_ground_state_solvers.ipynb
@@ -99,12 +99,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qiskit.algorithms.minimum_eigensolvers import VQE\n",
     "from qiskit.algorithms.optimizers import SLSQP\n",
     "from qiskit.primitives import Estimator\n",
-    "from qiskit_nature.second_q.algorithms import VQEUCCFactory\n",
-    "from qiskit_nature.second_q.circuit.library import UCCSD\n",
+    "from qiskit_nature.second_q.circuit.library import HartreeFock, UCCSD\n",
     "\n",
-    "vqe_solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())"
+    "ansatz = UCCSD(\n",
+    "    es_problem.num_spatial_orbitals,\n",
+    "    es_problem.num_particles,\n",
+    "    converter,\n",
+    "    initial_state=HartreeFock(\n",
+    "        es_problem.num_spatial_orbitals,\n",
+    "        es_problem.num_particles,\n",
+    "        converter,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "vqe_solver = VQE(Estimator(), ansatz, SLSQP())\n",
+    "vqe_solver.initial_point = [0.0] * ansatz.num_parameters"
    ]
   },
   {
@@ -114,7 +126,7 @@
     "To define the VQE solver one needs three essential elements:\n",
     "\n",
     "1. An Estimator primitive: these were released as part of Qiskit Terra 0.22. To learn more about primitives, check out [this resource](https://qiskit.org/documentation/apidoc/primitives.html).\n",
-    "2. A variational form: here we use the Unitary Coupled Cluster (UCC) ansatz (see for instance [Physical Review A 98.2 (2018): 022322]). Since it is a chemistry standard, a factory is already available allowing a fast initialization of a VQE with UCC. The default is to use all single and double excitations. However, the excitation type (S, D, SD) as well as other parameters can be selected. Since we are using the `VQEUCCFactory`, this will also prepend the `UCCSD` variational form with a `HartreeFock` initial state, which initializes the occupation of our qubits according to the problem which we are trying solve.\n",
+    "2. A variational form: here we use the Unitary Coupled Cluster (UCC) ansatz (see for instance [Physical Review A 98.2 (2018): 022322]). Since it is a chemistry standard, a factory is already available allowing a fast initialization of a VQE with UCC. The default is to use all single and double excitations. However, the excitation type (S, D, SD) as well as other parameters can be selected. We also prepend the `UCCSD` variational form with a `HartreeFock` initial state, which initializes the occupation of our qubits according to the problem which we are trying solve.\n",
     "3. An optimizer: this is the classical piece of code in charge of optimizing the parameters in our variational form. See [the corresponding documentation of Qiskit Terra](https://qiskit.org/documentation/stubs/qiskit.algorithms.optimizers.html) for more information.\n",
     "\n",
     "One could also use any available ansatz / initial state or even define one's own. For instance,"
@@ -168,9 +180,8 @@
     "This will now take of the entire workflow:\n",
     "1. generating the second-quantized operators stored in our `problem`\n",
     "2. mapping (and potentially reducing) the operators in the qubit space\n",
-    "3. if we provided a quantum algorithm factory (e.g. `VQEUCCFactory`): finalizing its setup based on the `problem`\n",
-    "4. running the quantum algorithm on the Hamiltonian qubit operator\n",
-    "5. once converged, evaluating the additional observables at the determined ground state"
+    "3. running the quantum algorithm on the Hamiltonian qubit operator\n",
+    "4. once converged, evaluating the additional observables at the determined ground state"
    ]
   },
   {
@@ -303,8 +314,8 @@
     }
    ],
    "source": [
+    "from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver\n",
     "from qiskit_nature.second_q.drivers import GaussianForcesDriver\n",
-    "from qiskit_nature.second_q.algorithms import NumPyMinimumEigensolverFactory\n",
     "from qiskit_nature.second_q.mappers import DirectMapper\n",
     "from qiskit_nature.second_q.problems import HarmonicBasis\n",
     "\n",
@@ -315,8 +326,10 @@
     "\n",
     "converter = QubitConverter(DirectMapper())\n",
     "\n",
-    "solver_without_filter = NumPyMinimumEigensolverFactory(use_default_filter_criterion=False)\n",
-    "solver_with_filter = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)\n",
+    "solver_without_filter = NumPyMinimumEigensolver()\n",
+    "solver_with_filter = NumPyMinimumEigensolver(\n",
+    "    filter_criterion=vib_problem.get_default_filter_criterion()\n",
+    ")\n",
     "\n",
     "gsc_wo = GroundStateEigensolver(converter, solver_without_filter)\n",
     "result_wo = gsc_wo.solve(vib_problem)\n",
@@ -337,7 +350,7 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.23.0.dev0+72ba2ee</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.0</td></tr><tr><td><code>qiskit-nature</code></td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.15</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20220819 (Red Hat 12.2.1-2)</td></tr><tr><td>Python build</td><td>main, Oct 12 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.501182556152344</td></tr><tr><td colspan='2'>Mon Oct 31 17:52:27 2022 CET</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0.dev0+3005806</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.2</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.16</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20221121 (Red Hat 12.2.1-4)</td></tr><tr><td>Python build</td><td>main, Dec  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.50002670288086</td></tr><tr><td colspan='2'>Tue Mar 14 18:22:35 2023 CET</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -349,7 +362,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2022.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
+       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2023.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -383,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/04_excited_states_solvers.ipynb
+++ b/docs/tutorials/04_excited_states_solvers.ipynb
@@ -76,9 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit_nature.second_q.algorithms import NumPyEigensolverFactory\n",
+    "from qiskit.algorithms.eigensolvers import NumPyEigensolver\n",
     "\n",
-    "numpy_solver = NumPyEigensolverFactory(use_default_filter_criterion=True)"
+    "numpy_solver = NumPyEigensolver(filter_criterion=es_problem.get_default_filter_criterion())"
    ]
   },
   {
@@ -132,15 +132,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qiskit.algorithms.minimum_eigensolvers import VQE\n",
     "from qiskit.algorithms.optimizers import SLSQP\n",
     "from qiskit.primitives import Estimator\n",
-    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver, QEOM, VQEUCCFactory\n",
-    "from qiskit_nature.second_q.circuit.library import UCCSD\n",
+    "from qiskit_nature.second_q.algorithms import GroundStateEigensolver, QEOM\n",
+    "from qiskit_nature.second_q.circuit.library import HartreeFock, UCCSD\n",
+    "\n",
+    "ansatz = UCCSD(\n",
+    "    es_problem.num_spatial_orbitals,\n",
+    "    es_problem.num_particles,\n",
+    "    converter,\n",
+    "    initial_state=HartreeFock(\n",
+    "        es_problem.num_spatial_orbitals,\n",
+    "        es_problem.num_particles,\n",
+    "        converter,\n",
+    "    ),\n",
+    ")\n",
     "\n",
     "estimator = Estimator()\n",
     "# This first part sets the ground state solver\n",
     "# see more about this part in the ground state calculation tutorial\n",
-    "solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())\n",
+    "solver = VQE(estimator, ansatz, SLSQP())\n",
+    "solver.initial_point = [0.0] * ansatz.num_parameters\n",
     "gse = GroundStateEigensolver(converter, solver)\n",
     "\n",
     "# The qEOM algorithm is simply instantiated with the chosen ground state solver and Estimator primitive\n",
@@ -365,7 +378,7 @@
     "    return np.isclose(aux_values[\"ParticleNumber\"][0], 2.0)\n",
     "\n",
     "\n",
-    "new_numpy_solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)\n",
+    "new_numpy_solver = NumPyEigensolver(filter_criterion=filter_criterion)\n",
     "new_numpy_excited_states_solver = ExcitedStatesEigensolver(converter, new_numpy_solver)\n",
     "new_numpy_results = new_numpy_excited_states_solver.solve(es_problem)\n",
     "\n",
@@ -380,7 +393,7 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.23.0.dev0+fca8db6</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.14</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20220819 (Red Hat 12.2.1-1)</td></tr><tr><td>Python build</td><td>main, Sep  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.501182556152344</td></tr><tr><td colspan='2'>Fri Oct 21 14:59:29 2022 CEST</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0.dev0+3005806</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.2</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.16</td></tr><tr><td>Python compiler</td><td>GCC 12.2.1 20221121 (Red Hat 12.2.1-4)</td></tr><tr><td>Python build</td><td>main, Dec  7 2022 00:00:00</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>62.50002670288086</td></tr><tr><td colspan='2'>Tue Mar 14 18:25:04 2023 CET</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -392,7 +405,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2022.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
+       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2023.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -426,7 +439,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/qiskit_nature/deprecation.py
+++ b/qiskit_nature/deprecation.py
@@ -197,7 +197,7 @@ def warn_deprecated_type(
     version: str,
     argument_name: str,
     old_type: str,
-    new_type: str,
+    new_type: Optional[str] = None,
     additional_msg: Optional[str] = None,
     stack_level: int = 2,
     category: Type[Warning] = DeprecationWarning,
@@ -209,7 +209,7 @@ def warn_deprecated_type(
         version: Version to be used
         argument_name: The name of the argument whose type gets deprecated.
         old_type: Old type to be used
-        new_type: New type to be used.
+        new_type: New type to be used, if None, the type is deprecated without replacement.
         additional_msg: any additional message
         stack_level: stack level
         category: warning category
@@ -223,9 +223,10 @@ def warn_deprecated_type(
 
     msg = (
         f"The {old_type} type in the '{argument_name}' argument is deprecated as of version "
-        f"{version} and will be removed no sooner than 3 months after the release. "
-        f"Instead use the {new_type} type"
+        f"{version} and will be removed no sooner than 3 months after the release"
     )
+    if new_type:
+        msg += f". Instead use the {new_type} type"
     if additional_msg:
         msg += f" {additional_msg}"
     msg += "."

--- a/qiskit_nature/second_q/algorithms/__init__.py
+++ b/qiskit_nature/second_q/algorithms/__init__.py
@@ -40,7 +40,7 @@ the solvers themselves
    ExcitedStatesEigensolver
    QEOM
 
-the specific raw result for the qEOM solver
+and the specific raw result for the qEOM solver.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -48,8 +48,8 @@ the specific raw result for the qEOM solver
 
    QEOMResult
 
-and factories to provision quantum and/or classical algorithms upon which the above solvers may
-depend
+The following factories are still available but have been **deprecated** in version 0.6.0 of Qiskit
+Nature:
 
 .. autosummary::
    :toctree: ../stubs/
@@ -70,7 +70,7 @@ The interface for such solvers,
 
    GroundStateSolver
 
-the solvers themselves
+the solvers themselves.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -78,8 +78,8 @@ the solvers themselves
 
    GroundStateEigensolver
 
-and factories to provision quantum and/or classical algorithms upon which the above solvers may
-depend
+The following factories are still available but have been **deprecated** in version 0.6.0 of Qiskit
+Nature:
 
 .. autosummary::
    :toctree: ../stubs/
@@ -92,8 +92,14 @@ depend
 
 Initial Points
 ++++++++++++++
-The factories linked above make use of utility classes to compute initial points to use with
-specific ansatzes. More details may be found in the sub-module linked below.
+When using variational algorithms such as the :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`
+it may be necessary to set the initial parameters for the optimizer to a specific value (by default,
+the optimizer will start from a random point). This depends on the problem one is trying to solve as
+well as the ansatz used to solve the problem. To this extent, the following submodule provides
+generator classes for such an ``initial_point``. For more information, refer to the documentation of
+the submodule linked below as well as the how-to guides on
+:ref:`using a UCC-like ansatz with a VQE <how-to-vqe-ucc>` or on
+:ref:`using a UVCC-like ansatz with a VQE <how-to-vqe-uvcc>` for some specific examples.
 
 .. autosummary::
    :toctree:

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/eigensolver_factories/eigensolver_factory.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/eigensolver_factories/eigensolver_factory.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,7 +20,7 @@ from qiskit_nature.second_q.problems.base_problem import BaseProblem
 
 
 class EigensolverFactory(ABC):
-    """A factory to construct an eigensolver based on a qubit operator transformation."""
+    """DEPRECATED A factory to construct an eigensolver based on a qubit operator transformation."""
 
     @abstractmethod
     def get_solver(self, problem: BaseProblem) -> Eigensolver:

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/eigensolver_factories/numpy_eigensolver_factory.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/eigensolver_factories/numpy_eigensolver_factory.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,12 +18,19 @@ import numpy as np
 from qiskit.algorithms.eigensolvers import Eigensolver, NumPyEigensolver
 from qiskit.utils.validation import validate_min
 
+from qiskit_nature.deprecation import DeprecatedType, warn_deprecated
 from qiskit_nature.second_q.problems.base_problem import BaseProblem
 from .eigensolver_factory import EigensolverFactory
 
 
 class NumPyEigensolverFactory(EigensolverFactory):
-    """A factory to construct a NumPyEigensolver."""
+    """DEPRECATED A factory to construct a NumPyEigensolver.
+
+    .. warning::
+
+        This class is deprecated! Please see :ref:`this guide <how-to-numpy>` for how to replace
+        your usage of it!
+    """
 
     def __init__(
         self,
@@ -46,6 +53,16 @@ class NumPyEigensolverFactory(EigensolverFactory):
             use_default_filter_criterion: Whether to use the transformation's default filter
                 criterion if ``filter_criterion`` is ``None``.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "NumPyMinimumEigensolverFactory",
+            additional_msg=(
+                ". This class is deprecated without replacement. Instead, refer to this how-to "
+                "guide which explains the steps you need to take to replace the use of this class: "
+                "https://qiskit.org/documentation/nature/howtos/numpy_minimum_eigensolver.html"
+            ),
+        )
         self._filter_criterion = filter_criterion
         self._k = k  # pylint:disable=invalid-name
         self._use_default_filter_criterion = use_default_filter_criterion

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/excited_states_eigensolver.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/excited_states_eigensolver.py
@@ -60,6 +60,12 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
             qubit_converter: DEPRECATED The ``QubitConverter`` or ``QubitMapper`` to use for mapping
                 and symmetry reduction.
         """
+        if isinstance(solver, EigensolverFactory):
+            warn_deprecated_type(
+                "0.6.0",
+                "solver",
+                "EigensolverFactory",
+            )
         self._qubit_mapper = qubit_mapper
         self._solver = solver
 
@@ -71,6 +77,12 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
     @solver.setter
     def solver(self, solver: Eigensolver | EigensolverFactory) -> None:
         """Sets the minimum eigensolver or factory."""
+        if isinstance(solver, EigensolverFactory):
+            warn_deprecated_type(
+                "0.6.0",
+                "solver",
+                "EigensolverFactory",
+            )
         self._solver = solver
 
     def get_qubit_operators(
@@ -136,6 +148,11 @@ class ExcitedStatesEigensolver(ExcitedStatesSolver):
                     )
 
         if isinstance(self._solver, EigensolverFactory):
+            warn_deprecated_type(
+                "0.6.0",
+                "solver",
+                "EigensolverFactory",
+            )
             # this must be called after transformation.transform
             self._solver = self._solver.get_solver(problem)
 

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/ground_state_eigensolver.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/ground_state_eigensolver.py
@@ -62,6 +62,12 @@ class GroundStateEigensolver(GroundStateSolver):
             solver: Minimum Eigensolver or MESFactory object, e.g. the VQEUCCSDFactory.
         """
         super().__init__(qubit_mapper)
+        if isinstance(solver, MinimumEigensolverFactory):
+            warn_deprecated_type(
+                "0.6.0",
+                "solver",
+                "MinimumEigensolverFactory",
+            )
         self._solver = solver
 
     @property
@@ -155,6 +161,11 @@ class GroundStateEigensolver(GroundStateSolver):
                     )
 
         if isinstance(self.solver, MinimumEigensolverFactory):
+            warn_deprecated_type(
+                "0.6.0",
+                "solver",
+                "MinimumEigensolverFactory",
+            )
             # this must be called after transformation.transform
             self._solver = self.solver.get_solver(problem, self._qubit_mapper)
         # if the eigensolver does not support auxiliary operators, reset them

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/minimum_eigensolver_factory.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/minimum_eigensolver_factory.py
@@ -24,7 +24,9 @@ from qiskit_nature.deprecation import deprecate_arguments
 
 
 class MinimumEigensolverFactory(ABC):
-    """A factory to construct a minimum eigensolver based on a qubit operator transformation."""
+    """DEPRECATED A factory to construct a minimum eigensolver based on a qubit operator
+    transformation.
+    """
 
     @abstractmethod
     @deprecate_arguments(

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/numpy_minimum_eigensolver_factory.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/numpy_minimum_eigensolver_factory.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from qiskit.algorithms.minimum_eigensolvers import MinimumEigensolver, NumPyMinimumEigensolver
 
+from qiskit_nature.deprecation import DeprecatedType, warn_deprecated
 from qiskit_nature.second_q.mappers import QubitConverter, QubitMapper
 from qiskit_nature.second_q.problems import BaseProblem
 from qiskit_nature.deprecation import deprecate_arguments
@@ -24,7 +25,13 @@ from .minimum_eigensolver_factory import MinimumEigensolverFactory
 
 
 class NumPyMinimumEigensolverFactory(MinimumEigensolverFactory):
-    """A factory to construct a NumPyMinimumEigensolver."""
+    """DEPRECATED A factory to construct a NumPyMinimumEigensolver.
+
+    .. warning::
+
+        This class is deprecated! Please see :ref:`this guide <how-to-numpy-min>` for how to replace
+        your usage of it!
+    """
 
     def __init__(
         self,
@@ -38,6 +45,16 @@ class NumPyMinimumEigensolverFactory(MinimumEigensolverFactory):
             kwargs: Keyword arguments passed to NumpyMinimumEigensolver to construct
                 the internal ``MinimumEigensolver``.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "NumPyMinimumEigensolverFactory",
+            additional_msg=(
+                ". This class is deprecated without replacement. Instead, refer to this how-to "
+                "guide which explains the steps you need to take to replace the use of this class: "
+                "https://qiskit.org/documentation/nature/howtos/numpy_minimum_eigensolver.html"
+            ),
+        )
         self._use_default_filter_criterion = use_default_filter_criterion
         self._minimum_eigensolver = NumPyMinimumEigensolver(**kwargs)
 

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_ucc_factory.py
@@ -21,6 +21,7 @@ from qiskit.algorithms.optimizers import Minimizer, Optimizer
 from qiskit.circuit import QuantumCircuit
 from qiskit.primitives import BaseEstimator
 
+from qiskit_nature.deprecation import DeprecatedType, warn_deprecated
 from qiskit_nature.second_q.circuit.library import HartreeFock, UCC
 from qiskit_nature.second_q.mappers import QubitConverter, QubitMapper
 from qiskit_nature.second_q.problems import (
@@ -35,8 +36,13 @@ logger = logging.getLogger(__name__)
 
 
 class VQEUCCFactory(MinimumEigensolverFactory):
-    """Factory to construct a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` minimum
-    eigensolver with :class:`~.UCC` ansatz wavefunction.
+    """DEPRECATED Factory to construct a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`
+    minimum eigensolver with :class:`~.UCC` ansatz wavefunction.
+
+    .. warning::
+
+        This class is deprecated! Please see :ref:`this guide <how-to-vqe-ucc>` for how to replace
+        your usage of it!
     """
 
     def __init__(
@@ -73,6 +79,16 @@ class VQEUCCFactory(MinimumEigensolverFactory):
             kwargs: Remaining keyword arguments are passed to the
                 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "VQEUCCFactory",
+            additional_msg=(
+                ". This class is deprecated without replacement. Instead, refer to this how-to "
+                "guide which explains the steps you need to take to replace the use of this class: "
+                "https://qiskit.org/documentation/nature/howtos/vqe_ucc.html"
+            ),
+        )
         self._initial_state = initial_state
         self._initial_point = initial_point if initial_point is not None else HFInitialPoint()
 

--- a/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
+++ b/qiskit_nature/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/vqe_uvcc_factory.py
@@ -22,6 +22,7 @@ from qiskit.algorithms.optimizers import Minimizer, Optimizer
 from qiskit.circuit import QuantumCircuit
 from qiskit.primitives import BaseEstimator
 
+from qiskit_nature.deprecation import DeprecatedType, warn_deprecated
 from qiskit_nature.second_q.circuit.library import UVCC, VSCF
 from qiskit_nature.second_q.mappers import QubitConverter, QubitMapper
 from qiskit_nature.second_q.problems import (
@@ -36,8 +37,13 @@ logger = logging.getLogger(__name__)
 
 
 class VQEUVCCFactory(MinimumEigensolverFactory):
-    """Factory to construct a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` minimum
-    eigensolver with :class:`~.UVCC` ansatz wavefunction.
+    """DEPRECATED Factory to construct a :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`
+    minimum eigensolver with :class:`~.UVCC` ansatz wavefunction.
+
+    .. warning::
+
+        This class is deprecated! Please see :ref:`this guide <how-to-vqe-uvcc>` for how to replace
+        your usage of it!
     """
 
     def __init__(
@@ -72,6 +78,16 @@ class VQEUVCCFactory(MinimumEigensolverFactory):
             kwargs: Remaining keyword arguments are passed to the
                 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE`.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "VQEUVCCFactory",
+            additional_msg=(
+                ". This class is deprecated without replacement. Instead, refer to this how-to "
+                "guide which explains the steps you need to take to replace the use of this class: "
+                "https://qiskit.org/documentation/nature/howtos/vqe_uvcc.html"
+            ),
+        )
         self._initial_state = initial_state
         self._initial_point = initial_point if initial_point is not None else VSCFInitialPoint()
 

--- a/qiskit_nature/second_q/algorithms/initial_points/__init__.py
+++ b/qiskit_nature/second_q/algorithms/initial_points/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,6 +15,10 @@ Initial Points (:mod:`qiskit_nature.second_q.algorithms.initial_points`)
 ========================================================================
 
 Utility classes that provide initial points to use with specific ansatzes.
+
+For some concrete usage examples refer to the how-to guides on
+:ref:`using a UCC-like ansatz with a VQE <how-to-vqe-ucc>` or on
+:ref:`using a UVCC-like ansatz with a VQE <how-to-vqe-uvcc>`.
 
 .. currentmodule:: qiskit_nature.second_q.algorithms.initial_points
 

--- a/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
@@ -45,9 +45,7 @@ class UCC(EvolvedOperatorAnsatz):
     :class:`~qiskit_nature.second_q.circuit.library.HartreeFock` reference state by default. When
     setting up a ``VQE`` algorithm using this ansatz and initial state, it is likely you will also
     want to use a :class:`~qiskit_nature.second_q.algorithms.initial_points.HFInitialPoint` that has
-    been configured using the corresponding ansatz parameters. When using a
-    :class:`~qiskit_nature.second_q.algorithms.VQEUCCFactory` this is set by default. When directly
-    using ``VQE`` you can set it manually. For example:
+    been configured using the corresponding ansatz parameters. This can be done as follows:
 
     .. code-block:: python
 

--- a/qiskit_nature/second_q/circuit/library/ansatzes/uvcc.py
+++ b/qiskit_nature/second_q/circuit/library/ansatzes/uvcc.py
@@ -40,9 +40,7 @@ class UVCC(EvolvedOperatorAnsatz):
     :class:`~qiskit_nature.second_q.circuit.library.VSCF` reference state by default. When setting
     up a ``VQE`` algorithm using this ansatz and initial state, it is likely you will also want to
     use a :class:`~qiskit_nature.second_q.algorithms.initial_points.VSCFInitialPoint` that has been
-    configured using the corresponding ansatz parameters. When using a
-    :class:`~qiskit_nature.second_q.algorithms.VQEUVCCFactory` this is set by default. When directly
-    using ``VQE``, you can set it manually. For example:
+    configured using the corresponding ansatz parameters. This can be done as follows:
 
     .. code-block:: python
 

--- a/qiskit_nature/second_q/problems/electronic_structure_problem.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_problem.py
@@ -61,7 +61,8 @@ class ElectronicStructureProblem(BaseProblem):
     about the problem which you are trying to solve, which can be used by various modules in the
     stack. For example, specifying the number of particles in the system :attr:`num_particles` is
     useful (and even required) for many components that interact with this problem instance to make
-    your life easier (for example the :class:`qiskit_nature.second_q.algorithms.VQEUCCFactory`).
+    your life easier (for example the
+    :class:`qiskit_nature.second_q.transformers.ActiveSpaceTransformer`).
 
     In the fermionic case the default filter ensures that the number of particles is being
     preserved.
@@ -77,7 +78,7 @@ class ElectronicStructureProblem(BaseProblem):
     .. code-block:: python
 
         import numpy as np
-        from qiskit_nature.second_q.algorithms import NumPyEigensolverFactory
+        from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
 
         expected_spin = 2
         expected_num_electrons = 6
@@ -91,7 +92,8 @@ class ElectronicStructureProblem(BaseProblem):
                 np.isclose(num_particles_aux, expected_num_electrons)
             )
 
-        solver = NumPyEigensolverFactory(filter_criterion=filter_criterion_custom)
+        solver = NumPyEigensolver()
+        solver.filter_criterion = filter_criterion_custom
 
     The following attributes can be read and updated once the ``ElectronicStructureProblem`` object
     has been constructed.

--- a/qiskit_nature/settings.py
+++ b/qiskit_nature/settings.py
@@ -145,7 +145,6 @@ class QiskitNatureSettings:
             not self._use_symmetry_reduced_integrals
             and "SymmetricTwoBodyIntegrals" not in self._deprecation_shown
         ):
-            warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
                     "As of version 0.6.0 the current default-value `False` of "
@@ -155,7 +154,6 @@ class QiskitNatureSettings:
                 ),
                 stacklevel=3,
             )
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("SymmetricTwoBodyIntegrals")
 
         return self._use_symmetry_reduced_integrals
@@ -166,7 +164,6 @@ class QiskitNatureSettings:
             not use_symmetry_reduced_integrals
             and "SymmetricTwoBodyIntegrals" not in self._deprecation_shown
         ):
-            warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
                     "As of version 0.6.0 the current default-value `False` of "
@@ -176,7 +173,6 @@ class QiskitNatureSettings:
                 ),
                 stacklevel=3,
             )
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("SymmetricTwoBodyIntegrals")
 
         self._use_symmetry_reduced_integrals = use_symmetry_reduced_integrals
@@ -192,7 +188,6 @@ class QiskitNatureSettings:
         ``numpy.ndarray``, ``sparse.SparseArray`` or a plain ``Number``.
         """
         if self._tensor_unwrapping and "Tensor" not in self._deprecation_shown:
-            warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
                     "As of version 0.6.0 the return of unwrapped tensors in the "
@@ -203,7 +198,6 @@ class QiskitNatureSettings:
                 ),
                 stacklevel=3,
             )
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("Tensor")
 
         return self._tensor_unwrapping
@@ -219,7 +213,6 @@ class QiskitNatureSettings:
         ``numpy.ndarray``, ``sparse.SparseArray`` or a plain ``Number``.
         """
         if tensor_unwrapping and "Tensor" not in self._deprecation_shown:
-            warnings.filterwarnings("default", category=DeprecationWarning)
             warnings.warn(
                 DeprecationWarning(
                     "As of version 0.6.0 the return of unwrapped tensors in the "
@@ -230,7 +223,6 @@ class QiskitNatureSettings:
                 ),
                 stacklevel=3,
             )
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
             self._deprecation_shown.add("Tensor")
 
         self._tensor_unwrapping = tensor_unwrapping

--- a/releasenotes/notes/deprecate-eigensolver-factories-91808a78261e7f6b.yaml
+++ b/releasenotes/notes/deprecate-eigensolver-factories-91808a78261e7f6b.yaml
@@ -1,0 +1,12 @@
+---
+deprecations:
+  - |
+    Deprecated all :class:`~qiskit_nature.second_q.algorithms.MinimumEigensolverFactory`
+    and :class:`~qiskit_nature.second_q.algorithms.EigensolverFactory` classes.
+    Instead, users should now build the respectively generated solver instances
+    themselves. How-to guides to detail the involved steps have been added:
+
+    - :ref:`Building a NumPyEigensolver <how-to-numpy>`
+    - :ref:`Building a NumPyMinimumEigensolver <how-to-numpy-min>`
+    - :ref:`Using a UCC-like ansatz with VQE <how-to-vqe-ucc>`
+    - :ref:`Using a UVCC-like ansatz with VQE <how-to-vqe-uvcc>`

--- a/test/second_q/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
+++ b/test/second_q/algorithms/excited_state_solvers/eigensolver_factories/test_numpy_eigensolver_factory.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 """ Test NumPyMinimumEigensolver Factory """
 import unittest
+import warnings
 from test import QiskitNatureTestCase
 import numpy as np
 
@@ -46,9 +47,11 @@ class TestNumPyEigensolverFactory(QiskitNatureTestCase):
             return np.isclose(aux_values["ParticleNumber"][0], 2.0)
 
         self.k = 99
-        self._numpy_eigensolver_factory = NumPyEigensolverFactory(
-            filter_criterion=filter_criterion, k=self.k
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            self._numpy_eigensolver_factory = NumPyEigensolverFactory(
+                filter_criterion=filter_criterion, k=self.k
+            )
 
     def test_setters_getters(self):
         """Test Getter/Setter"""

--- a/test/second_q/algorithms/excited_state_solvers/test_bosonic_esc_calculation.py
+++ b/test/second_q/algorithms/excited_state_solvers/test_bosonic_esc_calculation.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,6 +15,7 @@
 import contextlib
 import io
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 
@@ -107,7 +108,9 @@ class TestBosonicESCCalculation(QiskitNatureTestCase):
     def test_numpy_mes(self):
         """Test with NumPyMinimumEigensolver"""
         estimator = Estimator()
-        solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
         esc = QEOM(gsc, estimator, "sd")
         results = esc.solve(self.vibrational_problem)
@@ -115,7 +118,9 @@ class TestBosonicESCCalculation(QiskitNatureTestCase):
 
     def test_numpy_factory(self):
         """Test with NumPyEigensolver"""
-        solver = NumPyEigensolverFactory(use_default_filter_criterion=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyEigensolverFactory(use_default_filter_criterion=True)
         esc = ExcitedStatesEigensolver(self.qubit_converter, solver)
         results = esc.solve(self.vibrational_problem)
         self._assert_energies(results.computed_vibrational_energies, self.reference_energies)
@@ -124,7 +129,9 @@ class TestBosonicESCCalculation(QiskitNatureTestCase):
         """Test with VQE plus UVCCSD"""
         optimizer = COBYLA(maxiter=5000)
         estimator = Estimator()
-        solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer)
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
         esc = QEOM(gsc, estimator, "sd")
         results = esc.solve(self.vibrational_problem)
@@ -137,7 +144,9 @@ class TestBosonicESCCalculation(QiskitNatureTestCase):
         initial_point = np.asarray([-7.35250290e-05, -9.73079292e-02, -5.43346282e-05])
         estimator = Estimator()
         optimizer = COBYLA(maxiter=1)
-        solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer, initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer, initial_point=initial_point)
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
         esc = QEOM(gsc, estimator, "sd")
         results = esc.solve(self.vibrational_problem)
@@ -154,7 +163,9 @@ class TestBosonicESCCalculation(QiskitNatureTestCase):
         estimator = Estimator()
         optimizer = COBYLA(maxiter=5000)
 
-        solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer, callback=cb_callback)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUVCCFactory(estimator, UVCCSD(), optimizer, callback=cb_callback)
         gsc = GroundStateEigensolver(self.qubit_converter, solver)
         esc = QEOM(gsc, estimator, "sd")
         with contextlib.redirect_stdout(io.StringIO()) as out:

--- a/test/second_q/algorithms/excited_state_solvers/test_excited_states_solvers.py
+++ b/test/second_q/algorithms/excited_state_solvers/test_excited_states_solvers.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 from ddt import ddt, named_data
@@ -92,7 +93,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
     def _compute_and_assert_qeom_energies(self, mapper: QubitConverter | QubitMapper):
         estimator = Estimator()
-        solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
         gsc = GroundStateEigensolver(mapper, solver)
         esc = QEOM(gsc, estimator, "sd")
         results = esc.solve(self.electronic_structure_problem)
@@ -154,7 +157,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
         def filter_criterion(eigenstate, eigenvalue, aux_values):
             return np.isclose(aux_values["ParticleNumber"][0], 2.0)
 
-        solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
         esc = ExcitedStatesEigensolver(self.qubit_converter, solver)
         results = esc.solve(self.electronic_structure_problem)
 
@@ -197,7 +202,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
                 num_particles_aux, expected_num_electrons
             )
 
-        solver = NumPyEigensolverFactory(filter_criterion=custom_filter_criterion)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyEigensolverFactory(filter_criterion=custom_filter_criterion)
         esc = ExcitedStatesEigensolver(converter, solver)
         results = esc.solve(esp)
 
@@ -227,7 +234,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
             return np.isclose(aux_values["ParticleNumber"][0], 2.0)
 
         with self.subTest("Excited states solver with qubit converter"):
-            solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
             esc_converter = ExcitedStatesEigensolver(self.qubit_converter, solver)
             results_converter = esc_converter.solve(self.electronic_structure_problem)
             computed_energies_converter = [results_converter.computed_energies[0]]
@@ -238,7 +247,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
             self._assert_energies(computed_energies_converter, self.reference_energies)
 
         with self.subTest("Excited states solver with qubit mapper"):
-            solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                solver = NumPyEigensolverFactory(filter_criterion=filter_criterion)
             esc_mapper = ExcitedStatesEigensolver(self.mapper, solver)
             results_mapper = esc_mapper.solve(self.electronic_structure_problem)
             # filter duplicates from list
@@ -250,7 +261,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
         with self.subTest("QEOM with qubit converter"):
             estimator = Estimator()
-            solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
             gsc_converter = GroundStateEigensolver(self.qubit_converter, solver)
             esc_converter = QEOM(gsc_converter, estimator, "sd")
             results_converter = esc_converter.solve(self.electronic_structure_problem)
@@ -263,7 +276,9 @@ class TestNumericalQEOMESCCalculation(QiskitNatureTestCase):
 
         with self.subTest("QEOM with qubit mapper"):
             estimator = Estimator()
-            solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
+                solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
             gsc_mapper = GroundStateEigensolver(self.mapper, solver)
             esc_mapper = QEOM(gsc_mapper, estimator, "sd")
             results_mapper = esc_mapper.solve(self.electronic_structure_problem)

--- a/test/second_q/algorithms/excited_state_solvers/test_excited_states_solvers_auxiliaries.py
+++ b/test/second_q/algorithms/excited_state_solvers/test_excited_states_solvers_auxiliaries.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 from ddt import ddt, named_data
@@ -133,7 +134,9 @@ class TestNumericalQEOMObscalculation(QiskitNatureTestCase):
         hamiltonian_op, _ = self.electronic_structure_problem.second_q_ops()
         aux_ops = {"hamiltonian": hamiltonian_op}
         estimator = Estimator()
-        solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
         gsc = GroundStateEigensolver(mapper, solver)
         esc = QEOM(gsc, estimator, "sd", aux_eval_rules=EvaluationRule.DIAG)
         results = esc.solve(self.electronic_structure_problem, aux_operators=aux_ops)
@@ -152,7 +155,9 @@ class TestNumericalQEOMObscalculation(QiskitNatureTestCase):
         aux_ops = {"hamiltonian_derivative": self._hamiltonian_derivative()}
 
         estimator = Estimator()
-        solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(estimator, UCCSD(), SLSQP())
         gsc = GroundStateEigensolver(mapper, solver)
         esc = QEOM(gsc, estimator, excitations="sd", aux_eval_rules=aux_eval_rules)
         results = esc.solve(self.electronic_structure_problem, aux_operators=aux_ops)

--- a/test/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
+++ b/test/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_ucc_factory.py
@@ -13,6 +13,7 @@
 """ Test VQE UCC MinimumEigensolver Factory """
 
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 
@@ -36,7 +37,9 @@ class TestVQEUCCFactory(QiskitNatureTestCase):
     def setUp(self):
         super().setUp()
         self.mapper = QubitConverter(JordanWignerMapper())
-        self._vqe_ucc_factory = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            self._vqe_ucc_factory = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
 
     def auxiliary_tester(self, title: str, prop: str, cases: tuple):
         """

--- a/test/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
+++ b/test/second_q/algorithms/ground_state_solvers/minimum_eigensolver_factories/test_vqe_uvcc_factory.py
@@ -12,6 +12,7 @@
 """ Test VQE UVCC MinimumEigensolver Factory """
 
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 
@@ -34,7 +35,9 @@ class TestVQEUVCCFactory(QiskitNatureTestCase):
     def setUp(self):
         super().setUp()
         self.mapper = QubitConverter(JordanWignerMapper())
-        self._vqe_uvcc_factory = VQEUVCCFactory(Estimator(), UVCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            self._vqe_uvcc_factory = VQEUVCCFactory(Estimator(), UVCCSD(), SLSQP())
 
     def auxiliary_tester(self, title: str, prop: str, cases: tuple):
         """

--- a/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -16,6 +16,7 @@ import contextlib
 import copy
 import io
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 
@@ -64,28 +65,36 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
     def test_npme(self):
         """Test NumPyMinimumEigensolver"""
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_npme_with_default_filter(self):
         """Test NumPyMinimumEigensolver with default filter"""
-        solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_vqe_uccsd(self):
         """Test VQE UCCSD case"""
-        solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_vqe_uccsd_mapper(self):
         """Test VQE UCCSD case with QubitMapper"""
-        solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
         calc = GroundStateEigensolver(self.mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
@@ -97,7 +106,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             # pylint: disable=unused-argument
             print(f"iterations {nfev}: energy: {energy}")
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), callback=callback)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), callback=callback)
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         with contextlib.redirect_stdout(io.StringIO()) as out:
             res = calc.solve(self.electronic_structure_problem)
@@ -108,7 +119,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
     def test_vqe_ucc_custom(self):
         """Test custom ansatz in Factory use case"""
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
@@ -116,7 +129,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_aux_ops_reusability(self):
         """Test that the auxiliary operators can be reused"""
         # Regression test against #1475
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.qubit_converter, solver)
 
         modes = 4
@@ -133,7 +148,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
     def _setup_evaluation_operators(self):
         # first we run a ground state calculation
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -207,7 +224,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             z2symmetry_reduction="auto",
         )
 
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         gsc = GroundStateEigensolver(qubit_converter, solver)
 
         result = gsc.solve(problem)
@@ -218,14 +237,18 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
         An issue with calculating the dipole moment that had division None/float.
         """
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_dipole_moment_in_debye[0], 0.0, places=1)
 
     def test_print_result(self):
         """Regression test against #198 and general issues with printing results."""
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         with contextlib.redirect_stdout(io.StringIO()) as out:
@@ -259,7 +282,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
     def test_default_initial_point(self):
         """Test when using the default initial point."""
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -270,7 +295,11 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         """Test VQEUCCFactory when using it with a user defined initial point."""
 
         initial_point = np.asarray([1.28074029e-19, 5.92226076e-08, 1.11762559e-01])
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(maxiter=1), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(
+                Estimator(), UCCSD(), SLSQP(maxiter=1), initial_point=initial_point
+            )
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
         np.testing.assert_array_almost_equal(res.raw_result.optimal_point, initial_point)
@@ -280,7 +309,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
 
         initial_point = MP2InitialPoint()
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), initial_point=initial_point)
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -298,7 +329,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             reps=2,
         )
 
-        solver = VQEUCCFactory(Estimator(), ansatz, SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), ansatz, SLSQP())
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -321,7 +354,9 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
             reps=2,
         )
 
-        solver = VQEUCCFactory(Estimator(), ansatz, SLSQP(), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), ansatz, SLSQP(), initial_point=initial_point)
         calc = GroundStateEigensolver(self.qubit_converter, solver)
         res = calc.solve(self.electronic_structure_problem)
 

--- a/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver_mapper.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver_mapper.py
@@ -16,6 +16,7 @@ import contextlib
 import copy
 import io
 import unittest
+import warnings
 
 from test import QiskitNatureTestCase
 
@@ -64,28 +65,36 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
 
     def test_npme(self):
         """Test NumPyMinimumEigensolver"""
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_npme_with_default_filter(self):
         """Test NumPyMinimumEigensolver with default filter"""
-        solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory(use_default_filter_criterion=True)
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_vqe_uccsd(self):
         """Test VQE UCCSD case"""
-        solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
 
     def test_vqe_uccsd_mapper(self):
         """Test VQE UCCSD case with QubitMapper"""
-        solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCC(excitations="d"), SLSQP())
         calc = GroundStateEigensolver(self.mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
@@ -97,7 +106,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
             # pylint: disable=unused-argument
             print(f"iterations {nfev}: energy: {energy}")
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), callback=callback)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), callback=callback)
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         with contextlib.redirect_stdout(io.StringIO()) as out:
             res = calc.solve(self.electronic_structure_problem)
@@ -108,7 +119,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
 
     def test_vqe_ucc_custom(self):
         """Test custom ansatz in Factory use case"""
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
@@ -116,7 +129,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
     def test_aux_ops_reusability(self):
         """Test that the auxiliary operators can be reused"""
         # Regression test against #1475
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
 
         modes = 4
@@ -133,7 +148,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
 
     def _setup_evaluation_operators(self):
         # first we run a ground state calculation
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -204,7 +221,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
         num_particles = problem.num_particles
         tapered_mapper = problem.get_tapered_mapper(ParityMapper(num_particles))
 
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         gsc = GroundStateEigensolver(tapered_mapper, solver)
 
         result = gsc.solve(problem)
@@ -215,14 +234,18 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
 
         An issue with calculating the dipole moment that had division None/float.
         """
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         self.assertAlmostEqual(res.total_dipole_moment_in_debye[0], 0.0, places=1)
 
     def test_print_result(self):
         """Regression test against #198 and general issues with printing results."""
-        solver = NumPyMinimumEigensolverFactory()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = NumPyMinimumEigensolverFactory()
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         with contextlib.redirect_stdout(io.StringIO()) as out:
@@ -256,7 +279,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
     def test_default_initial_point(self):
         """Test when using the default initial point."""
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP())
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -267,7 +292,11 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
         """Test VQEUCCFactory when using it with a user defined initial point."""
 
         initial_point = np.asarray([1.28074029e-19, 5.92226076e-08, 1.11762559e-01])
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(maxiter=1), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(
+                Estimator(), UCCSD(), SLSQP(maxiter=1), initial_point=initial_point
+            )
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
         np.testing.assert_array_almost_equal(res.raw_result.optimal_point, initial_point)
@@ -277,7 +306,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
 
         initial_point = MP2InitialPoint()
 
-        solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), UCCSD(), SLSQP(), initial_point=initial_point)
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -295,7 +326,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
             reps=2,
         )
 
-        solver = VQEUCCFactory(Estimator(), ansatz, SLSQP())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), ansatz, SLSQP())
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
 
@@ -318,7 +351,9 @@ class TestGroundStateEigensolverMapper(QiskitNatureTestCase):
             reps=2,
         )
 
-        solver = VQEUCCFactory(Estimator(), ansatz, SLSQP(), initial_point=initial_point)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            solver = VQEUCCFactory(Estimator(), ansatz, SLSQP(), initial_point=initial_point)
         calc = GroundStateEigensolver(self.tapered_mapper, solver)
         res = calc.solve(self.electronic_structure_problem)
 

--- a/test/second_q/properties/test_electronic_density.py
+++ b/test/second_q/properties/test_electronic_density.py
@@ -21,12 +21,11 @@ from test import QiskitNatureTestCase
 import numpy as np
 from ddt import ddt, data, unpack
 
+from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
+
 import qiskit_nature.optionals as _optionals
 
-from qiskit_nature.second_q.algorithms import (
-    GroundStateEigensolver,
-    NumPyMinimumEigensolverFactory,
-)
+from qiskit_nature.second_q.algorithms import GroundStateEigensolver
 from qiskit_nature.second_q.drivers import PySCFDriver, MethodType
 from qiskit_nature.second_q.mappers import JordanWignerMapper, QubitConverter
 from qiskit_nature.second_q.operators import ElectronicIntegrals
@@ -278,7 +277,7 @@ class TestElectronicDensity(QiskitNatureTestCase):
 
         algo = GroundStateEigensolver(
             QubitConverter(JordanWignerMapper()),
-            NumPyMinimumEigensolverFactory(),
+            NumPyMinimumEigensolver(),
         )
 
         result = algo.solve(problem)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR deprecates the various `(Minimum)EigensolverFactory` classes.
In their place we will have detailed How-To guides as well as generally improved documentation around the intricacies which the Factory classes used to hide from the user.

### Details and comments

- [x] add How-To guides
- [x] deprecate Factory classes
- [x] update all docstrings to:
    - [x] *not* refer to the `Factory` classes
    - [x] detail intricacies which these classes used to handle (and point to the new How-To guides)
- [x] add a release note

Closes #854, #1036 