### PR TITLE
Fix the behavior of `SparseLabelOp.is_zero` for parameterized operators

### DIFF
--- a/qiskit_nature/second_q/operators/sparse_label_op.py
+++ b/qiskit_nature/second_q/operators/sparse_label_op.py
@@ -545,7 +545,7 @@ class SparseLabelOp(LinearMixin, AdjointMixin, GroupMixin, TolerancesMixin, ABC,
         if len(self) == 0:
             return True
         tol = tol if tol is not None else self.atol
-        return all(np.isclose(val, 0, atol=tol) for val in self._data.values())
+        return all(np.isclose(_to_number(val), 0, atol=tol) for val in self._data.values())
 
     def parameters(self) -> list[ParameterExpression]:
         """Returns a list of the parameters in the operator.

--- a/releasenotes/notes/fix-sparse-label-op-is-zero-ebeca4d6871c9642.yaml
+++ b/releasenotes/notes/fix-sparse-label-op-is-zero-ebeca4d6871c9642.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the behavior of :meth:`~qiskit_nature.second_q.operators.SparseLabelOp.is_zero` when
+    called on a parameterized operator.

--- a/test/second_q/operators/test_sparse_label_op.py
+++ b/test/second_q/operators/test_sparse_label_op.py
@@ -567,6 +567,12 @@ class TestSparseLabelOp(QiskitNatureTestCase):
             )
             self.assertFalse(test_op.is_zero(tol=0.001))
 
+        with self.subTest("parameterized coefficient"):
+            test_op = DummySparseLabelOp({"+_0 -_1": a})
+            self.assertFalse(test_op.is_zero())
+            bound_op = test_op.assign_parameters({a: 0.0})
+            self.assertTrue(bound_op.is_zero())
+
     def test_parameters(self):
         """Test parameters."""
         op = DummySparseLabelOp({"+_0 -_1": a, "+_0 -_2": b})


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1110

### Details and comments


