### PR TITLE
Fix Mac CI PSI4 to 1.6

### DIFF
--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -38,8 +38,9 @@ runs:
           conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4
           pip install -U numpy
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
-          echo 'installs psi4 stable release'
-          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
+          release=1.6
+          echo 'installs psi4 release $release'
+          conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4
           echo 'update intel-openmp'
           conda update -y -c anaconda intel-openmp
           echo 'update llvm-openmp'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Mac 3.9 unit tests have been failing with PSI4 where it system exits code 11 recently. It seems that, when it was passing before, it was pulling in PSI4 1.6.1 but now the automatic version resolution is dropping back to 1.5 and its failing. This sets the version to 1.6 explicitly.


### Details and comments


