### PR TITLE
Fall back to numpy arrays in `VibrationalIntegrals`

### DIFF
--- a/qiskit_nature/second_q/drivers/gaussiand/gaussian_log_result.py
+++ b/qiskit_nature/second_q/drivers/gaussiand/gaussian_log_result.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,6 +20,8 @@ import copy
 import logging
 import re
 
+import numpy as np
+
 from qiskit_nature.second_q.formats.watson import WatsonHamiltonian
 import qiskit_nature.optionals as _optionals
 
@@ -38,7 +40,6 @@ else:
 logger = logging.getLogger(__name__)
 
 
-@_optionals.HAS_SPARSE.require_in_instance
 class GaussianLogResult:
     """Result for Gaussian™ 16 log driver.
 
@@ -274,10 +275,28 @@ class GaussianLogResult:
 
         max_index = max(quadratic_max_index, cubic_max_index, quartic_max_index)
 
-        watson = WatsonHamiltonian(
-            as_coo(quadratic_data, shape=(max_index,) * 2),
-            as_coo(cubic_data, shape=(max_index,) * 3),
-            as_coo(quartic_data, shape=(max_index,) * 4),
-            -as_coo(quadratic_data, shape=(max_index,) * 2),
-        )
+        if _optionals.HAS_SPARSE:
+            watson = WatsonHamiltonian(
+                as_coo(quadratic_data, shape=(max_index,) * 2),
+                as_coo(cubic_data, shape=(max_index,) * 3),
+                as_coo(quartic_data, shape=(max_index,) * 4),
+                -as_coo(quadratic_data, shape=(max_index,) * 2),
+            )
+        else:
+            quadratic_numpy = np.zeros((max_index,) * 2)
+            for coord, value in quadratic_data.items():
+                quadratic_numpy[coord] = value
+            cubic_numpy = np.zeros((max_index,) * 3)
+            for coord, value in cubic_data.items():
+                cubic_numpy[coord] = value
+            quartic_numpy = np.zeros((max_index,) * 4)
+            for coord, value in quartic_data.items():
+                quartic_numpy[coord] = value
+            watson = WatsonHamiltonian(
+                quadratic_numpy,
+                cubic_numpy,
+                quartic_numpy,
+                -quadratic_numpy,
+            )
+
         return watson

--- a/releasenotes/notes/numpy-based-vibrational-integrals-7343c0fa56e2e5c5.yaml
+++ b/releasenotes/notes/numpy-based-vibrational-integrals-7343c0fa56e2e5c5.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Extends the :class:`~qiskit_nature.second_q.operators.VibrationalIntegrals`
+    to fall back to using ``numpy`` arrays when the optional ``sparse`` dependency
+    is not installed.

--- a/test/second_q/drivers/gaussiand/test_driver_gaussian_forces.py
+++ b/test/second_q/drivers/gaussiand/test_driver_gaussian_forces.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -231,7 +231,6 @@ class TestDriverGaussianForces(QiskitNatureTestCase):
         return exp_vals
 
     @unittest.skipIf(not _optionals.HAS_GAUSSIAN, "gaussian not available.")
-    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
     def test_driver_jcf(self):
         """Test the driver works with job control file"""
         driver = GaussianForcesDriver(
@@ -266,7 +265,6 @@ class TestDriverGaussianForces(QiskitNatureTestCase):
         print("]\n")
 
     @unittest.skipIf(not _optionals.HAS_GAUSSIAN, "gaussian not available.")
-    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
     @data("B3LYP", "PBEPBE")
     def test_driver_molecule(self, xcf: str):
         """Test the driver works with Molecule"""
@@ -291,7 +289,6 @@ class TestDriverGaussianForces(QiskitNatureTestCase):
         ("C01", _C01_REV_EXPECTED),
     )
     @unpack
-    @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
     def test_driver_logfile(self, suffix, expected):
         """Test the driver works with logfile (Gaussian does not need to be installed)"""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This extends the `VibrationalIntegrals` class to fall back to using numpy arrays when the `sparse` package is not installed.

### Details and comments

This is required if we want to support Python 3.11 before `sparse` does so.
