### PR TITLE
Update documentation of `sum` for `SparseLabelOp` classes

### DIFF
--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -129,17 +129,6 @@ class FermionicOp(SparseLabelOp):
 
       FermionicOp({"+_0 -_1": 1j}, num_spin_orbitals=2).adjoint()
 
-    In principle, you can also add `FermionicOp` and integers, but the only valid case is the
-    addition of `0 + FermionicOp`. This makes the `sum` operation from the example above possible
-    and it is useful in the following scenario:
-
-    .. code-block:: python
-
-        fermion = 0
-        for i in some_iterable:
-            # some processing
-            fermion += FermionicOp(somedata)
-
     **Iteration**
 
     Instances of ``FermionicOp`` are iterable. Iterating a ``FermionicOp`` yields (term, coefficient)

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -149,17 +149,6 @@ class VibrationalOp(SparseLabelOp):
 
       VibrationalOp({"+_0_0 -_1_0": 1j}, num_modals=[1, 1]).adjoint()
 
-    In principle, you can also add :class:`VibrationalOp` and integers, but the only valid case is the
-    addition of `0 + VibrationalOp`. This makes the `sum` operation from the example above possible
-    and it is useful in the following scenario:
-
-    .. code-block:: python
-
-        vibrational_op = 0
-        for i in some_iterable:
-            # some processing
-            vibrational_op += VibrationalOp(somedata)
-
     **Iteration**
 
     Instances of ``VibrationalOp`` are iterable. Iterating a ``VibrationalOp`` yields (term, coefficient)

--- a/test/second_q/operators/test_fermionic_op.py
+++ b/test/second_q/operators/test_fermionic_op.py
@@ -85,6 +85,11 @@ class TestFermionicOp(QiskitNatureTestCase):
         targ = FermionicOp({"+_0 -_0": 1 + self.a})
         self.assertEqual(fer_op, targ)
 
+        with self.subTest("sum"):
+            fer_op = sum(FermionicOp({label: 1}) for label in ["+_0", "-_1", "+_2 -_2"])
+            targ = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
+            self.assertEqual(fer_op, targ)
+
     def test_sub(self):
         """Test __sub__"""
         fer_op = self.op3 - self.op2

--- a/test/second_q/operators/test_sparse_label_op.py
+++ b/test/second_q/operators/test_sparse_label_op.py
@@ -155,6 +155,18 @@ class TestSparseLabelOp(QiskitNatureTestCase):
 
             self.assertEqual(test_op, target_op)
 
+        with self.subTest("sum"):
+            test_op = sum([DummySparseLabelOp(op1), DummySparseLabelOp(op3)])
+            target_op = DummySparseLabelOp(
+                {
+                    "+_0 -_1": 0.5,
+                    "+_0 -_2": 1.0,
+                    "+_0 -_3": 3.0,
+                },
+            )
+
+            self.assertEqual(test_op, target_op)
+
     def test_mul(self):
         """Test scalar multiplication method"""
         with self.subTest("real * real"):

--- a/test/second_q/operators/test_spin_op.py
+++ b/test/second_q/operators/test_spin_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -65,6 +65,11 @@ class TestSpinOp(QiskitNatureTestCase):
         spin_op = self.op1 + self.op2
         targ = self.op3
         self.assertEqual(spin_op, targ)
+
+        with self.subTest("sum"):
+            spin_op = sum(SpinOp({label: 1}, num_spins=3) for label in ["X_0", "Z_1", "X_2 Z_2"])
+            targ = SpinOp({"X_0": 1, "Z_1": 1, "X_2 Z_2": 1})
+            self.assertEqual(spin_op, targ)
 
     def test_sub(self):
         """Test __sub__"""

--- a/test/second_q/operators/test_vibrational_op.py
+++ b/test/second_q/operators/test_vibrational_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -77,6 +77,14 @@ class TestVibrationalOp(QiskitNatureTestCase):
         vib_op = self.op1 + self.op2
         targ = self.op3
         self.assertEqual(vib_op, targ)
+
+        with self.subTest("sum"):
+            vib_op = sum(
+                VibrationalOp({label: 1}, num_modals=[1, 1, 1])
+                for label in ["+_0_0", "-_1_0", "+_2_0 -_2_0"]
+            )
+            targ = VibrationalOp({"+_0_0": 1, "-_1_0": 1, "+_2_0 -_2_0": 1})
+            self.assertEqual(vib_op, targ)
 
     def test_sub(self):
         """Test __sub__"""


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This updates the documentation as mentioned in #929. However, I opted to outright remove the questionable paragraph since we now have `SparseLabelOp.zero()` anyways.
I also added unittests for the documented `sum` behavior since this was missing.

### Details and comments

Closes #929

