### PR TITLE
Fix lint after opflow deprecation

### DIFF
--- a/qiskit_nature/operators/second_quantization/second_quantized_op.py
+++ b/qiskit_nature/operators/second_quantization/second_quantized_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/operators/second_quantization/second_quantized_op.py
+++ b/qiskit_nature/operators/second_quantization/second_quantized_op.py
@@ -36,6 +36,7 @@ class SecondQuantizedOp(StarAlgebraMixin, TolerancesMixin, ABC):
 
     def __pow__(self, power):
         if power == 0:
+            # pylint: disable=too-many-function-args
             return self.__class__("I" * self.register_length)
 
         return super().__pow__(power)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit-terra#9176 deprecated opflow, which included StarAlebraMixin used by SecondQuantizedOp. To add the deprecated decorator for the class an empty init() method was added in order to add a decorator.

The above then gave rise to this in the nightly scheduled builds here in Nature

```
************* Module qiskit_nature.operators.second_quantization.second_quantized_op
qiskit_nature/operators/second_quantization/second_quantized_op.py:39:19: E1121: Too many positional arguments for constructor call (too-many-function-args)
```

which I have simply supressed in the code. The code, like opflow, is deprecated and will be removed in the future,

### Details and comments


