### PR TITLE
fix: replace DFT with HF in BasisTransformer unittests

### DIFF
--- a/test/second_q/transformers/test_basis_transformer.py
+++ b/test/second_q/transformers/test_basis_transformer.py
@@ -33,7 +33,7 @@ class TestBasisTransformer(QiskitNatureTestCase):
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
     def test_restricted_spin(self):
         """A simple restricted-spin test case."""
-        driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", method=MethodType.RKS)
+        driver = PySCFDriver(atom="H 0 0 0; H 0 0 0.735", method=MethodType.RHF)
         driver.run_pyscf()
         mo_coeff = driver._calc.mo_coeff
 
@@ -97,7 +97,7 @@ class TestBasisTransformer(QiskitNatureTestCase):
     @unittest.skipIf(not _optionals.HAS_PYSCF, "pyscf not available.")
     def test_unrestricted_spin(self):
         """A simple unrestricted-spin test case."""
-        driver = PySCFDriver(atom="O 0 0 0; H 0 0 0.9697", spin=1, method=MethodType.UKS)
+        driver = PySCFDriver(atom="O 0 0 0; H 0 0 0.9697", spin=1, method=MethodType.UHF)
         driver.run_pyscf()
         mo_coeff, mo_coeff_b = driver._calc.mo_coeff
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This test started to be flaky with PySCF 2.2.0 on MacOS with Python 3.10 Since it is not needed that we use DFT here we can simply avoid the problem by using HF.

### Details and comments


