### PR TITLE
Enable sparse optional for 3.11

### DIFF
--- a/releasenotes/notes/sparse-3_11-1538988547ff6dd6.yaml
+++ b/releasenotes/notes/sparse-3_11-1538988547ff6dd6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support optional `sparse` install under Python 3.11.

--- a/releasenotes/notes/sparse-3_11-1538988547ff6dd6.yaml
+++ b/releasenotes/notes/sparse-3_11-1538988547ff6dd6.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+fixes:
   - |
-    Support optional `sparse` install under Python 3.11.
+    Compatibility fix to support optional `sparse` install under Python 3.11.

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setuptools.setup(
     extras_require={
         "pyscf": ["pyscf; sys_platform != 'win32'"],
         "mpl": ["matplotlib>=3.3"],
-        "sparse": ["sparse; python_version < '3.11'"],
+        "sparse": ["sparse"],
         "opt_einsum": ["opt_einsum"],
     },
     zip_safe=False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Now that the sparse dependence numba has a 3.11 supported release this removes the Python version limit from the optional sparse install.

### Details and comments


