### PR TITLE
fix: the integer rounding in the ActiveSpaceTransformer

### DIFF
--- a/qiskit_nature/second_q/transformers/active_space_transformer.py
+++ b/qiskit_nature/second_q/transformers/active_space_transformer.py
@@ -249,8 +249,8 @@ class ActiveSpaceTransformer(BaseTransformer):
             cast(np.ndarray, self._active_density.beta["+-"])
         )[self._active_orbs_indices]
         new_problem.num_particles = (
-            int(sum(new_problem.orbital_occupations)),
-            int(sum(new_problem.orbital_occupations_b)),
+            round(sum(new_problem.orbital_occupations)),
+            round(sum(new_problem.orbital_occupations_b)),
         )
 
         if problem.orbital_energies is not None:

--- a/releasenotes/notes/fix-active-space-integer-rounding-753ae77146610d9d.yaml
+++ b/releasenotes/notes/fix-active-space-integer-rounding-753ae77146610d9d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The :class:`.ActiveSpaceTransformer` would sometimes set the wrong number of active particles
+    because of a flawed integer rounding. This has now been fixed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This one was hard to debug.. Basically what could happen prior to this PR is that the number of particles would sum up to something like `1.9999999991` which would get turned by `int(...)` into a `1` rather than a `2`.
This PR fixes exactly that.

### Details and comments

I have not found a case which can reproduce this consistently for a unittest to guard against this, since this heavily relies on numerical precision to kick in... I did however grep for usage of `int(...)` and did not find any other potential pitfalls like this one.