### PR TITLE
fix: formatting of ElectronicStructureResult

### DIFF
--- a/qiskit_nature/second_q/problems/electronic_structure_result.py
+++ b/qiskit_nature/second_q/problems/electronic_structure_result.py
@@ -321,7 +321,7 @@ class ElectronicStructureResult(EigenstateResult):
             )
             for name, value in self.extracted_transformer_energies.items():
                 lines.append(
-                    "  - {name} extracted energy part: "
+                    f"  - {name} extracted energy part: "
                     f"{_complex_to_string(value, self.formatting_precision)}"
                 )
         if self.nuclear_repulsion_energy is not None:

--- a/releasenotes/notes/fix-electronic-structure-result-printing-6e0b092097386c8f.yaml
+++ b/releasenotes/notes/fix-electronic-structure-result-printing-6e0b092097386c8f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a formatting issue when printing an
+    :class:`~qiskit_nature.second_q.problems.ElectronicStructureResult` which
+    contains values in :attr:`~qiskit_nature.second_q.problems.ElectronicStructureResult.extracted_transformer_energies`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I found a bug occurring when printing an `ElectronicStructureResult` which contains values in the `extracted_transformer_energies`

### Details and comments


