### PR TITLE
Update intersphinx mappings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,7 +212,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "qiskit": ("https://qiskit.org/documentation/", None),
-    "rustworkx": ("https://qiskit.org/documentation/rustworkx/", None),
+    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
     "sparse": ("https://sparse.pydata.org/en/stable/", None),
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the change to publishing many of the qiskit docs in `ecosystem` this updates the mapping url for `rustworkx` accordingly. 

Since this is now the correct url, I also marked it for stable backport, for any docs updates we do, though I imagine the redirect on the former url will be in place for some time.

### Details and comments


