### PR TITLE
Improve docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -21,11 +21,9 @@
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_attributes %}
-      {%- if item not in inherited_members %}
-        {%- if not item.startswith('_') %}
-            ~{{ name }}.{{ item }}
-        {%- endif -%}
-      {%- endif %}
+      {%- if not item.startswith('_') %}
+          ~{{ name }}.{{ item }}
+      {%- endif -%}
    {%- endfor %}
    {% endif %}
    {% endblock %}
@@ -33,16 +31,14 @@
    {% block methods_summary %}
    {% if methods %}
 
-   .. rubric:: Methods Defined Here
+   .. rubric:: Methods
 
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_methods %}
-      {%- if item not in inherited_members %}
-        {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-            ~{{ name }}.{{ item }}
-        {%- endif -%}
-      {%- endif %}
+      {%- if not item.startswith('_') %}
+          ~{{ name }}.{{ item }}
+      {%- endif -%}
    {%- endfor %}
 
    {% endif %}

--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -21,9 +21,11 @@
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_attributes %}
-      {%- if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
-      {%- endif -%}
+      {%- if item not in inherited_members %}
+        {%- if not item.startswith('_') %}
+            ~{{ name }}.{{ item }}
+        {%- endif -%}
+      {%- endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}
@@ -36,9 +38,11 @@
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_methods %}
-      {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-          ~{{ name }}.{{ item }}
-      {%- endif -%}
+      {%- if item not in inherited_members %}
+        {%- if not item.startswith('_') %}
+            ~{{ name }}.{{ item }}
+        {%- endif -%}
+      {%- endif %}
    {%- endfor %}
 
    {% endif %}

--- a/qiskit_nature/second_q/circuit/library/__init__.py
+++ b/qiskit_nature/second_q/circuit/library/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/circuit/library/__init__.py
+++ b/qiskit_nature/second_q/circuit/library/__init__.py
@@ -21,6 +21,7 @@ A collection of circuits used as building blocks or inputs for algorithms.
 .. autosummary::
    :toctree: ../stubs/
    :nosignatures:
+   :template: autosummary/class_no_inherited_members.rst
 
 
    BogoliubovTransform
@@ -31,6 +32,7 @@ Initial states
 .. autosummary::
    :toctree: ../stubs/
    :nosignatures:
+   :template: autosummary/class_no_inherited_members.rst
 
 
    FermionicGaussianState
@@ -44,6 +46,7 @@ Ansatzes
 .. autosummary::
    :toctree: ../stubs/
    :nosignatures:
+   :template: autosummary/class_no_inherited_members.rst
 
 
    UCC

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -54,7 +54,6 @@ BosonicOp Mappers
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    BosonicLinearMapper

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -21,7 +21,6 @@ The classes here are used to convert fermionic, vibrational and spin operators t
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    QubitMapper
@@ -31,7 +30,6 @@ FermionicOp Mappers
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    BravyiKitaevMapper
@@ -45,7 +43,6 @@ blocked) order, you can use the following wrapper:
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    InterleavedQubitMapper
@@ -55,7 +52,6 @@ VibrationalOp Mappers
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    DirectMapper
@@ -66,7 +62,6 @@ SpinOp Mappers
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    LinearMapper
@@ -80,7 +75,6 @@ after the mapping to qubit operators, you can use the following wrapper for symm
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    TaperedQubitMapper
@@ -90,7 +84,6 @@ Qubit Converter
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    QubitConverter

--- a/qiskit_nature/second_q/operators/symmetric_two_body.py
+++ b/qiskit_nature/second_q/operators/symmetric_two_body.py
@@ -34,7 +34,6 @@ interchangeably.
 
 .. autosummary::
    :toctree: ../stubs/
-   :template: autosummary/class_with_inherited_members.rst
    :nosignatures:
 
    SymmetricTwoBodyIntegrals


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Similar to Qiskit/qiskit-machine-learning#635 
Resolves #1055

This changes things here, which used to have a couple of templates where inherited methods was the choice and no inheritence the default, over to inherited methods are shown by default and it has to be selected to suppress them - which presently is just done for circuit library classes inheriting from QuantumCircuit. This is also how Qiskit does things.

It fails locally with make spell for me, as I imagine it pulls stuff in that was not before. But I will let it go through CI here once before changing anything in that regard assuming it fails likewise here.

Locally I had deleted the with_inherited rst template and added a the no_inherited one - but it ended up as a rename and change of contents which is fine.

### Details and comments


