### PR TITLE
Install jupyter for tutorials builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -304,6 +304,7 @@ jobs:
           use-conda: "false"
       - name: Install Dependencies
         run: |
+          pip install jupyter
           sudo apt-get install -y pandoc
           echo "earliest_version: 0.1.0" >> releasenotes/config.yaml
         shell: bash


### PR DESCRIPTION
Currently the tutorials jobs are failing. In the other repos, which are still passing their equivalent jobs, they pip install jupyter there which did not seem to be done in the workfllow here
```
    self.parser.parse(self.input, document)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/nbsphinx/__init__.py", line 622, in parse
    raise NotebookError(type(e).__name__ + ' in ' +
nbsphinx.NotebookError: NoSuchKernel in migration/00_Migration_Guide_to_v0.5.ipynb:
No such kernel named python3

Notebook error:
NoSuchKernel in migration/00_Migration_Guide_to_v0.5.ipynb:
No such kernel named python3
make: *** [Makefile:71: html] Error 2
```