### PR TITLE
Remove unneeded casts

### DIFF
--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from collections.abc import Collection, Mapping
-from typing import cast, Iterator
+from typing import Iterator
 
 import numpy as np
 from scipy.sparse import csc_matrix
@@ -244,8 +244,7 @@ class FermionicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                # TODO: deal with complexity
-                data[""] = cast(float, tensor[key])
+                data[""] = tensor[key]
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import re
 from collections.abc import Collection, Mapping
 from collections import defaultdict
-from typing import cast, Iterator
+from typing import Iterator
 from fractions import Fraction
 from functools import partial, reduce
 
@@ -300,8 +300,7 @@ class SpinOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                # TODO: deal with complexity
-                data[""] = cast(float, tensor[key])
+                data[""] = tensor[key]
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from collections.abc import Collection, Mapping
-from typing import Iterator, Sequence, Tuple, cast
+from typing import Iterator, Sequence, Tuple
 import logging
 import operator
 import itertools
@@ -284,8 +284,7 @@ class VibrationalOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                # TODO: deal with complexity
-                data[""] = cast(float, tensor[key])
+                data[""] = tensor[key]
                 continue
 
             mat = tensor[key]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This removes some unneeded casts from the operator classes.


### Details and comments

Complexity should not pose a real problem any longer because we do not do any explicit down- or up-conversions in the stack any longer. This can be seen since `Tensor` and `PolynomialTensor` explicitly allow complex values. I do not recall why I added these casts in the first place, but I think they can simply be removed.
