### PR TITLE
Fix references breaking with nbpshinx 0.9.2

### DIFF
--- a/docs/migration/0.5_b_solving_problems.rst
+++ b/docs/migration/0.5_b_solving_problems.rst
@@ -23,10 +23,10 @@ Table of Contents
 In this document, we will provide an overview of the API changes
 alongside with some minimal explanations:
 
--  `qiskit_nature.mappers <#qiskit_nature.mappers>`__
--  `qiskit_nature.converters <#qiskit_nature.converters>`__
--  `qiskit_nature.circuit <#qiskit_nature.circuit>`__
--  `qiskit_nature.algorithms <#qiskit_nature.algorithms>`__
+-  `qiskit_nature.mappers <#qiskit-nature-mappers>`__
+-  `qiskit_nature.converters <#qiskit-nature-converters>`__
+-  `qiskit_nature.circuit <#qiskit-nature-circuit>`__
+-  `qiskit_nature.algorithms <#qiskit-nature-algorithms>`__
 
 Further Resources
 ~~~~~~~~~~~~~~~~~

--- a/docs/migration/0.5_c_electronic_structure.rst
+++ b/docs/migration/0.5_c_electronic_structure.rst
@@ -9,12 +9,12 @@ Qiskit Nature v0.4 and v0.5. Thus, this file is split into multiple
 sections that go into various amounts of details. Here is a table of
 contents to help you navigate:
 
--  `TL;DR <#TL;DR>`__
--  `qiskit_nature.drivers <#qiskit_nature.drivers>`__
--  `qiskit_nature.transformers <#qiskit_nature.transformers>`__
+-  `TL;DR <#tl-dr>`__
+-  `qiskit_nature.drivers <#qiskit-nature-drivers>`__
+-  `qiskit_nature.transformers <#qiskit-nature-transformers>`__
 -  `The ElectronicStructureProblem
-   (qiskit_nature.problems) <#The-ElectronicStructureProblem-(qiskit_nature.problems)>`__
--  `qiskit_nature.properties <#qiskit_nature.properties>`__
+   (qiskit_nature.problems) <#the-electronicstructureproblem-qiskit-nature-problems>`__
+-  `qiskit_nature.properties <#qiskit-nature-properties>`__
 
 Further resources
 -----------------

--- a/docs/migration/0.5_d_vibrational_structure.rst
+++ b/docs/migration/0.5_d_vibrational_structure.rst
@@ -9,11 +9,11 @@ between Qiskit Nature v0.4 and v0.5. Thus, this file is split into
 multiple sections that go into various amounts of details. Here is a
 table of contents to help you navigate:
 
--  `TL;DR <#TL;DR>`__
--  `qiskit_nature.drivers <#qiskit_nature.drivers>`__
+-  `TL;DR <#tl-dr>`__
+-  `qiskit_nature.drivers <#qiskit-nature-drivers>`__
 -  `The VibrationalStructureProblem
-   (qiskit_nature.problems) <#The-VibrationalStructureProblem-(qiskit_nature.problems)>`__
--  `qiskit_nature.properties <#qiskit_nature.properties>`__
+   (qiskit_nature.problems) <#the-vibrationalstructureproblem-qiskit-nature-problems>`__
+-  `qiskit_nature.properties <#qiskit-nature-properties>`__
 
 Further resources
 -----------------

--- a/docs/migration/0.5_e_lattice_models.rst
+++ b/docs/migration/0.5_e_lattice_models.rst
@@ -45,10 +45,10 @@ Table of Contents
 Concrete examples are provided below. You can use the following links to
 jump to a specific section:
 
--  `FermiHubbardModel.uniform_parameters <#FermiHubbardModel.uniform_parameters>`__
--  `FermiHubbardModel.from_parameters <#FermiHubbardModel.from_parameters>`__
--  `IsingModel.uniform_parameters <#IsingModel.uniform_parameters>`__
--  `IsingModel.from_parameters <#IsingModel.from_parameters>`__
+-  `FermiHubbardModel.uniform_parameters <#fermihubbardmodel-uniform-parameters>`__
+-  `FermiHubbardModel.from_parameters <#fermihubbardmodel-from-parameters>`__
+-  `IsingModel.uniform_parameters <#isingmodel-uniform-parameters>`__
+-  `IsingModel.from_parameters <#isingmodel-from-parameters>`__
 
 Further Resources
 ~~~~~~~~~~~~~~~~~

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,6 @@ discover
 qiskit-aer>=0.11.2
 mypy>=0.991
 mypy-extensions>=0.4.3
-nbsphinx
+nbsphinx>=0.9.2
 qiskit_sphinx_theme~=1.11.1
 networkx>=2.2,<2.6


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Docs broke overnight with errors like this:

> /home/runner/work/qiskit-nature/qiskit-nature/docs/migration/0.5_b_solving_problems.rst:26: WARNING: undefined label: '/migration/0.5_b_solving_problems.rst#qiskit_nature.mappers'

This is due to nbpshinx 0.9.2, and we suspect specifically https://github.com/spatialaudio/nbsphinx/commit/ce39da6798d9f654a3942b255cbe4d6a266d02d1.

Rather than pinning to npshinx 0.9.1, we fix forward.