### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   Checks:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -140,6 +141,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
   Nature:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -278,6 +280,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
   Tutorials:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -357,6 +360,7 @@ jobs:
           path: docs/_build/html/artifacts/tutorials.tar.gz
         if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
+    if: github.repository_owner == 'Qiskit'
     needs: [Checks, Nature, Tutorials]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -8,6 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   neko:
+    if: github.repository_owner == 'Qiskit'
     name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Most people agree that GitHub made a mistake by having forks run CI both on the fork and in the upstream repository. It wastes computing resources (which has a real environmental cost!).

### Details and comments

If people really want to run CI in their fork, they can always modify their fork's config to revert this change.
