### PR TITLE
Fix docstring of ElectronicDipoleMoment

### DIFF
--- a/qiskit_nature/second_q/properties/dipole_moment.py
+++ b/qiskit_nature/second_q/properties/dipole_moment.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -34,7 +34,7 @@ class ElectronicDipoleMoment:
     the electronic integrals:
 
     .. math::
-        \vec{d}_{pq} = \int \phi_{p} \frac{1}{\vec{r}} \phi_{q} ,
+        \vec{d}_{pq} = \int \phi_{p} \vec{r} \phi_{q} ,
 
     where the integral is over the all space. The operator can then be expressed as:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As pointed out in [this](https://quantumcomputing.stackexchange.com/q/32402/13342) question on stack exchange, the docs of the `ElectronicDipoleMoment` had a mistake. This PR addresses that.

### Details and comments


