### PR TITLE
Fix support of `BackendV2` in `VQEClient`

### DIFF
--- a/qiskit_nature/runtime/vqe_client.py
+++ b/qiskit_nature/runtime/vqe_client.py
@@ -20,7 +20,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.providers import Provider
-from qiskit.providers.backend import Backend
+from qiskit.providers.backend import Backend, BackendV2
 from qiskit.algorithms import (
     MinimumEigensolver,
     MinimumEigensolverResult,
@@ -289,7 +289,11 @@ class VQEClient(VariationalAlgorithm, MinimumEigensolver):
         }
 
         # define runtime options
-        options = {"backend_name": self.backend.name()}
+        options = {
+            "backend_name": self.backend.name
+            if isinstance(self.backend, BackendV2)
+            else self.backend.name()
+        }
 
         # send job to runtime and return result
         job = self.provider.runtime.run(

--- a/releasenotes/notes/vqeclient-v2-compat-5fd7a2b58cac8651.yaml
+++ b/releasenotes/notes/vqeclient-v2-compat-5fd7a2b58cac8651.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix support of ``BackendV2`` in the :class:`.VQEClient`. Previously, backends instantiated
+    with the ``IBMProvider`` failed since they return backends of type ``BackendV2``, which
+    were not correctly supported in the VQE client. Backends instantiated with the ``IBMQ``
+    provider continue to work as before.

--- a/test/runtime/test_vqeprogram.py
+++ b/test/runtime/test_vqeprogram.py
@@ -19,6 +19,7 @@ import unittest
 from ddt import ddt, data
 import numpy as np
 from qiskit.providers.basicaer import QasmSimulatorPy
+from qiskit.providers.fake_provider import FakeArmonk, FakeArmonkV2
 from qiskit.algorithms import VQEResult
 from qiskit.algorithms.optimizers import SPSA
 from qiskit.circuit.library import RealAmplitudes
@@ -75,6 +76,25 @@ class TestVQEClient(QiskitNatureDeprecatedTestCase):
         qubit_converter = QubitConverter(JordanWignerMapper())
         gss = GroundStateEigensolver(qubit_converter, vqe)
         self.assertTrue(gss.returns_groundstate)
+
+    @data(FakeArmonk, FakeArmonkV2)
+    def test_v1_and_v2_compatibility(self, backend_cls):
+        """Test the VQE client is compatible both with V1 and V2 backends.
+
+        Regression test of github.com/Qiskit/qiskit-nature/issues/1100.
+        """
+        provider = FakeRuntimeProvider()
+        backend = backend_cls()
+
+        circuit = RealAmplitudes(1, reps=0)
+        operator = Z
+        initial_point = np.array([0])
+        optimizer = SPSA(maxiter=1, perturbation=0.1, learning_rate=0.1)
+
+        vqe = VQEClient(circuit, optimizer, initial_point, provider, backend)
+        result = vqe.compute_minimum_eigenvalue(operator)
+
+        self.assertIsInstance(result, VQERuntimeResult)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1100.

### Details and comments

The backend name for backens of type ``BackendV2`` are accessed as property, but for ``BackendV1`` as method. This PR checks for the backend type and correctly queries the name. 
