### PR TITLE
Remove manual Table of Contents in favor of autogenerated Page Table of Contents

### DIFF
--- a/docs/migration/0.5_b_solving_problems.rst
+++ b/docs/migration/0.5_b_solving_problems.rst
@@ -17,17 +17,6 @@ suggest that you read the `corresponding
 resources <https://qiskit.org/documentation/apidoc/primitives.html>`__
 of the Qiskit Terra documentation instead.
 
-Table of Contents
-~~~~~~~~~~~~~~~~~
-
-In this document, we will provide an overview of the API changes
-alongside with some minimal explanations:
-
--  `qiskit_nature.mappers <#qiskit_nature.mappers>`__
--  `qiskit_nature.converters <#qiskit_nature.converters>`__
--  `qiskit_nature.circuit <#qiskit_nature.circuit>`__
--  `qiskit_nature.algorithms <#qiskit_nature.algorithms>`__
-
 Further Resources
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/migration/0.5_c_electronic_structure.rst
+++ b/docs/migration/0.5_c_electronic_structure.rst
@@ -1,21 +1,6 @@
 Electronic Structure Problems with v0.5
 =======================================
 
-Table of Contents
------------------
-
-The electronic structure stack has received the most updates between
-Qiskit Nature v0.4 and v0.5. Thus, this file is split into multiple
-sections that go into various amounts of details. Here is a table of
-contents to help you navigate:
-
--  `TL;DR <#TL;DR>`__
--  `qiskit_nature.drivers <#qiskit_nature.drivers>`__
--  `qiskit_nature.transformers <#qiskit_nature.transformers>`__
--  `The ElectronicStructureProblem
-   (qiskit_nature.problems) <#The-ElectronicStructureProblem-(qiskit_nature.problems)>`__
--  `qiskit_nature.properties <#qiskit_nature.properties>`__
-
 Further resources
 -----------------
 

--- a/docs/migration/0.5_d_vibrational_structure.rst
+++ b/docs/migration/0.5_d_vibrational_structure.rst
@@ -1,20 +1,6 @@
 Vibrational Structure Problems with v0.5
 ========================================
 
-Table of Contents
------------------
-
-The vibrational structure stack has also received significant updates
-between Qiskit Nature v0.4 and v0.5. Thus, this file is split into
-multiple sections that go into various amounts of details. Here is a
-table of contents to help you navigate:
-
--  `TL;DR <#TL;DR>`__
--  `qiskit_nature.drivers <#qiskit_nature.drivers>`__
--  `The VibrationalStructureProblem
-   (qiskit_nature.problems) <#The-VibrationalStructureProblem-(qiskit_nature.problems)>`__
--  `qiskit_nature.properties <#qiskit_nature.properties>`__
-
 Further resources
 -----------------
 

--- a/docs/migration/0.5_e_lattice_models.rst
+++ b/docs/migration/0.5_e_lattice_models.rst
@@ -39,17 +39,6 @@ Furthermore, the factory methods for ``Lattice`` objects defined on the
 | ``IsingModel.from_parameters``           | ``Lattice.from_adjacency_matrix`` |
 +------------------------------------------+-----------------------------------+
 
-Table of Contents
-~~~~~~~~~~~~~~~~~
-
-Concrete examples are provided below. You can use the following links to
-jump to a specific section:
-
--  `FermiHubbardModel.uniform_parameters <#FermiHubbardModel.uniform_parameters>`__
--  `FermiHubbardModel.from_parameters <#FermiHubbardModel.from_parameters>`__
--  `IsingModel.uniform_parameters <#IsingModel.uniform_parameters>`__
--  `IsingModel.from_parameters <#IsingModel.from_parameters>`__
-
 Further Resources
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

This is a better fix for the problem described in https://github.com/Qiskit/qiskit-nature/pull/1179.

@woodsp-ibm and I realized that it's redundant for us to have a manual Table of Contents section in the docs. qiskit_sphinx_theme will already auto-generate a page table of contents. It's duplicative to have our own manual section too.

![image](https://github.com/Qiskit/qiskit-nature/assets/14852634/679fb87e-c34b-43f3-9def-323e42642d4f)

We suspect that we picked up this habit from old docs that did it before qiskit_sphinx_theme used Pytorch to autogenerate the page table of contents. It's now an out-of-date practice that has a bad user experience & results in the issue in https://github.com/Qiskit/qiskit-nature/pull/1179.