### PR TITLE
Switch howtos from tiles to list

### DIFF
--- a/docs/howtos/adapt_vqe.rst
+++ b/docs/howtos/adapt_vqe.rst
@@ -1,5 +1,5 @@
-How to use the ``AdaptVQE``
-===========================
+Find ground state energy using AdaptVQE
+=======================================
 
 As of Qiskit Nature v0.5, the :class:`~qiskit.algorithms.minimum_eigensolvers.AdaptVQE`
 algorithm has been migrated to Qiskit Terra (released in v0.22).

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -1,13 +1,23 @@
-#####################
-Qiskit Nature How-Tos
-#####################
+###########################
+Qiskit Nature How-To Guides
+###########################
 
+This section of the documentation provides concrete step-by-step instructions for how to
+do specific useful actions in Qiskit Nature.
 
-.. nbgallery::
+.. toctree::
+    :caption: How to...
+    :maxdepth: 1
     :glob:
 
     *
 
+|
+
+If there are guides on solving specific problems that you'd like to see added, please
+`file an issue on GitHub <https://github.com/Qiskit/qiskit-nature/issues/new?assignees=&labels=type%3A+feature+request&template=FEATURE_REQUEST.yaml>`_.
+
+|
 
 .. Hiding - Indices and tables
    :ref:`genindex`

--- a/docs/howtos/numpy_eigensolver.rst
+++ b/docs/howtos/numpy_eigensolver.rst
@@ -1,7 +1,7 @@
 .. _how-to-numpy:
 
-How to use the ``NumPyEigensolver``
-===================================
+Find excited state energies using the NumPyEigensolver
+======================================================
 
 In order to ensure a physically meaningful excited states of a hamiltonian are found when using the
 :class:`~qiskit.algorithms.eigensolvers.NumPyEigensolver` one needs to set the

--- a/docs/howtos/numpy_minimum_eigensolver.rst
+++ b/docs/howtos/numpy_minimum_eigensolver.rst
@@ -1,7 +1,7 @@
 .. _how-to-numpy-min:
 
-How to use the ``NumPyMinimumEigensolver``
-==========================================
+Find ground state energy using the NumPyMinimumEigensolver
+==========================================================
 
 In order to ensure a physically meaningful ground state of a hamiltonian is found when using the
 :class:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver` one needs to set the

--- a/docs/howtos/vqe_ucc.rst
+++ b/docs/howtos/vqe_ucc.rst
@@ -1,7 +1,7 @@
 .. _how-to-vqe-ucc:
 
-How to use a UCC-like ansatz with a ``VQE``
-===========================================
+Use a UCC-like ansatz with a VQE
+================================
 
 When using a :class:`~qiskit_nature.second_q.circuit.library.UCC`-style ansatz with a
 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the

--- a/docs/howtos/vqe_uvcc.rst
+++ b/docs/howtos/vqe_uvcc.rst
@@ -1,7 +1,7 @@
 .. _how-to-vqe-uvcc:
 
-How to use a UVCC-like ansatz with a ``VQE``
-============================================
+Use a UVCC-like ansatz with a VQE
+=================================
 
 When using a :class:`~qiskit_nature.second_q.circuit.library.UVCC`-style ansatz with a
 :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` one needs to pay particular attention to the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolves #1114

 * #1114 shows the howtos, as they came out, with tiles
 
The size of the tiles in comparison with the text is leading to overlapping titles. Also given the tiles all use the default images having the howtos as simple list seems a "better" choice. I will note [Qiskit Experiments' howtos](https://qiskit.org/documentation/experiments/howtos/index.html) are already in such a simple list format rather than tiles. So I redid the page with a toctree glob rather than a nbgallery glob. I also put other other text there consistent with what experiments has and updated the titles. 

### Details and comments

This is how it looks now (from local build of html) - refer to #1114 for a before image

![image](https://user-images.githubusercontent.com/40241007/230661941-8e89bbee-30f7-491b-9bc0-2334d6d9c62f.png)

