### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -38,7 +38,7 @@ runs:
         if [ "${{ inputs.event-name }}" == "schedule" ] || [ "${{ inputs.run-slow }}" == "true" ]; then
           export QISKIT_TESTS="run_slow"
         fi
-        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.9" ]; then
+        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.10" ]; then
           export PYTHON="coverage3 run --source qiskit_nature --omit */gauopen/* --parallel-mode"
         fi
         stestr --test-path test run 2> >(tee /dev/stderr out.txt > /dev/null)

--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - name: Print Concurrency Group
         env:
@@ -149,14 +149,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: macos-latest
             python-version: 3.12
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.10'
           - os: windows-latest
             python-version: 3.12
     steps:
@@ -246,7 +246,7 @@ jobs:
           conda activate psi4env
           coverage3 combine
           mv .coverage ./ci-artifact-data/nat.dat
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         shell: bash
       - uses: actions/upload-artifact@v4
         with:
@@ -275,7 +275,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: ['3.10', 3.12]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -342,30 +342,26 @@ jobs:
           cd docs/_build/html
           mkdir artifacts
           tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
-        if: ${{ matrix.python-version == 3.9 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+        if: ${{ matrix.python-version == '3.10' && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
         shell: bash
       - name: Run upload stable tutorials
         uses: actions/upload-artifact@v4
         with:
           name: tutorials-stable${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
-        if: ${{ matrix.python-version == 3.9 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+        if: ${{ matrix.python-version == '3.10' && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
     if: github.repository_owner == 'qiskit-community'
     needs: [Checks, Nature, Tutorials]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v5
-        with:
-          name: ubuntu-latest-3.9
-          path: /tmp/u39
       - uses: actions/download-artifact@v5
         with:
           name: ubuntu-latest-3.10
@@ -380,16 +376,16 @@ jobs:
           path: /tmp/u312
       - uses: actions/download-artifact@v5
         with:
-          name: macos-latest-3.9
-          path: /tmp/m39
+          name: macos-latest-3.10
+          path: /tmp/m310
       - uses: actions/download-artifact@v5
         with:
           name: macos-latest-3.12
           path: /tmp/m312
       - uses: actions/download-artifact@v5
         with:
-          name: windows-latest-3.9
-          path: /tmp/w39
+          name: windows-latest-3.10
+          path: /tmp/w310
       - uses: actions/download-artifact@v5
         with:
           name: windows-latest-3.12
@@ -399,10 +395,10 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/u311/nat.dep /tmp/u312/nat.dep /tmp/m39/nat.dep /tmp/m312/nat.dep /tmp/w39/nat.dep /tmp/w312/nat.dep || true
+          sort -f -u /tmp/u310/nat.dep /tmp/u311/nat.dep /tmp/u312/nat.dep /tmp/m310/nat.dep /tmp/m312/nat.dep /tmp/w310/nat.dep /tmp/w312/nat.dep || true
         shell: bash
       - name: Coverage combine
-        run: coverage3 combine /tmp/u39/nat.dat
+        run: coverage3 combine /tmp/u310/nat.dat
         shell: bash
       - name: Upload to Coveralls
         env:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,13 @@
 queue_rules:
   - name: automerge
     queue_conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.9)
+      - check-success=Deprecation_Messages_and_Coverage (3.10)
     merge_method: squash
 
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.9)
+      - check-success=Deprecation_Messages_and_Coverage (3.10)
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,1 @@
 numpy>=1.20.0
-ipython<8.13;python_version<'3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py310', 'py311']

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -72,7 +71,7 @@ setuptools.setup(
     packages=setuptools.find_packages(include=["qiskit_nature", "qiskit_nature.*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     extras_require={
         "pyscf": ["pyscf; sys_platform != 'win32'"],
         "mpl": ["matplotlib>=3.3"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py38, py39, py310, py311, py312, lint
+envlist = py310, py311, py312, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
### Summary

Remove Python 3.9 from all CI matrices, tox envlist, black target versions, setup.py classifiers/python_requires, and Mergify checks. Minimum supported version is now Python 3.10.

### Details and comments

Support for Python 3.9 ended in 2025. 
