### PR TITLE
Add project urls to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,10 @@ setuptools.setup(
         "sparse": ["sparse"],
         "opt_einsum": ["opt_einsum"],
     },
+    project_urls={
+        "Bug Tracker": "https://github.com/Qiskit/qiskit-nature/issues",
+        "Documentation": "https://qiskit.org/ecosystem/nature/",
+        "Source Code": "https://github.com/Qiskit/qiskit-nature",
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds project urls to setup so that PyPI project page has more than just a `Homepage` url. This adds additional project urls comparable to qiskit-terra i.e. `Bug Tracker`, `Documentation` and `Source Code`.

As per Qiskit/qiskit-optimization#523

Could be backported, if desired, to add these urls for next bug fix release or wait until next minor release.

### Details and comments


