### PR TITLE
Various small updates for docs and docs CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - name: Print Concurrency Group
         env:
@@ -99,13 +99,13 @@ jobs:
           python tools/check_copyright.py -check
         if: ${{ !cancelled() }}
         shell: bash
- #     - name: Spell Check
- #       run: |
- #         source "$CONDA/etc/profile.d/conda.sh"
- #         conda activate psi4env
- #         make spell
- #       if: ${{ !cancelled() }}
- #       shell: bash
+      - name: Spell Check
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate psi4env
+          make spell
+        if: ${{ !cancelled() }}
+        shell: bash
       - name: Style Check
         run: |
           source "$CONDA/etc/profile.d/conda.sh"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,13 +99,13 @@ jobs:
           python tools/check_copyright.py -check
         if: ${{ !cancelled() }}
         shell: bash
-      - name: Spell Check
-        run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate psi4env
-          make spell
-        if: ${{ !cancelled() }}
-        shell: bash
+ #     - name: Spell Check
+ #       run: |
+ #         source "$CONDA/etc/profile.d/conda.sh"
+ #         conda activate psi4env
+ #         make spell
+ #       if: ${{ !cancelled() }}
+ #       shell: bash
       - name: Style Check
         run: |
           source "$CONDA/etc/profile.d/conda.sh"

--- a/.pylintdict
+++ b/.pylintdict
@@ -556,6 +556,7 @@ tavernelli
 taylor
 tb
 tdg
+tcoeff
 tensored
 tensoring
 terra

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_design",
     "jupyter_sphinx",
-    "sphinx_autodoc_typehints",
     "reno.sphinxext",
     "sphinx.ext.doctest",
     "nbsphinx",
@@ -121,6 +120,7 @@ nbsphinx_thumbnails = {
     "tutorials/05_problem_transformers": "_static/core-orbitals.png",
     "tutorials/06_qubit_mappers": "_images/jw_mapping.png",
     "tutorials/07_leveraging_qiskit_runtime": "_static/runtime.png",
+    "**": "_static/no_image.png",
 }
 
 spelling_word_list_filename = "../.pylintdict"
@@ -136,6 +136,12 @@ autosummary_generate_overwrite = False
 # -----------------------------------------------------------------------------
 # Autodoc
 # -----------------------------------------------------------------------------
+# Move type hints from signatures to the parameter descriptions (except in overload cases, where
+# that's not possible).
+autodoc_typehints = "description"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 autodoc_default_options = {
     "inherited-members": None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,10 +6,9 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 reno>=3.4.0
-Sphinx>=1.8.3,!=3.1.0,!=5.2.0,!=5.2.0.post0
+Sphinx>=5.0
 sphinx-design>=0.2.0
 sphinx-gallery
-sphinx-autodoc-typehints<1.14.0
 sphinxcontrib-spelling!=7.3.1
 jupyter-sphinx
 discover

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ deps =
   sparse
   opt_einsum
   sphinx-intl
+  jupyter
 commands =
   sphinx-build -W -T --keep-going -b gettext docs/ docs/_build/gettext {posargs}
   sphinx-intl -c docs/conf.py update -p docs/_build/gettext -l en -d docs/locale


### PR DESCRIPTION
### Summary

- Removes dependency on sphinx-autodoc-typehints as per Qiskit/qiskit-terra#9705
- Adds default thumbnail config as that changed in nbsphinx 0.9 see Qiskit/qiskit-metapackage#1707
- Updates tox.ini gettext section used for translatable strings due to ipykernel not being installed by default now see Qiskit/qiskit-machine-learning#589

### Details and comments


